### PR TITLE
Vertical Tab Padding Adjustment

### DIFF
--- a/lib/src/tabs/tab-set.component.scss
+++ b/lib/src/tabs/tab-set.component.scss
@@ -12,7 +12,7 @@
 }
 
 .tab-bar-vertical {
-    padding-top: 15px;
+    padding: 15px 0;
     background-color: $white;
     width: 20%;
 }


### PR DESCRIPTION
Really minor change, but I just noticed this when we added the Typeform component.  When the vertical tab list is longer than the content, if you select the last component, the highlighted state is flush with the bottom of the page, which looks a little odd.  Just like at the top of the tab list, it's better if we have a small white buffer so it looks more like this:

<img width="355" alt="tabbuffer" src="https://user-images.githubusercontent.com/22795893/36760723-3cecdf4a-1bd9-11e8-80c7-1544fabbd189.png">
