### PR TITLE
Fix missing tab title bug; make @corykon's suggestion

### DIFF
--- a/docs/app/components/typeform-survey/typeform-survey-demo.component.html
+++ b/docs/app/components/typeform-survey/typeform-survey-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated {{lastModified | date:'longDate'}}</h6>
 
     <hc-tab-set direction="horizontal">
-        <hc-tab title="Overview">
+        <hc-tab tabTitle="Overview">
 
             <hc-tile>
                 <h5>About</h5>
@@ -27,7 +27,7 @@
             </hc-tile>
 
         </hc-tab>
-        <hc-tab title="Documentation">
+        <hc-tab tabTitle="Documentation">
 
             <hc-tile>
                 <h5>Angular Component</h5>

--- a/lib/src/tabs/tab-set.component.ts
+++ b/lib/src/tabs/tab-set.component.ts
@@ -86,7 +86,10 @@ export class TabSetComponent implements AfterContentInit {
             this.tabs
                 .map(tab => tab.routerLink)
                 .map(routerLink => this.mapRouterLinkToString(routerLink))
-                .find(routerLink => this.routerMatchFound(routerLink));
+                .find(routerLink => {
+                    let currentRoute = this.router.url;
+                    return currentRoute === routerLink || currentRoute.indexOf(`${routerLink}/`) > -1;
+                });
 
         if (foundRoute) {
             return;
@@ -101,21 +104,5 @@ export class TabSetComponent implements AfterContentInit {
             routerLink = routerLink.join('/');
         }
         return routerLink;
-    }
-
-    private routerMatchFound(routerLink: string): boolean {
-        let matchFound = false;
-        let currentRoute = this.router.url;
-        if (currentRoute === routerLink) {
-            matchFound = true;
-            return matchFound;
-        }
-
-        if (currentRoute.indexOf(`${routerLink}/`) > -1) {
-            matchFound = true;
-            return matchFound;
-        }
-
-        return matchFound;
     }
 }


### PR DESCRIPTION
Noticed I forgot to change the typeform demo component to be `tabTitle` on the demo so the tab's were missing. I also implemented @corykon 's suggestion to remove a method. 