### PR TITLE
Checkbox better support for angular forms and native properties

### DIFF
--- a/src/app/demo/demo.module.ts
+++ b/src/app/demo/demo.module.ts
@@ -14,16 +14,18 @@ import { CheckboxDemoComponent } from 'app/lib/checkbox/checkbox-demo/checkbox-d
 import { CheckboxModule } from 'app/lib/checkbox/checkbox.module';
 import { SelectModule } from 'app/lib/select/select.module';
 import { SelectDemoComponent } from 'app/lib/select/select-demo/select-demo.component';
-import { IconModule } from '../lib/icon/icon.module';
+import { IconModule } from '../lib/icon';
+import { FormsModule } from '@angular/forms';
 import { HomeComponent } from 'app/home/home.component';
 import { DrawerDemoComponent } from '../lib/drawer/drawer-demo/drawer-demo.component';
-import { DrawerModule } from '../lib/drawer/drawer.module';
+import { DrawerModule } from '../lib/drawer';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   imports: [
     BrowserAnimationsModule,
     BrowserModule,
+    FormsModule,
     ButtonModule,
     CheckboxModule,
     IconModule,

--- a/src/app/lib/cashmere.ts
+++ b/src/app/lib/cashmere.ts
@@ -14,3 +14,4 @@ export * from './vertical-tabs/vertical-tabs.component';
 
 export * from './icon';
 export * from './drawer';
+export * from './checkbox';

--- a/src/app/lib/checkbox/checkbox-demo/checkbox-demo.component.html
+++ b/src/app/lib/checkbox/checkbox-demo/checkbox-demo.component.html
@@ -1,57 +1,92 @@
 <div class="demo-page">
-    <h2 style="margin: 0">Checkbox</h2>
-    <h4 style="font-weight: 300; margin-top: 0">Checkboxes allow the user to make a binary choice, i.e. a choice between one of two possible mutually exclusive options.</h4>
+  <h2 style="margin: 0">Checkbox</h2>
+  <h4 style="font-weight: 300; margin-top: 0">Checkboxes allow the user to make a binary choice, i.e. a choice between
+    one of two possible mutually exclusive options.</h4>
 
-    <h5>Standard</h5>
-    <hc-checkbox name="light">Standard Checkbox</hc-checkbox>
+  <h5>Standard</h5>
+  <hc-checkbox id="light">Standard Checkbox</hc-checkbox>
 
-    <h5>Disabled</h5>
-    <hc-checkbox disabled="true" name="disabled">Disabled Checkbox</hc-checkbox>
+  <h5>Disabled</h5>
+  <hc-checkbox id="disabled" disabled="true">Disabled Checkbox</hc-checkbox>
 
-    <br>
-    <br>
-    <hr style="height:1px;border:none;background-color:#E5E5E5;">
-    <br>
-    <p class="description">
-        <b>Checkbox Usage</b>
-        <br>Checkboxes are typically used with labels, but can be used without in certain situations (table columns, etc).</p>
-    <br>
-    <hr style="height:1px;border:none;background-color:#E5E5E5;">
-    <br>
-    <div class="headerName">Angular Component</div>
+  <h5>Forms Support(two-way data binding and Reactive Forms)</h5>
+  <hc-checkbox id="ngModel" [(ngModel)]="isChecked">{{getCheckboxText()}}</hc-checkbox>
+
   <br>
-      <pre>
+  <br>
+  <hr style="height:1px;border:none;background-color:#E5E5E5;">
+  <br>
+  <p class="description">
+    <b>Checkbox Usage</b>
+    <br>Checkboxes are typically used with labels, but can be used without in certain situations (table columns, etc).
+    <br>This checkbox can be used with both reactive and template forms
+  </p>
+  <br>
+  <hr style="height:1px;border:none;background-color:#E5E5E5;">
+  <br>
+  <div class="headerName">Angular Component</div>
+  <br>
+  <pre>
           <code>
-&#x3C;hc-checkbox name=&#x22;name&#x22;&#x3E;Checkbox Label&#x3C;/hc-checkbox&#x3E;
+            &#x3C;hc-checkbox id=&#x22;checkbox-id&#x22;&#x3E;Checkbox Label&#x3C;/hc-checkbox&#x3E;
+            &#x3C;hc-checkbox id=&#x22;checkbox-id&#x22; [(ngModel)]=&#x22;data&#x22;&#x3E;Checkbox Label&#x3C;/hc-checkbox&#x3E;
           </code>
       </pre>
-      <br>
+  <br>
   <hr style="height:1px;border:none;background-color:#E5E5E5;">
   <br>
   <div class="headerName">Component Parameters</div>
   <br>
 
   <table class="apiTable parameters">
-      <tr>
-          <th>name</th>
-          <td>
-              <span>Type:</span> String
-          </td>
-          <td width=50%>Required identifier used to connect the checkbox and label</td>
-      </tr>
-      <tr>
-        <th>[disabled]</th>
-        <td>
-            <span>Type:</span> Boolean
-        </td>
-        <td width=50%>Boolean value that enables/disables the checkbox</td>
-      </tr>
-      <tr>
-        <th>[(model)]</th>
-        <td>
-            <span>Type:</span> Boolean
-        </td>
-        <td width=50%>Boolean value for two way binding to the checkbox</td>
-      </tr>
+    <tr>
+      <th>id</th>
+      <td>
+        <span>Type:</span> String
+      </td>
+      <td width=50%>Optional - checkbox identifier</td>
+    </tr>
+    <tr>
+      <th>disabled</th>
+      <td>
+        <span>Type:</span> string|boolean
+      </td>
+      <td width=50%>Optional - disables the checkbox</td>
+    </tr>
+    <tr>
+      <th>required</th>
+      <td>
+        <span>Type:</span> string|boolean
+      </td>
+      <td width=50%>Optional - whether the checkbox is required</td>
+    </tr>
+    <tr>
+      <th>name</th>
+      <td>
+        <span>Type:</span> string
+      </td>
+      <td width=50%>Optional - name to be applied to input element</td>
+    </tr>
+    <tr>
+      <th>value</th>
+      <td>
+        <span>Type:</span> string
+      </td>
+      <td width=50%>Optional - value attribute for the input element</td>
+    </tr>
+    <tr>
+      <th>tabIndex</th>
+      <td>
+        <span>Type:</span> number
+      </td>
+      <td width=50%>Optional - tabIndex for the element</td>
+    </tr>
+    <tr>
+      <th>checked</th>
+      <td>
+        <span>Type:</span> number
+      </td>
+      <td width=50%>Optional - whether the checkbox is checked or not</td>
+    </tr>
   </table>
 </div>

--- a/src/app/lib/checkbox/checkbox-demo/checkbox-demo.component.ts
+++ b/src/app/lib/checkbox/checkbox-demo/checkbox-demo.component.ts
@@ -1,11 +1,14 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'hc-checkbox-demo',
-    templateUrl: './checkbox-demo.component.html',
-    styleUrls: ['./checkbox-demo.component.scss']
+  selector: 'hc-checkbox-demo',
+  templateUrl: './checkbox-demo.component.html',
+  styleUrls: ['./checkbox-demo.component.scss']
 })
 export class CheckboxDemoComponent {
+  isChecked: boolean;
 
-    constructor() { }
+  getCheckboxText() {
+    return `${this.isChecked ? 'Disable' : 'Enable'} Button`;
+  }
 }

--- a/src/app/lib/checkbox/checkbox.component.html
+++ b/src/app/lib/checkbox/checkbox.component.html
@@ -1,7 +1,16 @@
 <div class="hc-checkbox-container" [ngClass]="{'disabled': disabled}">
-    <input type="checkbox" [attr.id]="name" [disabled]="disabled" [(ngModel)]="model" />
-    <label class="hc-checkbox-overlay" [attr.for]="name"></label>
-    <label class="hc-checkbox-label" [attr.for]="name">
-        <ng-content></ng-content>
-    </label>
+  <input type="checkbox"
+         [id]="inputId"
+         [attr.value]="value"
+         [attr.name]="name"
+         [tabIndex]="tabIndex"
+         [indeterminate]="indeterminate"
+         [disabled]="disabled"
+         [required]="required"
+         (change)="stopChangeEvent($event)"
+         (click)="clickEvent($event)"/>
+  <label class="hc-checkbox-overlay" [attr.for]="inputId"></label>
+  <label class="hc-checkbox-label" [attr.for]="inputId">
+    <ng-content></ng-content>
+  </label>
 </div>

--- a/src/app/lib/checkbox/checkbox.component.scss
+++ b/src/app/lib/checkbox/checkbox.component.scss
@@ -1,66 +1,66 @@
 @import '../colors';
 
 .hc-checkbox-container {
-    position: relative;
+  position: relative;
 
-    .hc-checkbox-overlay {
-        background-color: $white;
-        border: 2px solid $gray-300;
-        border-radius: 3px;
-        cursor: pointer;
-        height: 18px;
-        left: 0;
-        position: absolute;
-        top: 0;
-        width: 18px;
+  .hc-checkbox-overlay {
+    background-color: $white;
+    border: 2px solid $gray-300;
+    border-radius: 3px;
+    cursor: pointer;
+    height: 18px;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 18px;
 
-        &:hover {
-            border: 2px solid $primary-brand;
-          }
-
-        &:after {
-            border: 3px solid $white;
-            border-top: none;
-            border-right: none;
-            content: "";
-            height: 5px;
-            left: 3px;
-            opacity: 0;
-            position: absolute;
-            top: 3.5px;
-            transform: rotate(-45deg);
-            width: 10px;
-        }
+    &:hover {
+      border: 2px solid $primary-brand;
     }
 
-    &.disabled {
-        label:first-of-type {
-            background-color: $gray-200;
-            border-color: $gray-300;
-            cursor: not-allowed;
-        }
-
-        .hc-checkbox-label {
-            color: $gray-300;
-            cursor: not-allowed;
-        }
+    &:after {
+      border: 3px solid $white;
+      border-top: none;
+      border-right: none;
+      content: "";
+      height: 5px;
+      left: 3px;
+      opacity: 0;
+      position: absolute;
+      top: 3.5px;
+      transform: rotate(-45deg);
+      width: 10px;
     }
+  }
 
-    input[type="checkbox"] {
-        visibility: hidden;
-
-        &:checked + label {
-            background-color: $primary-brand;
-            border-color: $primary-brand;
-        }
-
-        &:checked + label:after {
-            opacity: 1;
-        }
+  &.disabled {
+    label:first-of-type {
+      background-color: $gray-200;
+      border-color: $gray-300;
+      cursor: not-allowed;
     }
 
     .hc-checkbox-label {
-        margin-left: 10px;
-        cursor: pointer;
+      color: $gray-300;
+      cursor: not-allowed;
     }
+  }
+
+  input[type="checkbox"] {
+    visibility: hidden;
+
+    &:checked + label {
+      background-color: $primary-brand;
+      border-color: $primary-brand;
+    }
+
+    &:checked + label:after {
+      opacity: 1;
+    }
+  }
+
+  .hc-checkbox-label {
+    margin-left: 10px;
+    cursor: pointer;
+  }
 }

--- a/src/app/lib/checkbox/checkbox.component.ts
+++ b/src/app/lib/checkbox/checkbox.component.ts
@@ -1,21 +1,158 @@
-/* tslint:disable:component-selector */
+/* tslint:disable:no-use-before-declare */
 
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  Attribute,
+  Component,
+  EventEmitter,
+  forwardRef,
+  HostBinding,
+  HostListener,
+  Input,
+  Output
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+let nextCheckboxId = 1;
+
+export class CheckboxChangeEvent {
+  constructor(public source: CheckboxComponent, public checked: boolean) {
+  }
+}
+
+export const hcCheckboxValueAccessor: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => CheckboxComponent),
+  multi: true
+};
 
 @Component({
-    selector: 'hc-checkbox',
-    templateUrl: './checkbox.component.html',
-    styleUrls: ['./checkbox.component.scss']
+  selector: 'hc-checkbox',
+  templateUrl: './checkbox.component.html',
+  styleUrls: ['./checkbox.component.scss'],
+  providers: [hcCheckboxValueAccessor],
+  exportAs: 'hcCheckbox'
 })
-export class CheckboxComponent implements OnInit {
-    @Input() name: string;
-    @Input() disabled: boolean = false;
-    @Input() model: boolean;
+export class CheckboxComponent implements ControlValueAccessor {
+  private uniqueId = `hc-checkbox-${nextCheckboxId++}`;
+  private _checked: boolean = false;
+  private _required: boolean = false;
+  private _disabled: boolean = false;
+  private _tabIndex: number;
 
-    constructor() {
-    }
+  // list out all properties or attributes an input[type=checkbox] can have since we're wrapping the input
+  @Input() value: string;
+  @Input() indeterminate: boolean;
+  @Input() id: string = this.uniqueId;
+  @Input() name: string | null = null;
 
-    ngOnInit() {
-        this.disabled = <any>this.disabled === 'true';
+  @Output() change = new EventEmitter<CheckboxChangeEvent>();
+
+  @HostListener('blur')
+  onBlur() {
+    this.onTouchFunc();
+  }
+
+  @HostBinding('attr.id')
+  get getHostId(): string {
+    return this.uniqueId;
+  }
+
+  @Input()
+  get required(): boolean {
+    return this._required;
+  }
+
+  set required(required) {
+    this._required = this.anyToBoolean(required);
+  }
+
+  @Input()
+  get disabled(): boolean {
+    return this._disabled;
+  }
+
+  set disabled(isDisabled) {
+    this._disabled = this.anyToBoolean(isDisabled);
+  }
+
+  @Input()
+  get checked(): boolean {
+    return this._checked;
+  }
+
+  set checked(checked: boolean) {
+    if (this._checked === checked) {
+      return;
     }
+    this._checked = checked;
+  }
+
+  get tabIndex(): number {
+    return this.disabled ? -1 : this._tabIndex;
+  }
+
+  set tabIndex(value: number) {
+    this._tabIndex = value == null ? 0 : value;
+  }
+
+  get inputId() {
+    if (this.id) {
+      return this.id;
+    }
+    return `${this.uniqueId}-input`;
+  }
+
+  private onChangeFunc: (value: any) => void = () => {
+  };
+
+  private onTouchFunc: () => any = () => {
+  };
+
+  constructor(@Attribute('tabindex') tabindex: string) {
+    this.tabIndex = parseInt(tabindex, 10) || 0;
+  }
+
+  writeValue(value: any): void {
+    this.checked = !!value;
+  }
+
+  registerOnChange(fn: (value: any) => void): void {
+    this.onChangeFunc = fn;
+  }
+
+  registerOnTouched(fn: () => any): void {
+    this.onTouchFunc = fn;
+  }
+
+  toggle() {
+    this.checked = !this.checked;
+  }
+
+  clickEvent(event: Event) {
+    event.stopPropagation(); // prevent native click event from being dispatched
+
+    if (!this.disabled) {
+      this.toggle();
+      this.emitChangeEvent();
+    }
+  }
+
+  stopChangeEvent(event: Event) {
+    event.stopPropagation(); // prevent native change event from emitting its own object through output 'change'
+  }
+
+  private emitChangeEvent(): void {
+    this.onChangeFunc(this.checked);
+    this.change.emit(new CheckboxChangeEvent(this, this.checked));
+  }
+
+  private anyToBoolean(value: any): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return value === 'true';
+    }
+    return !!value;
+  }
 }

--- a/src/app/lib/checkbox/index.ts
+++ b/src/app/lib/checkbox/index.ts
@@ -1,0 +1,2 @@
+export * from './checkbox.module';
+export * from './checkbox.component';


### PR DESCRIPTION
Updated checkbox so that it is compatible with angular's reactive and template forms. Added support for more of the input element's native attributes and properties. I didn't mess with any of the component's styles. The alterations to the css is a format change, and I don't know why tslint seems to be letting these differences get through. This is purely a functional update