### PR TITLE
Tab height fix

### DIFF
--- a/docs/app/components/tabs/tabs-demo.component.scss
+++ b/docs/app/components/tabs/tabs-demo.component.scss
@@ -1,12 +1,10 @@
 @import "colors";
 
 .tab-demo {
-    height: 200px;
     border: 1px solid $gray-200;
 }
 
 .demo-tab-content {
     padding: 15px;
     display: block;
-    height: 134px;
 }

--- a/lib/src/tabs/tab-set.component.scss
+++ b/lib/src/tabs/tab-set.component.scss
@@ -1,6 +1,13 @@
 @import '../sass/cashmere';
 
-:host {
+.horizontal-container {
+    height: auto;
+    width: 100%;
+}
+
+.vertical-container {
+    display: table;
+    height: 100%;
     width: 100%;
 }
 
@@ -8,8 +15,7 @@
     padding-top: 15px;
     background-color: $white;
     width: 20%;
-    float: left;
-    height: 100%;
+    display: table-cell;
 }
 
 .tab-vertical {
@@ -33,9 +39,7 @@
 .tab-content-vertical {
     background-color: $slate-gray-100;
     width: 80%;
-    float: right;
-    height: 100%;
-    overflow: auto;
+    display: table-cell;
 }
 
 .tab-bar-horizontal {

--- a/lib/src/tabs/tab-set.component.ts
+++ b/lib/src/tabs/tab-set.component.ts
@@ -11,6 +11,7 @@ export function throwErrorForMissingRouterLink(tabsWithoutRouterLink: TabCompone
 
 @Component({
     template: `
+        <div class="{{direction}}-container">
             <div class="tab-bar-{{direction}}">
                 <div *ngFor="let tab of tabs">
                     <a *ngIf="routerEnabled" class="tab-{{direction}}"
@@ -31,7 +32,8 @@ export function throwErrorForMissingRouterLink(tabsWithoutRouterLink: TabCompone
                  <router-outlet *ngIf="routerEnabled"></router-outlet>
                  <ng-content *ngIf="!routerEnabled"></ng-content>
              </div>
-           `,
+        </div>
+    `,
     selector: `hc-tab-set`,
     styleUrls: ['./tab-set.component.scss']
 })


### PR DESCRIPTION
Resolves #137.  @corytak - I think/hope this is a complete fix.  It's kind of a mix between your approach and my old approach, with one extra bit mixed in.  I went back to `display: table` to avoid the overflow issue I mentioned - but it wouldn't work properly without the body height you added today.  The one additional piece I added was a container div to the component template that applies a different style if it's a horizontal or vertical tab set.