### PR TITLE
Adds Accordion component

### DIFF
--- a/docs/app/demo/accordion/accordion-demo.component.html
+++ b/docs/app/demo/accordion/accordion-demo.component.html
@@ -1,0 +1,96 @@
+<hc-subnav>
+    <h2>Accordion</h2>
+</hc-subnav>
+
+<div class="demo-content">
+    <p>Accordion allows you to expand/contract </p>
+
+    <h4>Accordion</h4>
+    <div class="sample-container">
+        <hc-accordion [triggerAlign]="alignment" [hideToolbar]="hideToolbar" #accordion>
+            <hc-accordion-toolbar>Toolbar</hc-accordion-toolbar>
+            Content
+        </hc-accordion>
+
+        <button hc-button (click)="accordion.toggle()">Toggle</button>
+        <button hc-button (click)="toggleAlign()">Toggle Alignment</button>
+        <button hc-button (click)="toggleToolbar()">Toggle Toolbar</button>
+    </div>
+
+    <hr>
+
+    <h3>Accordion Usage</h3>
+    <p>When you have auxiliary data to show the user that isn't necessary for them to see</p>
+
+    <hr>
+
+    <h3>Angular Component</h3>
+    <hc-tab-set direction="horizontal">
+        <hc-tab title="HTML">
+            <pre>
+            <code>
+                &lt;hc-accordion [triggerAlign]=&quot;alignment&quot; [hideToolbar]=&quot;showToolbar&quot;&gt;
+                    &lt;hc-accordion-toolbar&gt;Toolbar&lt;/hc-accordion-toolbar&gt;
+                    Accordion content
+                &lt;/hc-accordion&gt;
+            </code>
+            </pre>
+        </hc-tab>
+        <hc-tab title="TypeScript">
+            <pre><code>
+    import &#123; AccordionModule &#125; from &#x27;@healthcatalyst/cashmere&#x27;;
+
+    @NgModule(&#123;
+        imports: [
+            ...,
+        AccordionModule,
+        ],
+        declarations: [...],
+        exports: [..]
+    &#125;)
+    export class SomeModule &#123; &#125;
+            </code></pre>
+        </hc-tab>
+    </hc-tab-set>
+
+    <hr>
+
+    <h3>Inputs</h3>
+    <table class="api-table">
+        <tr>
+            <th>triggerAlign</th>
+            <td><span class="type-label">Type:</span>'left' | 'right' (default: 'left')</td>
+            <td>Placement of the toolbar button</td>
+        </tr>
+        <tr>
+            <th>hideToolbar</th>
+            <td><span class="type-label">Type:</span> Boolean</td>
+            <td>Show/Hide the accordion toolbar</td>
+        </tr>
+        <tr>
+            <th>open</th>
+            <td><span class="type-label">Type:</span> Boolean</td>
+            <td>Set accordion opened state</td>
+        </tr>
+    </table>
+
+    <h3>Events</h3>
+    <table class="api-table">
+        <tr>
+            <th>opened</th>
+            <td>Accordion is in the open state</td>
+        </tr>
+        <tr>
+            <th>openStart</th>
+            <td>Accordion is beginning to open</td>
+        </tr>
+        <tr>
+            <th>closed</th>
+            <td>Accordion is in close state</td>
+        </tr>
+        <tr>
+            <th>closeStart</th>
+            <td>Accordion is beginning to close</td>
+        </tr>
+    </table>
+</div>

--- a/docs/app/demo/accordion/accordion-demo.component.ts
+++ b/docs/app/demo/accordion/accordion-demo.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+    templateUrl: './accordion-demo.component.html',
+    styleUrls: ['./accordion-demo.component.scss']
+})
+export class AccordionDemoComponent {
+    alignment = 'left';
+    hideToolbar = false;
+
+    toggleAlign(): void {
+        this.alignment = this.alignment === 'left' ? 'right' : 'left';
+    }
+
+    toggleToolbar(): void {
+        this.hideToolbar = !this.hideToolbar;
+    }
+}

--- a/docs/app/demo/demo-routes.ts
+++ b/docs/app/demo/demo-routes.ts
@@ -16,6 +16,7 @@ import { TabsDemoComponent } from './tabs/tabs-demo.component';
 import { DrawerDemoComponent } from './drawer/drawer-demo.component';
 import { ListDemoComponent } from './list/list-demo.component';
 import { SubnavDemoComponent } from './subnav/subnav-demo.component';
+import { AccordionDemoComponent } from './accordion/accordion-demo.component';
 import { TypographyDemoComponent } from './typography/typography-demo.component';
 import { BreadcrumbsDemoComponent } from './breadcrumbs/breadcrumbs-demo.component';
 import { Breadcrumb1DemoComponent } from './breadcrumbs/breadcrumbs1-demo.component';
@@ -114,6 +115,10 @@ export const routes: Routes = [
             {
                 path: 'list',
                 component: ListDemoComponent
+            },
+            {
+                path: 'accordion',
+                component: AccordionDemoComponent
             },
             {
                 path: '**',

--- a/docs/app/demo/demo.module.ts
+++ b/docs/app/demo/demo.module.ts
@@ -8,7 +8,6 @@ import { RouterModule } from '@angular/router';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
 import { ButtonModule } from '../../../lib/src/button/button.module';
 import { DemoComponent } from './demo.component';
 import { SideNavComponent } from './side-nav/side-nav.component';
@@ -30,7 +29,6 @@ import { SelectModule } from '../../../lib/src/select/select.module';
 import { SelectDemoComponent } from './select/select-demo.component';
 import { AppSwitcherModule } from '../../../lib/src/app-switcher/app-switcher.module';
 import { MockAppSwitcherService } from '../../../lib/src/app-switcher/app-switcher.service';
-import { SelectComponent } from '../../../lib/src/select/select.component';
 import { DrawerDemoComponent } from './drawer/drawer-demo.component';
 import { IconModule } from '../../../lib/src/icon';
 import { DrawerModule } from '../../../lib/src/drawer';
@@ -39,6 +37,8 @@ import { IconDemoComponent } from './icon/icon-demo.component';
 import { ListDemoComponent } from './list/list-demo.component';
 import { SubnavModule } from '../../../lib/src/subnav/subnav.module';
 import { SubnavDemoComponent } from './subnav/subnav-demo.component';
+import { AccordionModule } from '../../../lib/src/accordion/accordion.module';
+import { AccordionDemoComponent } from './accordion/accordion-demo.component';
 import { TypographyDemoComponent } from './typography/typography-demo.component';
 import { BreadcrumbsModule } from '../../../lib/src/breadcrumbs/breadcrumbs.module';
 import { BreadcrumbsDemoComponent } from './breadcrumbs/breadcrumbs-demo.component';
@@ -63,6 +63,7 @@ import { Breadcrumb2DemoComponent } from './breadcrumbs/breadcrumbs2-demo.compon
         ListModule,
         SubnavModule,
         BreadcrumbsModule,
+        AccordionModule,
         RouterModule.forRoot(routes)
     ],
     exports: [
@@ -89,6 +90,8 @@ import { Breadcrumb2DemoComponent } from './breadcrumbs/breadcrumbs2-demo.compon
         Tab3DemoComponent,
         IconDemoComponent,
         ListDemoComponent,
+        SubnavDemoComponent,
+        AccordionDemoComponent,
         SubnavDemoComponent,
         TypographyDemoComponent,
         BreadcrumbsDemoComponent,

--- a/docs/app/demo/side-nav/side-nav.component.html
+++ b/docs/app/demo/side-nav/side-nav.component.html
@@ -49,5 +49,8 @@
         <li>
             <a routerLink="/demo/list" routerLinkActive="active">List</a>
         </li>
+        <li>
+            <a routerLink="/demo/accordion" routerLinkActive="active">Accordion</a>
+        </li>
     </ul>
 </div>

--- a/lib/public_api.ts
+++ b/lib/public_api.ts
@@ -1,3 +1,4 @@
+export * from './src/accordion/accordion.module';
 export * from './src/app-switcher/app-switcher.module';
 export * from './src/button/button.module';
 export * from './src/checkbox/checkbox.module';

--- a/lib/src/accordion/accordion-toolbar.component.ts
+++ b/lib/src/accordion/accordion-toolbar.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component, HostBinding, ViewEncapsulation } from '@angular/core';
+
+@Component({
+    selector: 'hc-accordion-toolbar',
+    template: '<ng-content></ng-content>',
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AccordionToolbarComponent {
+    @HostBinding('class.hc-accordion-toolbar') true;
+}

--- a/lib/src/accordion/accordion.component.html
+++ b/lib/src/accordion/accordion.component.html
@@ -1,0 +1,13 @@
+<div class="hc-toolbar-wrapper" [ngClass]="alignment" *ngIf="!hideToolbar">
+    <button type="button" class="hc-accordion-trigger" (click)="triggerClick($event)"></button>
+    <ng-content select="hc-accordion-toolbar"></ng-content>
+</div>
+
+<div class="hc-accordion-collapse"
+     [@openState]="openState"
+     (@openState.start)="animationStart($event)"
+     (@openState.done)="animationEnd($event)">
+    <div class="hc-accordion-content">
+        <ng-content></ng-content>
+    </div>
+</div>

--- a/lib/src/accordion/accordion.component.scss
+++ b/lib/src/accordion/accordion.component.scss
@@ -1,0 +1,88 @@
+$accordion-border: 1px solid #DDDDDD;
+$accordion-background-color: #F0F0F0;
+$accordion-toolbar-padding: 0 10px;
+
+.hc-accordion {
+    display: block;
+    box-sizing: border-box;
+
+    .hc-toolbar-wrapper {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+
+        &.hc-align-right {
+            .hc-accordion-trigger {
+                order: 1;
+                margin-left: auto;
+            }
+            .hc-accordion-toolbar {
+                order: 0;
+            }
+        }
+    }
+
+    .hc-accordion-trigger {
+        position: relative;
+
+        &::after {
+            display: block;
+            transform: translate(-50%, 2px) rotate(46deg);
+            border-top: 2px solid;
+            border-left: 2px solid;
+            left: 50%;
+            content: "";
+            width: 8px;
+            height: 8px;
+            position: relative;
+        }
+    }
+
+    .hc-accordion-collapse {
+        display: block;
+        overflow: hidden;
+    }
+
+    &.hc-accordion-closed, &.hc-accordion-closing {
+        .hc-accordion-trigger::after {
+            transform: translate(-50%, -2px) rotate(-134deg);
+        }
+    }
+}
+
+.hc-accordion-toolbar {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    box-sizing: border-box;
+    align-items: center;
+    width: 100%;
+    padding: $accordion-toolbar-padding;
+}
+
+.hc-accordion-content {
+    background: white;
+    padding: 12px;
+    //border: $accordion-border;
+    //border-top: none;
+    outline: 0;
+}
+
+.hc-accordion-trigger {
+    height: 50px;
+    width: 50px;
+
+    outline: none;
+    background: transparent;
+    border: none;
+    padding: 0;
+
+    color: deepskyblue;
+
+    &::after {
+        transition: transform 500ms cubic-bezier(0.25, 0.8, 0.25, 1);
+    }
+}
+
+

--- a/lib/src/accordion/accordion.component.ts
+++ b/lib/src/accordion/accordion.component.ts
@@ -1,0 +1,149 @@
+import {
+    AfterContentInit,
+    Component,
+    EventEmitter,
+    HostBinding,
+    Input,
+    Output,
+    ViewEncapsulation
+} from '@angular/core';
+import { animate, AnimationEvent, state, style, transition, trigger } from '@angular/animations';
+import { anyToBoolean } from '../util';
+
+@Component({
+    selector: 'hc-accordion',
+    templateUrl: './accordion.component.html',
+    styleUrls: ['./accordion.component.scss'],
+    exportAs: 'hcAccordion',
+    animations: [
+        trigger('openState', [
+            state('open, open-instant', style({
+                height: '*'
+            })),
+            state('void', style({
+                height: '0px',
+                visibility: 'hidden'
+            })),
+            transition('void => open-instant', animate('0ms')),
+            transition('void <=> open', animate('400ms ease'))
+        ])
+    ],
+    encapsulation: ViewEncapsulation.None
+})
+export class AccordionComponent implements AfterContentInit {
+
+    private animationDisabled = false;
+    private currentlyAnimating = false;
+    private _hideToolbar = false;
+    private _isOpen = false;
+
+    @Input() triggerAlign: 'left' | 'right' = 'left';
+
+    @Input()
+    get hideToolbar(): boolean {
+        return this._hideToolbar;
+    }
+
+    set hideToolbar(hide) {
+        this._hideToolbar = anyToBoolean(hide);
+    }
+
+    @Input()
+    get open(): boolean {
+        return this.isOpen;
+    }
+
+    set open(opened: boolean) {
+        this.toggle(anyToBoolean(opened));
+    }
+
+    @Output() opened = new EventEmitter();
+
+    @Output() openStart = new EventEmitter();
+
+    @Output() closed = new EventEmitter();
+
+    @Output() closeStart = new EventEmitter();
+
+    get isOpen(): boolean {
+        return this._isOpen;
+    }
+
+    @HostBinding('class.hc-accordion') true;
+
+    get alignment(): string {
+        return this.triggerAlign === 'right' ? 'hc-align-right' : '';
+    }
+
+    get openState(): 'void' | 'open-instant' | 'open' {
+        if (this._isOpen) {
+            return this.animationDisabled ? 'open-instant' : 'open';
+        }
+        return 'void';
+    }
+
+    animationStart(event: AnimationEvent): void {
+        this.currentlyAnimating = true;
+
+        const {fromState, toState} = event;
+        if (fromState === 'void' && toState === 'open') {
+            this.openStart.emit();
+        } else if (fromState === 'open' && toState === 'void') {
+            this.closeStart.emit();
+        }
+    }
+
+    animationEnd(event: AnimationEvent): void {
+        const {fromState, toState} = event;
+        if (fromState === 'void' && toState === 'open') {
+            this.opened.emit();
+        } else if (fromState === 'open' && toState === 'void') {
+            this.closed.emit();
+        }
+
+        this.currentlyAnimating = false;
+    }
+
+    @HostBinding('class.hc-accordion-opened')
+    get isOpened(): boolean {
+        return this._isOpen && !this.currentlyAnimating;
+    }
+
+    @HostBinding('class.hc-accordion-opening')
+    get isOpening(): boolean {
+        return this._isOpen && this.currentlyAnimating;
+    }
+
+    @HostBinding('class.hc-accordion-closed')
+    get isClosed(): boolean {
+        return !this._isOpen && !this.currentlyAnimating;
+    }
+
+    @HostBinding('class.hc-accordion-closing')
+    get isClosing(): boolean {
+        return !this._isOpen && this.currentlyAnimating;
+    }
+
+    ngAfterContentInit(): void {
+        this.animationDisabled = false;
+    }
+
+    triggerClick(event: Event): void {
+        event.stopPropagation();
+        this.toggle();
+    }
+
+    openAccordion(): void {
+        return this.toggle(true);
+    }
+
+    closeAccordion(): void {
+        return this.toggle(false);
+    }
+
+    toggle(isOpen: boolean = !this.open): void {
+        if (!this.currentlyAnimating) {
+            this._isOpen = isOpen;
+        }
+    }
+}

--- a/lib/src/accordion/accordion.module.ts
+++ b/lib/src/accordion/accordion.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AccordionComponent } from './accordion.component';
+import { AccordionToolbarComponent } from './accordion-toolbar.component';
+
+@NgModule({
+    imports: [CommonModule],
+    declarations: [
+        AccordionComponent,
+        AccordionToolbarComponent
+    ],
+    exports: [
+        AccordionComponent,
+        AccordionToolbarComponent
+    ]
+})
+export class AccordionModule {
+}

--- a/lib/src/accordion/index.ts
+++ b/lib/src/accordion/index.ts
@@ -1,0 +1,3 @@
+export * from './accordion.component';
+export * from './accordion-toolbar.component';
+export * from './accordion.module';


### PR DESCRIPTION
For now I've left the styling very bare. This component allows you to have an accordion which expands/contracts a section in the DOM. There are properties that allow you to change the location of the trigger button and if you wish you could hide the toolbar at the top completely and toggle the accordion with a button anywhere on the DOM styled as you want.

In the future, if others would find it useful, I will add a parent component which controls sibling accordions so that when one accordion is expanded the others are closed, so you only have one accordion in focus at one time

Closes #99