### PR TITLE
Remove footer from home page

### DIFF
--- a/docs/app/home/home.component.html
+++ b/docs/app/home/home.component.html
@@ -40,14 +40,3 @@
     </section>
     <section><button hc-button title="Learn more about Cashmere" color="primary" routerLink="/styles">Get Started</button></section>
 </main>
-<footer>
-    <span class="footerLogo">
-        <img src="../../assets/CashmereLogoWhite.svg" alt="Fabric.Cashmere Logo"/>
-    </span>
-    <span class="footerVersion">
-        <p>Current Version: <b>0.0.3</b></p>
-    </span>
-    <span class="footerLicense">
-        <p>Powered by Health Catalyst<br>Code licensed under the Apache License, Version 2.0</p>
-    </span>
-</footer>


### PR DESCRIPTION
I yanked this out in a previous PR without explaining, and I saw it find it's way back in - but since I removed the CSS too it's messing up the home page.  The reason I pull out the footer is because I'd like to wrap the content it contained into an About Modal as soon as we get #107 added - nudge, nudge @joeskeen :-P

That way will be more consistent with where other Catalyst apps store version info, etc.  And we want Cashmere's demo site to be a model for other apps.  So that's why I pulled the footer out.