### PR TITLE
Bugs/140 tooltip

### DIFF
--- a/docs/app/components/accordion/accordion-demo.component.html
+++ b/docs/app/components/accordion/accordion-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -27,12 +27,12 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>
         <hc-tab-set direction="horizontal">
-            <hc-tab title="HTML">
+            <hc-tab tabTitle="HTML">
                 <pre>
                 <code>
     &lt;hc-accordion [triggerAlign]=&quot;alignment&quot; [hideToolbar]=&quot;showToolbar&quot;&gt;
@@ -42,7 +42,7 @@
                 </code>
                 </pre>
             </hc-tab>
-            <hc-tab title="TypeScript">
+            <hc-tab tabTitle="TypeScript">
                 <pre><code>
     import &#123; AccordionModule &#125; from &#x27;@healthcatalyst/cashmere&#x27;;
 

--- a/docs/app/components/breadcrumbs/breadcrumbs-demo.component.html
+++ b/docs/app/components/breadcrumbs/breadcrumbs-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -33,7 +33,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/button/button-demo.component.html
+++ b/docs/app/components/button/button-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -104,12 +104,12 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>
         <hc-tab-set direction="horizontal">
-            <hc-tab title="HTML">
+            <hc-tab tabTitle="HTML">
                     <pre>
                     <code>
     &#x3C;button hc-button title=&#x22;Button Tile&#x22; color=&#x22;primary&#x22; disabled=&quot;false&quot;&#x3E;
@@ -128,7 +128,7 @@
                     </code>
                     </pre>
                 </hc-tab>
-            <hc-tab title="TypeScript">
+            <hc-tab tabTitle="TypeScript">
                 <pre><code>
 import &#123; ButtonModule &#125; from &#x27;@healthcatalyst/cashmere&#x27;;
 

--- a/docs/app/components/checkbox/checkbox-demo.component.html
+++ b/docs/app/components/checkbox/checkbox-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -30,7 +30,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/chip/chip-demo.component.html
+++ b/docs/app/components/chip/chip-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
         <hc-tile>
             <h5>About</h5>
@@ -61,7 +61,7 @@
         </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
         <hc-tile>
             <h5>Angular Component</h5>

--- a/docs/app/components/components.component.html
+++ b/docs/app/components/components.component.html
@@ -1,47 +1,47 @@
 <hc-tab-set>
-    <hc-tab title="Accordion" routerLink="/components/accordion">
+    <hc-tab tabTitle="Accordion" routerLink="/components/accordion">
         Accordion
     </hc-tab>
-    <hc-tab title="Breadcrumbs" routerLink="/components/breadcrumbs">
+    <hc-tab tabTitle="Breadcrumbs" routerLink="/components/breadcrumbs">
         Breadcrumbs
     </hc-tab>
-    <hc-tab title="Button" routerLink="/components/button">
+    <hc-tab tabTitle="Button" routerLink="/components/button">
         Button
     </hc-tab>
-    <hc-tab title="Checkbox" routerLink="/components/checkbox">
+    <hc-tab tabTitle="Checkbox" routerLink="/components/checkbox">
         Checkbox
     </hc-tab>
-    <hc-tab title="Chips" routerLink="/components/chip">
+    <hc-tab tabTitle="Chips" routerLink="/components/chip">
         Chip
     </hc-tab>
-    <hc-tab title="Drawer" routerLink="/components/drawer">
+    <hc-tab tabTitle="Drawer" routerLink="/components/drawer">
         Drawer
     </hc-tab>
-    <hc-tab title="Icon" routerLink="/components/icon">
+    <hc-tab tabTitle="Icon" routerLink="/components/icon">
         Icon
     </hc-tab>
-    <hc-tab title="List" routerLink="/components/list">
+    <hc-tab tabTitle="List" routerLink="/components/list">
         List
     </hc-tab>
-    <hc-tab title="Navbar" routerLink="/components/navbar">
+    <hc-tab tabTitle="Navbar" routerLink="/components/navbar">
         Navbar
     </hc-tab>
-    <hc-tab title="Popover" routerLink="/components/popover">
+    <hc-tab tabTitle="Popover" routerLink="/components/popover">
         Popover
     </hc-tab>
-    <hc-tab title="Radio Button" routerLink="/components/radio-button">
+    <hc-tab tabTitle="Radio Button" routerLink="/components/radio-button">
         Radio Button
     </hc-tab>
-    <hc-tab title="Select" routerLink="/components/select">
+    <hc-tab tabTitle="Select" routerLink="/components/select">
         Select
     </hc-tab>
-    <hc-tab title="Subnavbar" routerLink="/components/subnav">
+    <hc-tab tabTitle="Subnavbar" routerLink="/components/subnav">
         Subnavbar
     </hc-tab>
-    <hc-tab title="Tabs" routerLink="/components/tabs">
+    <hc-tab tabTitle="Tabs" routerLink="/components/tabs">
         Tabs
     </hc-tab>
-    <hc-tab title="Tile" routerLink="/components/tile">
+    <hc-tab tabTitle="Tile" routerLink="/components/tile">
         Tile
     </hc-tab>
 </hc-tab-set>

--- a/docs/app/components/drawer/drawer-demo.component.html
+++ b/docs/app/components/drawer/drawer-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -47,7 +47,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/icon/icon-demo.component.html
+++ b/docs/app/components/icon/icon-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -32,7 +32,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/list/list-demo.component.html
+++ b/docs/app/components/list/list-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -31,7 +31,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/navbar/navbar-demo.component.html
+++ b/docs/app/components/navbar/navbar-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -41,7 +41,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>
@@ -70,10 +70,10 @@
         <h5>App Switcher</h5>
         <p>To include the app switcher, do the following:</p>
         <hc-tab-set direction="horizontal">
-            <hc-tab title="HTML">
+            <hc-tab tabTitle="HTML">
                     <pre><code>&lt;hc-app-switcher&gt;&lt;/hc-app-switcher&gt;</code></pre>
             </hc-tab>
-            <hc-tab title="TypeScript">
+            <hc-tab tabTitle="TypeScript">
                     <pre><code>{{moduleSetup}}</code></pre>
             </hc-tab>
         </hc-tab-set>

--- a/docs/app/components/popover/popover-demo.component.html
+++ b/docs/app/components/popover/popover-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -59,7 +59,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/radio-button/radio-button-demo.component.html
+++ b/docs/app/components/radio-button/radio-button-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -36,7 +36,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/select/select-demo.component.html
+++ b/docs/app/components/select/select-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -43,7 +43,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/subnav/subnav-demo.component.html
+++ b/docs/app/components/subnav/subnav-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -36,7 +36,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/components/tabs/tabs-demo.component.html
+++ b/docs/app/components/tabs/tabs-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -14,13 +14,13 @@
         <h5>Vertical Example</h5>
         <div class="tab-demo">
             <hc-tab-set>
-                <hc-tab title="Tab 1" [routerLink]="['/components/tabs', 1]">
+                <hc-tab tabTitle="Tab 1" [routerLink]="['/components/tabs', 1]">
                     Tab content 1
                 </hc-tab>
-                <hc-tab title="Tab 2" [routerLink]="['/components/tabs', 2]">
+                <hc-tab tabTitle="Tab 2" [routerLink]="['/components/tabs', 2]">
                     Tab content 2
                 </hc-tab>
-                <hc-tab title="Tab 3" [routerLink]="['/components/tabs', 3]">
+                <hc-tab tabTitle="Tab 3" [routerLink]="['/components/tabs', 3]">
                     Tab content 3
                 </hc-tab>
             </hc-tab-set>
@@ -31,17 +31,17 @@
         <h5>Horizontal Example </h5>
         <div class="tab-demo">
             <hc-tab-set direction="horizontal">
-                <hc-tab title="Tab 1">
+                <hc-tab tabTitle="Tab 1">
                     <div class="demo-tab-content">
                         Tab content 1
                     </div>
                 </hc-tab>
-                <hc-tab title="Tab 2">
+                <hc-tab tabTitle="Tab 2">
                     <div class="demo-tab-content">
                         Tab content 2
                     </div>
                 </hc-tab>
-                <hc-tab title="Tab 3">
+                <hc-tab tabTitle="Tab 3">
                     <div class="demo-tab-content">
                         Tab content 3
                     </div>
@@ -54,31 +54,31 @@
         <h5>Together Example </h5>
         <div class="tab-demo">
             <hc-tab-set>
-                <hc-tab title="Tab 1">
+                <hc-tab tabTitle="Tab 1">
                     <hc-tab-set direction="horizontal">
-                        <hc-tab title="Tab 1">
+                        <hc-tab tabTitle="Tab 1">
                             <div class="demo-tab-content">
                                 Horizontal Tab content 1
                             </div>
                         </hc-tab>
-                        <hc-tab title="Tab 2">
+                        <hc-tab tabTitle="Tab 2">
                             <div class="demo-tab-content">
                                 Horizontal Tab content 2
                             </div>
                         </hc-tab>
-                        <hc-tab title="Tab 3">
+                        <hc-tab tabTitle="Tab 3">
                             <div class="demo-tab-content">
                                 Horizontal Tab content 3
                             </div>
                         </hc-tab>
                     </hc-tab-set>
                 </hc-tab>
-                <hc-tab title="Tab 2">
+                <hc-tab tabTitle="Tab 2">
                     <div class="demo-tab-content">
                         Vertical Tab content 2
                     </div>
                 </hc-tab>
-                <hc-tab title="Tab 3">
+                <hc-tab tabTitle="Tab 3">
                     <div class="demo-tab-content">
                         Vertical Tab content 3
                     </div>
@@ -111,17 +111,17 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>
         <pre>
             <code>
     &lt;hc-tab-set direction=&quot;horizontal&quot; &gt;
-    &#9;&lt;hc-tab title=&quot;Tab 1&quot;&gt;
+    &#9;&lt;hc-tab tabTitle=&quot;Tab 1&quot;&gt;
     &#9;&#9;Tab content 1
     &#9;&lt;/hc-tab&gt;
-    &#9;&lt;hc-tab title=&quot;Tab 2&quot;&gt;
+    &#9;&lt;hc-tab tabTitle=&quot;Tab 2&quot;&gt;
     &#9;&#9;Tab content 2
     &#9;&lt;/hc-tab&gt;
     &lt;/hc-tab-set&gt;
@@ -132,8 +132,8 @@
     <pre>
         <code>
     &lt;hc-tab-set&gt;
-    &#9;&lt;hc-tab title=&quot;Tab 1&quot; routerLink=&quot;/components/tabs/tab1&quot;&gt;&lt;/hc-tab&gt;
-    &#9;&lt;hc-tab title=&quot;Tab 2&quot; routerLink=&quot;/components/tabs/tab2&quot;&gt;&lt;/hc-tab&gt;
+    &#9;&lt;hc-tab tabTitle=&quot;Tab 1&quot; routerLink=&quot;/components/tabs/tab1&quot;&gt;&lt;/hc-tab&gt;
+    &#9;&lt;hc-tab tabTitle=&quot;Tab 2&quot; routerLink=&quot;/components/tabs/tab2&quot;&gt;&lt;/hc-tab&gt;
     &lt;/hc-tab-set&gt;
             </code>
         </pre>

--- a/docs/app/components/tabs/tabs-demo.component.html
+++ b/docs/app/components/tabs/tabs-demo.component.html
@@ -143,7 +143,7 @@
         <h5>Properties</h5>
         <table class="api-table">
             <tr>
-                <th>title</th>
+                <th>tabTitle</th>
                 <td><span class="type-label">Type:</span> String</td>
                 <td> On Tab Component. Use to change the title of the tab</td>
             </tr>

--- a/docs/app/components/tile/tile-demo.component.html
+++ b/docs/app/components/tile/tile-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-    <hc-tab title="Overview">
+    <hc-tab tabTitle="Overview">
 
     <hc-tile>
         <h5>About</h5>
@@ -20,7 +20,7 @@
     </hc-tile>
 
     </hc-tab>
-    <hc-tab title="Documentation">
+    <hc-tab tabTitle="Documentation">
 
     <hc-tile>
         <h5>Angular Component</h5>

--- a/docs/app/styles/styles.component.html
+++ b/docs/app/styles/styles.component.html
@@ -1,11 +1,11 @@
 <hc-tab-set>
-    <hc-tab title="Color" routerLink="/styles/color">
+    <hc-tab tabTitle="Color" routerLink="/styles/color">
         Color
     </hc-tab>
-    <hc-tab title="Table" routerLink="/styles/table">
+    <hc-tab tabTitle="Table" routerLink="/styles/table">
         Table
     </hc-tab>
-    <hc-tab title="Typography" routerLink="/styles/typography">
+    <hc-tab tabTitle="Typography" routerLink="/styles/typography">
         Typography
     </hc-tab>
 </hc-tab-set>

--- a/lib/src/tabs/tab-set.component.ts
+++ b/lib/src/tabs/tab-set.component.ts
@@ -86,7 +86,7 @@ export class TabSetComponent implements AfterContentInit {
             this.tabs
                 .map(tab => tab.routerLink)
                 .map(routerLink => this.mapRouterLinkToString(routerLink))
-                .find(routerLink => routerLink === this.router.url);
+                .find(routerLink => this.routerMatchFound(routerLink));
 
         if (foundRoute) {
             return;
@@ -101,5 +101,21 @@ export class TabSetComponent implements AfterContentInit {
             routerLink = routerLink.join('/');
         }
         return routerLink;
+    }
+
+    private routerMatchFound(routerLink: string): boolean {
+        let matchFound = false;
+        let currentRoute = this.router.url;
+        if (currentRoute === routerLink) {
+            matchFound = true;
+            return matchFound;
+        }
+
+        if (currentRoute.indexOf(`${routerLink}/`) > -1) {
+            matchFound = true;
+            return matchFound;
+        }
+
+        return matchFound;
     }
 }

--- a/lib/src/tabs/tab-set.component.ts
+++ b/lib/src/tabs/tab-set.component.ts
@@ -5,7 +5,7 @@ import { Router, ActivatedRoute, UrlSegment } from '@angular/router';
 export type TabDirection = 'horizontal' | 'vertical';
 
 export function throwErrorForMissingRouterLink(tabsWithoutRouterLink: TabComponent[]) {
-    const tabTitles = tabsWithoutRouterLink.map(tab => tab.title);
+    const tabTitles = tabsWithoutRouterLink.map(tab => tab.tabTitle);
     throw Error(`Routerlink missing on ${tabTitles.join(',')}`);
 }
 
@@ -18,12 +18,12 @@ export function throwErrorForMissingRouterLink(tabsWithoutRouterLink: TabCompone
                        [routerLink]="tab.routerLink"
                        routerLinkActive="active"
                        (click)="setActive(tab)">
-                          {{tab.title}}
+                          {{tab.tabTitle}}
                     </a>
                     <a *ngIf="!routerEnabled" class="tab-{{direction}}"
                        [class.active]="tab.active"
                        (click)="setActive(tab)">
-                          {{tab.title}}
+                          {{tab.tabTitle}}
                     </a>
 
                 </div>

--- a/lib/src/tabs/tab.component.ts
+++ b/lib/src/tabs/tab.component.ts
@@ -9,7 +9,7 @@ import { RouterLink } from '@angular/router';
     styles: []
 })
 export class TabComponent {
-    @Input() title: string = '';
+    @Input() tabTitle: string = '';
     @Input() routerLink: any[] | string;
     active: boolean = false;
 }


### PR DESCRIPTION
Closes #140 

Rename `title` which is a standard attribute to `tabTitle` to avoid the omnipresent tooltip. 
I also noticed that after my last PR you could no longer directly route to a tab and that it would always route to the first tab and have included a fix for that. 