### PR TITLE
Removed button dropdown and glyph

### DIFF
--- a/src/app/lib/button/anchor.component.ts
+++ b/src/app/lib/button/anchor.component.ts
@@ -2,7 +2,7 @@
 /* tslint:disable:use-host-property-decorator */
 // https://github.com/mgechev/codelyzer/issues/178#issuecomment-265154480
 
-import { ChangeDetectionStrategy, Component, ElementRef, HostListener, Renderer2 } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Renderer2 } from '@angular/core';
 import { ButtonComponent } from './button.component';
 
 @Component({
@@ -17,6 +17,12 @@ import { ButtonComponent } from './button.component';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AnchorComponent extends ButtonComponent {
+
+  @HostBinding('class.hc-anchor')
+  get getAnchorClass(): boolean {
+    return true;
+  }
+
   constructor(elementRef: ElementRef,
               renderer: Renderer2) {
     super(elementRef, renderer);

--- a/src/app/lib/button/button-demo/button-demo.component.html
+++ b/src/app/lib/button/button-demo/button-demo.component.html
@@ -1,98 +1,109 @@
 <div class="demo-page">
-    <h2 style="margin: 0">Button</h2>
-    <h4 style="font-weight: 300; margin-top: 0">Buttons communicate the action that will occur when the user touches
-        them.</h4>
-    <h5>
-        Primary Buttons (Normal Size)
-    </h5>
-    <div class="sample-buttons">
-        <button hc-button title="Primary Button" color="primary">Primary</button>
-        <button hc-button title="Primary-Alt Button" color="primary-alt">Primary Alt</button>
-        <button hc-button title="Destructive Button" color="destructive">Destructive</button>
-        <button hc-button title="Neutral Button" color="neutral" >Neutral</button>
+  <h2 style="margin: 0">Button</h2>
+  <h4 style="font-weight: 300; margin-top: 0">Buttons communicate the action that will occur when the user touches
+    them.</h4>
+  <h5>
+    Primary Buttons (Normal Size)
+  </h5>
+  <div class="sample-buttons">
+    <button hc-button title="Primary Button" color="primary">Primary</button>
+    <button hc-button title="Primary-Alt Button" color="primary-alt">Primary Alt</button>
+    <button hc-button title="Destructive Button" color="destructive">Destructive</button>
+    <button hc-button title="Neutral Button" color="neutral">Neutral</button>
+  </div>
+  <h5>
+    Buttons w/ Icons
+  </h5>
+  <div class="sample-buttons" style="width: 50%">
+    <button hc-button title="Icon Button" color="primary">
+      <hc-icon fontSet="fa" fontIcon="fa-cog"></hc-icon>
+      Options
+    </button>
+    <button hc-button title="Icon Button" color="neutral">
+      <hc-icon fontSet="fa" fontIcon="fa-home"></hc-icon>
+      Home
+    </button>
+  </div>
+  <h5>
+    Secondary Buttons
+  </h5>
+  <button hc-button title="Secondary Button" color="secondary">Secondary Button</button>
+  <h5>
+    Disabled Buttons
+  </h5>
+  <button hc-button title="Disabled Button" color="primary" [disabled]="true">Disabled Button</button>
+  <h5>
+    Tertiary Buttons
+  </h5>
+  <button hc-button title="Tertiary Button" color="tertiary">Tertiary Button</button>
+  <h5>
+    Anchor Links
+  </h5>
+  <a hc-button title="Anchor Link">Anchor Link</a>
+  <br>
+  <br>
+  <hr style="height:1px;border:none;background-color:#E5E5E5;">
+  <br>
+
+  <p class="description">
+    <b>Color Variations</b>
+    <br>Above are all acceptable colors and their active states. Green should be used for most cases and especially
+    cases the
+    action is positive or in agreement. For negative actions use red. The purple and gray variations should be used
+    only in
+    cases where more colors are needed or if they are being placed on backgrounds which green doesn’t contrast well
+    enough.
+    Icons, if needed, should match text color of the button.</p>
+  <br>
+  <p class="description">
+    <b>Usage</b>
+    <br>Generally, there should only be one primary button per page. All other interactive items should either be
+    secondary buttons
+    or text links. A few scenarios in which there would be multiple primary buttons: a modal with both an “accept”
+    and “decline”
+    action, a page who’s content are non related and each content section have disparate actions associated with
+    them. For
+    modals the preference is one primary button and a cancel action set as a text link. Below are some examples of
+    buttons
+    usage.
+  </p>
+
+  <br>
+  <hr style="height:1px;border:none;background-color:#E5E5E5;">
+  <br>
+
+  <div class="headerName">Angular Component</div>
+  <br>
+  <div id="HTML" *ngIf="showTemplate">
+    <div class="codeToggle">
+      <span class="toggleOptionOn" (click)="viewToggle('html')">HTML</span>
+      <span class="toggleOptionOff" (click)="viewToggle('ts')">TypeScript</span>
     </div>
-    <h5>
-        Buttons w/ Glyphs
-    </h5>
-    <div class="sample-buttons" style="width: 50%">
-        <button hc-button title="Glyph Dropdown Button" color="primary" glyph="fa-cog" dropdown="true">Options</button>
-        <button hc-button title="Dropdown Button" color="primary-alt" dropdown="true">Dropdown</button>
-        <button hc-button title="Glyph Button" color="neutral" glyph="fa-home">Home</button>
-    </div>
-    <h5>
-        Secondary Buttons
-    </h5>
-    <button hc-button title="Secondary Button" color="secondary">Secondary Button</button>
-    <h5>
-        Disabled Buttons
-    </h5>
-    <button hc-button title="Disabled Button" color="primary" [disabled]="true">Disabled Button</button>
-    <h5>
-        Tertiary Buttons
-    </h5>
-    <button hc-button title="Tertiary Button" color="tertiary">Tertiary Button</button>
-    <h5>
-        Anchor Links
-    </h5>
-    <a hc-button title="Anchor Link">Anchor Link</a>
-    <br>
-    <br>
-    <hr style="height:1px;border:none;background-color:#E5E5E5;">
-    <br>
-
-    <p class="description">
-        <b>Color Variations</b>
-        <br>Above are all acceptable colors and their active states. Green should be used for most cases and especially
-        cases the
-        action is positive or in agreement. For negative actions use red. The purple and gray variations should be used
-        only in
-        cases where more colors are needed or if they are being placed on backgrounds which green doesn’t contrast well
-        enough.
-        Icons, if needed, should match text color of the button.</p>
-    <br>
-    <p class="description">
-        <b>Usage</b>
-        <br>Generally, there should only be one primary button per page. All other interactive items should either be
-        secondary buttons
-        or text links. A few scenarios in which there would be multiple primary buttons: a modal with both an “accept”
-        and “decline”
-        action, a page who’s content are non related and each content section have disparate actions associated with
-        them. For
-        modals the preference is one primary button and a cancel action set as a text link. Below are some examples of
-        buttons
-        usage.
-    </p>
-
-    <br>
-    <hr style="height:1px;border:none;background-color:#E5E5E5;">
-    <br>
-
-    <div class="headerName">Angular Component</div>
-    <br>
-    <div id="HTML" *ngIf="showTemplate">
-        <div class="codeToggle">
-            <span class="toggleOptionOn" (click)="viewToggle('html')">HTML</span>
-            <span class="toggleOptionOff" (click)="viewToggle('ts')">TypeScript</span>
-        </div>
-        <pre>
+    <pre>
             <code>
-    &#x3C;button hc-button 
-        title=&#x22;Button Tile&#x22; color=&#x22;primary&#x22; glyph=&#x22;fa-cog&#x22; dropdown=&#x22;true&#x22; [disabled]=false&#x3E;
+    &#x3C;button hc-button
+        title=&#x22;Button Tile&#x22; color=&#x22;primary&#x22; [disabled]=false&#x3E;
             Button Name
     &#x3C;/button&#x3E;
             </code>
             <code>
     &#x3C;a hc-button title=&#x22;Anchor Link&#x22; [disabled]=false&#x3E;Anchor Link&#x3C;/a&#x3E;
             </code>
+      <code>
+        &lt;button hc-button title=&quot;Icon Button&quot; color=&quot;primary&quot;&gt;
+          &lt;hc-icon fontSet=&quot;fa&quot; fontIcon=&quot;fa-cog&quot;&gt;&lt;/hc-icon&gt;
+          Options
+        &lt;/button&gt;
+      </code>
         </pre>
-    </div>
+  </div>
 
-    <div id="TS" *ngIf="!showTemplate">
-        <div class="codeToggle">
-            <span class="toggleOptionOff" (click)="viewToggle('html')">HTML</span>
-            <span class="toggleOptionOn" (click)="viewToggle('ts')">TypeScript</span>
-        </div>
-        <pre><code>import &#123; ButtonModule &#125; from &#x27;@healthcatalyst/cashmere&#x27;;
+  <div id="TS" *ngIf="!showTemplate">
+    <div class="codeToggle">
+      <span class="toggleOptionOff" (click)="viewToggle('html')">HTML</span>
+      <span class="toggleOptionOn" (click)="viewToggle('ts')">TypeScript</span>
+    </div>
+    <pre><code>import &#123; ButtonModule &#125; from &#x27;@healthcatalyst/cashmere&#x27;;
 
 @NgModule(&#123;
   imports: [
@@ -103,44 +114,30 @@
   exports: [..]
 &#125;)
 export class SomeModule &#123; &#125;</code></pre>
-        <br>
-    </div>
+    <br>
+  </div>
 
-    <br>
-    <hr style="height:1px;border:none;background-color:#E5E5E5;">
-    <br>
-    <div class="headerName">Component Parameters</div>
-    <br>
+  <br>
+  <hr style="height:1px;border:none;background-color:#E5E5E5;">
+  <br>
+  <div class="headerName">Component Parameters</div>
+  <br>
 
-    <table class="apiTable parameters">
-        <tr>
-            <th>color</th>
-            <td>
-                <span>Type:</span> String
-            </td>
-            <td width=50%>Sets the button's theme color</td>
-        </tr>
-        <tr>
-            <th>[disabled]</th>
-            <td>
-                <span>Type:</span> Boolean
-            </td>
-            <td width=50%>Boolean value that enables/disables the button</td>
-        </tr>
-        <tr>
-            <th>glyph</th>
-            <td>
-                <span>Type:</span> String
-            </td>
-            <td width=50%>FontAwesome glyph to include before the button name (eg. "fa-cog")</td>
-        </tr>
-        <tr>
-            <th>dropdown</th>
-            <td>
-                <span>Type:</span> Boolean
-            </td>
-            <td width=50%>Set to true to include a dropdown indicator</td>
-        </tr>
-    </table>
+  <table class="apiTable parameters">
+    <tr>
+      <th>color</th>
+      <td>
+        <span>Type:</span> String
+      </td>
+      <td width=50%>Sets the button's theme color</td>
+    </tr>
+    <tr>
+      <th>[disabled]</th>
+      <td>
+        <span>Type:</span> Boolean
+      </td>
+      <td width=50%>Boolean value that enables/disables the button</td>
+    </tr>
+  </table>
 
 </div>

--- a/src/app/lib/button/button.component.scss
+++ b/src/app/lib/button/button.component.scss
@@ -5,7 +5,7 @@
 /// @param {Color} $color - base color of the button
 /// @param {Number} $darken-pct - percentage amount by which to darken color in hover(1x) and active(2x) states
 /// @return {Color}
-@mixin colorButton($color, $darken-pct: 10%){
+@mixin colorButton($color, $darken-pct: 10%) {
   color: $white;
   background-color: $color;
 
@@ -22,19 +22,19 @@
   }
 }
 
-:host {
-  padding-left: 20px;
-  padding-right: 20px;
+.hc-button {
+  padding: 0 20px;
   height: 35px;
   min-width: 150px;
   font-size: 15px;
-  line-height: 20px;
+  line-height: 35px;
   display: inline-block;
   margin-bottom: 0;
   font-weight: normal;
   text-align: center;
   white-space: nowrap;
-  vertical-align: middle;
+  vertical-align: baseline;
+
   touch-action: manipulation;
   cursor: pointer;
   user-select: none;
@@ -52,58 +52,61 @@
     background-image: none;
     outline: none;
   }
+
+  .hc-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    vertical-align: middle;
+  }
+
+  &.hc-primary {
+    @include colorButton($primary-action);
+  }
+
+  &.hc-primary-alt {
+    @include colorButton($primary-alt-action);
+  }
+
+  &.hc-destructive {
+    @include colorButton($destructive-action);
+  }
+
+  &.hc-neutral {
+    @include colorButton($neutral-action);
+  }
+
+  &.hc-secondary {
+    @include colorButton($gray-100, 5%);
+    color: $gray-600;
+    border: 2px solid $gray-300;
+  }
+
+  &.hc-tertiary {
+    background-color: transparent;
+    color: $primary-brand;
+    font-weight: bold;
+
+    &:hover {
+      color: lighten($primary-brand, 10%);
+    }
+    &:active {
+      color: darken($primary-brand, 10%);
+    }
+
+    &[disabled] {
+      color: $gray-500;
+    }
+  }
 }
 
-:host(.hc-primary) { @include colorButton($primary-action);}
-:host(.hc-primary-alt) { @include colorButton($primary-alt-action); }
-:host(.hc-destructive) { @include colorButton($destructive-action); }
-:host(.hc-neutral) { @include colorButton($neutral-action); }
-
-:host(.hc-secondary) {
-  @include colorButton($gray-100, 5%);
-  color: $gray-600;
-  border: 2px solid $gray-300;
-}
-
-:host(.hc-tertiary) {
-  background-color: transparent;
+.hc-anchor {
   color: $primary-brand;
-  font-weight: bold;
 
-  &:hover {
-    color: lighten($primary-brand, 10%);
-  }
-  &:active {
-    color: darken($primary-brand, 10%);
-  }
-
-  &[disabled] {
-    color: $gray-500;
-  }
-}
-
-.button-glyph {
-  display: inline-block;
-  vertical-align: bottom;
-  font-size: 20px;
-  padding-right: 7px;
-  line-height: 20px;
-}
-
-.button-dropdown {
-  display: inline-block;
-  vertical-align: bottom;
-  font-size: 12px;
-  padding-left: 3px;
-  line-height: 20px;
-}
-
-:host( a ) {
-  color: $primary-brand;
-  padding-left: 0px;
-  padding-right: 0px;
-  min-width: 0px;
-  height:auto;
+  padding-left: 0;
+  padding-right: 0;
+  min-width: 0;
+  height: auto;
   text-decoration: none;
   border: none;
 

--- a/src/app/lib/button/button.component.ts
+++ b/src/app/lib/button/button.component.ts
@@ -2,7 +2,17 @@
 /* tslint:disable:use-host-property-decorator */
 // https://github.com/mgechev/codelyzer/issues/178#issuecomment-265154480
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnChanges, Renderer2, SimpleChanges } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostBinding,
+  Input,
+  OnChanges,
+  Renderer2,
+  SimpleChanges,
+  ViewEncapsulation
+} from '@angular/core';
 
 export function throwErrorForInvalidButtonColor(unsupportedColor: string) {
   throw Error('Unsupported color input value: ' + unsupportedColor);
@@ -12,22 +22,24 @@ export type ButtonColor = 'primary' | 'primary-alt' | 'destructive' | 'neutral' 
 
 @Component({
   selector: 'button[hc-button]',
-  template: `<i *ngIf="glyph" class="fa {{glyph}} button-glyph"></i>
-  <ng-content></ng-content>
-  <i *ngIf="dropdown" class="fa fa-chevron-down fa-fw button-dropdown"></i>`,
+  template: '<ng-content></ng-content>',
   styleUrls: ['./button.component.scss'],
   host: {
     '[disabled]': 'disabled || null',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None
 })
 export class ButtonComponent implements OnChanges {
   private supportedColors = ['primary', 'primary-alt', 'destructive', 'neutral', 'secondary', 'tertiary'];
 
   @Input() color: ButtonColor = 'primary';
   @Input() disabled = false;
-  @Input() dropdown: boolean = false;
-  @Input() glyph: string;
+
+  @HostBinding('class.hc-button')
+  get hostClass(): boolean {
+    return true;
+  }
 
   constructor(private elementRef: ElementRef,
               private renderer: Renderer2) {

--- a/src/app/lib/popover/popover-demo/popover-demo.component.html
+++ b/src/app/lib/popover/popover-demo/popover-demo.component.html
@@ -1,12 +1,13 @@
 <div class="demo-page">
   <h2>Popover</h2>
-  <p>A lightweight, extensible component for fancy popover creation. The popover directive supports multiple placements, optional
+  <p>A lightweight, extensible component for fancy popover creation. The popover directive supports multiple placements,
+    optional
     transition animation, and more.</p>
   <h3>Popover with List Items</h3>
   <button hc-button color="primary" [hcPopover]="options" popperPlacement="bottom" aria-hidden="true">
-    <i class="fa fa-gear" aria-hidden="true"></i>
+    <hc-icon fontSet="fa" fontIcon="fa-gear"></hc-icon>
     &nbsp;Options&nbsp;
-    <i class="fa fa-angle-down" aria-hidden="true"></i>
+    <hc-icon fontSet="fa" fontIcon="fa-angle-down"></hc-icon>
   </button>
   <hc-popover-content #options>
     <ul class="list-options">
@@ -34,119 +35,121 @@
     <br>
     <input type="text" [(ngModel)]="body">
   </div>
-  <button hc-button color="primary" [hcPopover]="dynamic" popperPlacement="bottom" [popperCloseOnClickOutside]="false" aria-hidden="true">Click Me</button>
+  <button hc-button color="primary" [hcPopover]="dynamic" popperPlacement="bottom" [popperCloseOnClickOutside]="false"
+          aria-hidden="true">Click Me
+  </button>
   <hc-popover-content #dynamic>
     <span [(innerText)]="body"></span>
   </hc-popover-content>
   <h3>Properties</h3>
   <table>
     <thead>
-      <tr>
-        <th>Option</th>
-        <th>Type</th>
-        <th>Default</th>
-      </tr>
+    <tr>
+      <th>Option</th>
+      <th>Type</th>
+      <th>Default</th>
+    </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>popperDisableAnimation</td>
-        <td>boolean</td>
-        <td>false</td>
-      </tr>
-      <tr>
-        <td>popperDisableStyle</td>
-        <td>boolean</td>
-        <td>false</td>
-      </tr>
-      <tr>
-        <td>popperDisabled</td>
-        <td>boolean</td>
-        <td>false</td>
-      </tr>
-      <tr>
-        <td>popperDelay</td>
-        <td>number</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>popperTimeout</td>
-        <td>number</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>popperTimeoutAfterShow</td>
-        <td>number</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>popperPlacement</td>
-        <td>Placement(string)</td>
-        <td>auto</td>
-      </tr>
-      <tr>
-        <td>popperTarget</td>
-        <td>HtmlElement</td>
-        <td>auto</td>
-      </tr>
-      <tr>
-        <td>popperBoundaries</td>
-        <td>string(selector)</td>
-        <td>undefined</td>
-      </tr>
-      <tr>
-        <td>popperShowOnStart</td>
-        <td>number</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>popperTrigger</td>
-        <td>Trigger(string)</td>
-        <td>hover</td>
-      </tr>
-      <tr>
-        <td>popperPositionFixed</td>
-        <td>boolean</td>
-        <td>false</td>
-      </tr>
-      <tr>
-        <td>popperHideOnClickOutside</td>
-        <td>boolean</td>
-        <td>true</td>
-      </tr>
-      <tr>
-        <td>popperHideOnScroll</td>
-        <td>boolean</td>
-        <td>false</td>
-      </tr>
-      <tr>
-        <td>popperForceDetection</td>
-        <td>boolean</td>
-        <td>false</td>
-      </tr>
-      <tr>
-        <td>popperTrigger</td>
-        <td>Trigger(string)</td>
-        <td>hover</td>
-      </tr>
-      <tr>
-        <td>popperModifiers</td>
-        <td>popperModifier</td>
-        <td>undefined</td>
-      </tr>
-      <tr>
-        <td>popperOnShown</td>
-        <td>EventEmitter</td>
-        <td>$event</td>
-      </tr>
-      <tr>
-        <td>popperOnHidden</td>
-        <td>EventEmitter</td>
-        <td>$event</td>
-      </tr>
+    <tr>
+      <td>popperDisableAnimation</td>
+      <td>boolean</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <td>popperDisableStyle</td>
+      <td>boolean</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <td>popperDisabled</td>
+      <td>boolean</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <td>popperDelay</td>
+      <td>number</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>popperTimeout</td>
+      <td>number</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>popperTimeoutAfterShow</td>
+      <td>number</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>popperPlacement</td>
+      <td>Placement(string)</td>
+      <td>auto</td>
+    </tr>
+    <tr>
+      <td>popperTarget</td>
+      <td>HtmlElement</td>
+      <td>auto</td>
+    </tr>
+    <tr>
+      <td>popperBoundaries</td>
+      <td>string(selector)</td>
+      <td>undefined</td>
+    </tr>
+    <tr>
+      <td>popperShowOnStart</td>
+      <td>number</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>popperTrigger</td>
+      <td>Trigger(string)</td>
+      <td>hover</td>
+    </tr>
+    <tr>
+      <td>popperPositionFixed</td>
+      <td>boolean</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <td>popperHideOnClickOutside</td>
+      <td>boolean</td>
+      <td>true</td>
+    </tr>
+    <tr>
+      <td>popperHideOnScroll</td>
+      <td>boolean</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <td>popperForceDetection</td>
+      <td>boolean</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <td>popperTrigger</td>
+      <td>Trigger(string)</td>
+      <td>hover</td>
+    </tr>
+    <tr>
+      <td>popperModifiers</td>
+      <td>popperModifier</td>
+      <td>undefined</td>
+    </tr>
+    <tr>
+      <td>popperOnShown</td>
+      <td>EventEmitter</td>
+      <td>$event</td>
+    </tr>
+    <tr>
+      <td>popperOnHidden</td>
+      <td>EventEmitter</td>
+      <td>$event</td>
+    </tr>
     </tbody>
   </table>
   <h3>popperPlacement</h3>
-  <pre><code>'top' | 'bottom' | 'left' | 'right' | 'top-start' | 'bottom-start' | 'left-start' | 'right-start' | 'top-end' | 
+  <pre><code>'top' | 'bottom' | 'left' | 'right' | 'top-start' | 'bottom-start' | 'left-start' | 'right-start' | 'top-end' |
 'bottom-end' | 'left-end' | 'right-end' | 'auto' | 'auto-top' | 'auto-bottom' | 'auto-left' | 'auto-right' | Function</code></pre>
 
   <h3>popperTrigger</h3>


### PR DESCRIPTION
I've removed the glyph input because the same thing can be achieved with using hc-icon like:

```html
<button hc-button>
  <hc-icon fontSet="fa" fontIcon="fa-cog"></hc-icon>
  Options
</button>
```

The benefit of this is that you can put the icon where ever you need it and you're not restricted to fontawesome.

I removed the dropdown because I'll be creating a new button dropdown component that uses the new popover.