### PR TITLE
Dynamic Responsive Select Menu

### DIFF
--- a/docs/app/components/components-routes.ts
+++ b/docs/app/components/components-routes.ts
@@ -122,7 +122,8 @@ export const routes: Routes = [
             },
             {
                 path: 'typeform-survey',
-                component: TypeFormSurveyDemoComponent
+                component: TypeFormSurveyDemoComponent,
+                data: { title: 'Typeform Survey' }
             },
             {
                 path: '**',

--- a/docs/app/components/components.component.html
+++ b/docs/app/components/components.component.html
@@ -2,7 +2,7 @@
     <div class="subnav-container">
         <span class="subnav-label">Components: </span>
         <span class="subnav-select">
-            <hc-select [options]="['Accordion', 'Breadcrumbs', 'Button', 'Checkbox', 'Chips', 'Drawer', 'Icon', 'List', 'Navbar', 'Popover', 'Radio Button', 'Select', 'Subnavbar', 'Tabs', 'Tile']" [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)"></hc-select>
+            <hc-select [options]="selectOptions" [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)"></hc-select>
         </span>
     </div>
 </hc-subnav>

--- a/docs/app/components/components.component.html
+++ b/docs/app/components/components.component.html
@@ -1,4 +1,4 @@
-<hc-subnav class="responsive-subnav">
+<hc-subnav class="responsive-subnav" fixedTop="true">
     <div class="subnav-container">
         <span class="subnav-label">Components: </span>
         <span class="subnav-select">

--- a/docs/app/components/components.component.ts
+++ b/docs/app/components/components.component.ts
@@ -7,7 +7,8 @@ import { Router, NavigationEnd, ActivatedRoute, Route } from '@angular/router';
 })
 export class ComponentsComponent {
 
-    thisPage = 'Accordion';
+    thisPage = '';
+    selectOptions: Array<string> = [];
 
     constructor( private activatedRoute: ActivatedRoute, private router: Router ) {
         // Listen for vertical tab bar navigation and update the select component
@@ -18,6 +19,17 @@ export class ComponentsComponent {
                 }
             }
         });
+
+        // Populate the responsive select component with the router information
+        let root = this.activatedRoute.routeConfig;
+        if ( root && root.children ) {
+            for ( let entry of root.children ) {
+                if ( entry.data && entry.data.title ) {
+                    this.selectOptions.push( entry.data.title );
+                }
+            }
+        }
+        this.selectOptions.sort();
     }
 
     // Handle changes to the select component and navigate

--- a/docs/app/components/typeform-survey/typeform-survey-demo.component.html
+++ b/docs/app/components/typeform-survey/typeform-survey-demo.component.html
@@ -27,6 +27,19 @@
                 </p>
             </hc-tile>
 
+            <hc-tile>
+                <h5>Survey Prompt Recommendations</h5>
+                <p>The following is recommended copy for use within the application specific modal that prompts the user to complete a survey:</p>
+                <h4>Prompt header</h4>
+                <p>Help us improve [app name]</p>
+                <h4>Body text:</h4>
+                <p>We'd love to hear about your experience with [app name].  Please take 1-2 minutes to share your feedback and help us improve the application.</p>
+                <h4>Confirm button text</h4>
+                <p>Provide Feedback</p>
+                <h4>Dismiss button text</h4>
+                <p>No thanks</p>
+            </hc-tile>
+
         </hc-tab>
         <hc-tab tabTitle="Documentation">
 

--- a/docs/app/components/typeform-survey/typeform-survey-demo.component.html
+++ b/docs/app/components/typeform-survey/typeform-survey-demo.component.html
@@ -19,10 +19,11 @@
 
             <hc-tile>
                 <h5>Component Usage</h5>
-
                 <p>
-                    The typeform survey component should be used in conjunction with application specific logic that prompts the user to take
-                    a survey every 30 days.
+                    Any survey created in Typeform may be linked using this component.  For Health Catalyst app developers,
+                    please contact the Customer Feedback team for the correct survey to link to within your app.  The typeform survey
+                    component should be used in conjunction with application specific logic that prompts the user to take
+                    a survey at predetermined intervals (every 30 days is a good rule of thumb).
                 </p>
             </hc-tile>
 

--- a/docs/app/styles/styles.component.html
+++ b/docs/app/styles/styles.component.html
@@ -3,7 +3,7 @@
     <div class="subnav-container">
         <span class="subnav-label">Styles: </span>
         <span class="subnav-select">
-            <hc-select [options]="['Colors', 'Tables', 'Typography']" [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)"></hc-select>
+            <hc-select [options]="selectOptions" [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)"></hc-select>
         </span>
     </div>
 </hc-subnav>

--- a/docs/app/styles/styles.component.html
+++ b/docs/app/styles/styles.component.html
@@ -1,5 +1,4 @@
-
-<hc-subnav class="responsive-subnav">
+<hc-subnav class="responsive-subnav" fixedTop="true">
     <div class="subnav-container">
         <span class="subnav-label">Styles: </span>
         <span class="subnav-select">

--- a/docs/app/styles/styles.component.ts
+++ b/docs/app/styles/styles.component.ts
@@ -8,7 +8,8 @@ import { SelectModule } from '../../../lib/src/select';
 })
 export class StylesComponent {
 
-    thisPage = 'Colors';
+    thisPage = '';
+    selectOptions: Array<string> = [];
 
     constructor( private activatedRoute: ActivatedRoute, private router: Router ) {
         // Listen for vertical tab bar navigation and update the select component
@@ -19,6 +20,17 @@ export class StylesComponent {
                 }
             }
         });
+
+        // Populate the responsive select component with the router information
+        let root = this.activatedRoute.routeConfig;
+        if ( root && root.children ) {
+            for ( let entry of root.children ) {
+                if ( entry.data && entry.data.title ) {
+                    this.selectOptions.push( entry.data.title );
+                }
+            }
+        }
+        this.selectOptions.sort();
     }
 
     // Handle changes to the select component and navigate

--- a/docs/styles.scss
+++ b/docs/styles.scss
@@ -68,8 +68,11 @@ body {
 @include media-breakpoint-down(md) {
     .demo-content { padding: 0; }
     .responsive-subnav { display: flex !important; }
-    hc-tab-set .vertical-container .tab-bar-vertical { display: none; }
-    hc-tab-set .vertical-container .tab-content-vertical { width: 100% !important; }
+    .full-height > .vertical-container > .tab-bar-vertical { display: none; }
+    .full-height > .vertical-container > .tab-content-vertical {
+        width: 100% !important;
+        margin-top: 52px;
+    }
     hc-tile { overflow-x: auto; }
 }
 


### PR DESCRIPTION
Realized after Cory's recent Typeform component addition that the responsive select navigation menu was still hard-coded.  Following the updates we made to make use of the router config for navigation, I'm now populating that select component dynamically the same way.  So when a new component is added to the routes, as long as it includes the data element, "title", it will get pulled into the responsive menu.

Also pinned the responsive subnav under the main navbar, because I found that it was annoying when viewing on a phone to have to scroll up to navigate.

And last, updated the content of the Typeform survey component overview as per a conversation Cory and I had with the Customer Feedback team.  Ultimately I think the recommendations I added for the survey prompt will make more sense as an item in our upcoming "Guides" section.  We can include a guide about collecting user feedback that goes into more detail on all that.  So I'm just including it here temporarily so there is a place for the recommended text to live.