### PR TITLE
Fixes a dependency issue with tsutils and tslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6365,9 +6365,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.0.tgz",
-      "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.14.0.tgz",
+      "integrity": "sha512-f6axSMV0RoUufiKiRQgmRlN1c+Ag+mDaZjcd6bHdvplT/zyhuMCGqw3pJS8s3+0x4EVkdoQajs9PchdDZlguvw==",
       "dev": true
     },
     "tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "shelljs": "^0.7.8",
     "ts-node": "~3.0.4",
-    "tslint": "5.8.0",
+    "tslint": "^5.8.0",
     "typescript": "2.4.2",
     "typescript-formatter": "^7.0.1",
     "uglify-js": "3.2.1",


### PR DESCRIPTION
There seems to be an issue with the package-lock file from pull request #10 where I did not commit a dependency that's needed. This resolved the issue I was experiencing where I deleted node_modules and ran 

```
npm install && npm run lint
```
but was getting "cannot find module tsutils"