### PR TITLE
Input Component & Select Component Update

### DIFF
--- a/docs/app/components/components-routes.ts
+++ b/docs/app/components/components-routes.ts
@@ -19,6 +19,7 @@ import { Breadcrumb1DemoComponent } from './breadcrumbs/breadcrumbs1-demo.compon
 import { Breadcrumb2DemoComponent } from './breadcrumbs/breadcrumbs2-demo.component';
 import { TileDemoComponent } from './tile/tile-demo.component';
 import { ChipDemoComponent } from './chip/chip-demo.component';
+import { InputDemoComponent } from './input/input-demo.component';
 
 export const routes: Routes = [
     {
@@ -124,6 +125,11 @@ export const routes: Routes = [
                 path: 'typeform-survey',
                 component: TypeFormSurveyDemoComponent,
                 data: { title: 'Typeform Survey' }
+            },
+            {
+                path: 'input',
+                component: InputDemoComponent,
+                data: { title: 'Input' }
             },
             {
                 path: '**',

--- a/docs/app/components/components.component.html
+++ b/docs/app/components/components.component.html
@@ -2,7 +2,9 @@
     <div class="subnav-container">
         <span class="subnav-label">Components: </span>
         <span class="subnav-select">
-            <hc-select [options]="selectOptions" [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)"></hc-select>
+            <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
+                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === value">{{option}}</option>
+            </hc-select>
         </span>
     </div>
 </hc-subnav>
@@ -14,6 +16,7 @@
     <hc-tab tabTitle="Chips" routerLink="/components/chip"></hc-tab>
     <hc-tab tabTitle="Drawer" routerLink="/components/drawer"></hc-tab>
     <hc-tab tabTitle="Icon" routerLink="/components/icon"></hc-tab>
+    <hc-tab tabTitle="Input" routerLink="/components/input"></hc-tab>
     <hc-tab tabTitle="List" routerLink="/components/list"></hc-tab>
     <hc-tab tabTitle="Navbar" routerLink="/components/navbar"></hc-tab>
     <hc-tab tabTitle="Popover" routerLink="/components/popover"></hc-tab>

--- a/docs/app/components/components.component.html
+++ b/docs/app/components/components.component.html
@@ -3,7 +3,7 @@
         <span class="subnav-label">Components: </span>
         <span class="subnav-select">
             <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
-                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === value">{{option}}</option>
+                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === thisPage">{{option}}</option>
             </hc-select>
         </span>
     </div>

--- a/docs/app/components/components.module.ts
+++ b/docs/app/components/components.module.ts
@@ -44,6 +44,8 @@ import { TileDemoComponent } from './tile/tile-demo.component';
 import { ChipModule } from '../../../lib/src/chip/chip.module';
 import { FilterButtonComponent } from './chip/filter-button.component';
 import { ChipDemoComponent } from './chip/chip-demo.component';
+import { InputModule } from '../../../lib/src/input/input.module';
+import { InputDemoComponent } from './input/input-demo.component';
 
 @NgModule({
     imports: [
@@ -67,6 +69,7 @@ import { ChipDemoComponent } from './chip/chip-demo.component';
         TypeformSurveyModule,
         TileModule,
         ChipModule,
+        InputModule,
         RouterModule.forRoot(routes)
     ],
     exports: [
@@ -96,7 +99,8 @@ import { ChipDemoComponent } from './chip/chip-demo.component';
         TileDemoComponent,
         ChipDemoComponent,
         FilterButtonComponent,
-        TypeFormSurveyDemoComponent
+        TypeFormSurveyDemoComponent,
+        InputDemoComponent
     ],
     providers: [
         {

--- a/docs/app/components/input/input-demo.component.html
+++ b/docs/app/components/input/input-demo.component.html
@@ -1,0 +1,90 @@
+<div class="demo-content">
+    <h1>Input Text Field</h1>
+    <h6>Last updated {{lastModified | date:'longDate'}}</h6>
+
+    <hc-tab-set direction="horizontal">
+    <hc-tab tabTitle="Overview">
+
+    <hc-tile>
+        <h5>About</h5>
+        <p>Text fields allow users to input, edit, and select text.
+            They typically reside inside forms, but can also be used in modal dialogs and subnavigation bars.  Input text fields are also used for
+            search and filtering of content.</p>
+    </hc-tile>
+
+    <hc-tile>
+        <h5>Example</h5>
+        <h4>Input with Validation</h4>
+        <form (ngSubmit)="onSubmit()">
+            <hc-input [valid]="validCheck">
+                <label hcInputRequired for="inputEmail">Validate an email address:</label>
+                <input required name="inputEmail" id="inputEmail" [(ngModel)]="emailText" #inputEmail="ngModel" width="250px"  />
+                <div hcInputErrors>
+                    <div *ngIf="errorVal===1">
+                        Email address is required
+                    </div>
+                    <div *ngIf="errorVal===2">
+                        Please enter a valid email address
+                    </div>
+                </div>
+            </hc-input>
+            <br>
+            <button hc-button title="Validate Input Text" color="primary" type="submit">Validate Input</button>
+        </form>
+
+        <h4>Input with Icon</h4>
+        <hc-input>
+            <input name="search" placeholder="search" width="250px" />
+            <hc-icon fontSet="fa" fontIcon="fa-search" class="search-icon"></hc-icon>
+        </hc-input>
+
+        <h4>Disabled Input</h4>
+        <hc-input>
+            <input disabled name="disabled" width="250px" />
+        </hc-input>
+
+    </hc-tile>
+
+    </hc-tab>
+    <hc-tab tabTitle="Documentation">
+
+    <hc-tile>
+            <h5>Angular Component</h5>
+            <pre>
+                <code>
+    &#x3C;hc-input valid=&#x22;true&#x22;&#x3E;
+        &#x3C;label hcInputRequired for=&#x22;inputEmail&#x22;&#x3E;Validate an email address:&#x3C;/label&#x3E;
+        &#x3C;input required &#x3E;
+        &#x3C;div hcInputErrors&#x3E;
+            Error messages are added here
+        &#x3C;/div&#x3E;
+    &#x3C;/hc-input&#x3E;
+                </code>
+            </pre>
+        </hc-tile>
+
+        <hc-tile>
+            <h5>Properties</h5>
+            <table class="api-table">
+                <tr>
+                    <th>valid</th>
+                    <td><span class="type-label">Type:</span> Boolean</td>
+                    <td>When true, highlights the border red and makes any items with the <code>hcInputErrors</code> directive visible</td>
+                </tr>
+            </table>
+        </hc-tile>
+
+        <hc-tile>
+            <h5>Directives</h5>
+            <p><strong>hcInputErrors</strong><br>
+                Should be added to an element or group of elements that contain error messages to be displayed when the component's <code>valid</code> flag is set to true.
+            </p>
+            <p><strong>hcInputRequired</strong><br>
+                Add to any <code>label</code> elements if the input is required for the form to be completed.
+                Adds a red asterisk to the end of the label to designate that it is required.
+            </p>
+        </hc-tile>
+
+    </hc-tab>
+    </hc-tab-set>
+</div>

--- a/docs/app/components/input/input-demo.component.scss
+++ b/docs/app/components/input/input-demo.component.scss
@@ -1,0 +1,5 @@
+.search-icon {
+    width: 18px !important;
+    height: 18px !important;
+    font-size: 18px !important;
+}

--- a/docs/app/components/input/input-demo.component.ts
+++ b/docs/app/components/input/input-demo.component.ts
@@ -1,0 +1,29 @@
+import { Component, ViewChild, ElementRef } from '@angular/core';
+import { FormsModule, EmailValidator } from '@angular/forms';
+
+@Component({
+    selector: 'hc-input-demo',
+    templateUrl: './input-demo.component.html',
+    styleUrls: ['./input-demo.component.scss']
+})
+export class InputDemoComponent {
+    lastModified: Date = new Date( document.lastModified );
+    validCheck: boolean = true;
+    errorVal: Number = 0;
+    emailText: string = '';
+
+    onSubmit() {
+        let EMAIL_REGEXP = /^[a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+
+        if ( this.emailText.length === 0 ) {
+            this.validCheck = false;
+            this.errorVal = 1;
+        } else if ( !EMAIL_REGEXP.test(this.emailText) ) {
+            this.validCheck = false;
+            this.errorVal = 2;
+        } else {
+            this.validCheck = true;
+            this.errorVal = 0;
+        }
+    }
+}

--- a/docs/app/components/select/select-demo.component.html
+++ b/docs/app/components/select/select-demo.component.html
@@ -15,15 +15,87 @@
         <h5>Examples</h5>
         <h4>Standard Select Component</h4>
         <div class="select-sample">
-            <hc-select placeholder="Select a city:"
-                    [options]="['Philadelphia', 'Atlanta', 'Salt Lake City', 'Chicago', 'Orlando']"></hc-select>
+            <hc-select placeholder="Select a city:">
+                <label>Facility Location:</label>
+                <option>Philadelphia</option>
+                <option>Atlanta</option>
+                <option>Salt Lake City</option>
+                <option>Chicago</option>
+                <option>Orlando</option>
+            </hc-select>
         </div>
         <h4>Disabled Select Component</h4>
         <div class="select-sample">
-            <hc-select [disabled]="true" placeholder="Select a city:"
-                    [options]="['Philadelphia', 'Atlanta', 'Salt Lake City', 'Chicago', 'Orlando']"></hc-select>
+            <hc-select disabled="true" placeholder="Select a city:">
+                <option>Philadelphia</option>
+                <option>Atlanta</option>
+            </hc-select>
+        </div>
+        <h4>Component Validation</h4>
+        <div class="select-sample">
+            <hc-select [valid]="validCheck">
+                <label hcSelectRequired>Project Status:</label>
+                <option>Active</option>
+                <option>Inactive</option>
+                <option>In progress</option>
+                <div hcSelectErrors>
+                    This is an example warning for an invalid response
+                </div>
+            </hc-select>
         </div>
         <br>
+        <button hc-button title="Toggle component validation" color="primary" (click)="toggleValidate()">Toggle Validate</button>
+    </hc-tile>
+
+    </hc-tab>
+    <hc-tab tabTitle="Documentation">
+
+    <hc-tile>
+        <h5>Angular Component</h5>
+        <pre>
+            <code>
+&#x3C;hc-select formControlName=&#x22;city&#x22; disabled=&#x22;false&#x22; valid=&#x22;true&#x22; placeholder=&#x22;Select a city:&#x22;&#x3E;
+    &#x3C;label hcSelectRequired&#x3E;Location:&#x3C;/label&#x3E;
+    &#x3C;option [value]=&#x22;1&#x22; [selected]=&#x22;value === 1&#x22;&#x3E;First&#x3C;/option&#x3E;
+    &#x3C;option [value]=&#x22;2&#x22; [selected]=&#x22;value === 2&#x22;&#x3E;Second&#x3C;/option&#x3E;
+    &#x3C;div hcSelectErrors&#x3E;
+        Error messages are added here
+    &#x3C;/div&#x3E;
+&#x3C;/hc-select&#x3E;
+            </code>
+        </pre>
+    </hc-tile>
+
+    <hc-tile>
+        <h5>Properties</h5>
+        <table class="api-table">
+            <tr>
+                <th>placeholder</th>
+                <td><span class="type-label">Type:</span> String</td>
+                <td>Optional string of text to appear before selection is made</td>
+            </tr>
+            <tr>
+                <th>disabled</th>
+                <td><span class="type-label">Type:</span> Boolean</td>
+                <td>Boolean value that enables/disables the component</td>
+            </tr>
+            <tr>
+                <th>valid</th>
+                <td><span class="type-label">Type:</span> Boolean</td>
+                <td>When true, highlights the border red and makes any items with the <code>hcSelectErrors</code> directive visible</td>
+            </tr>
+        </table>
+    </hc-tile>
+
+    <hc-tile>
+        <h5>Directives</h5>
+        <p><strong>hcSelectErrors</strong><br>
+            Should be added to an element or group of elements that contain error messages to be displayed when the component's <code>valid</code> flag is set to true.
+        </p>
+        <p><strong>hcSelectRequired</strong><br>
+            Add to any <code>label</code> elements if the select is required for the form to be completed.
+            Adds a red asterisk to the end of the label to designate that it is required.
+        </p>
     </hc-tile>
 
     <hc-tile>
@@ -40,41 +112,6 @@
         <p>To interact with reactive forms specify a <code>formControlName</code> on the component.
         Remember to import the <code>ReactiveFormsModule</code> into your application.
         </p>
-    </hc-tile>
-
-    </hc-tab>
-    <hc-tab tabTitle="Documentation">
-
-    <hc-tile>
-        <h5>Angular Component</h5>
-        <pre>
-            <code>
-&#x3C;hc-select formControlName=&#x22;city&#x22; &#91;disabled&#93;=&#x27;false&#x27; placeholder=&#x22;Select a city:&#x22;
-    [options]=&#x22;[&#x27;Philadelphia&#x27;, &#x27;Atlanta&#x27;, &#x27;Salt Lake City&#x27;, &#x27;Chicago&#x27;, &#x27;Orlando&#x27;]&#x22;&#x3E;
-&#x3C;/hc-select&#x3E;
-            </code>
-        </pre>
-    </hc-tile>
-
-    <hc-tile>
-        <h5>Properties</h5>
-        <table class="api-table">
-            <tr>
-                <th>placeholder</th>
-                <td><span class="type-label">Type:</span> String</td>
-                <td>Optional string of text to appear before selection is made</td>
-            </tr>
-            <tr>
-                <th>[options]</th>
-                <td><span class="type-label">Type:</span> Array</td>
-                <td>An array of strings for the select options</td>
-            </tr>
-            <tr>
-                <th>[disabled]</th>
-                <td><span class="type-label">Type:</span> Boolean</td>
-                <td>Boolean value that enables/disables the button</td>
-            </tr>
-        </table>
     </hc-tile>
 
     </hc-tab>

--- a/docs/app/components/select/select-demo.component.ts
+++ b/docs/app/components/select/select-demo.component.ts
@@ -3,15 +3,12 @@ import { Component, ViewEncapsulation } from '@angular/core';
 @Component({
     selector: 'hc-select-demo',
     templateUrl: './select-demo.component.html',
-    styleUrls: [
-        './select-demo.component.scss'
-    ]
+    styleUrls: ['./select-demo.component.scss']
 })
+
 export class SelectDemoComponent {
-    showTemplate: boolean = true;
+    validCheck: boolean = true;
     lastModified: Date = new Date( document.lastModified );
 
-    viewToggle(show: 'ts' | 'html') {
-        this.showTemplate = show === 'html';
-    }
+    toggleValidate() { this.validCheck = (this.validCheck) ? false : true; }
 }

--- a/docs/app/components/subnav/subnav-demo.component.scss
+++ b/docs/app/components/subnav/subnav-demo.component.scss
@@ -25,3 +25,7 @@ hc-subnav {
 .breadcrumb-text {
     color: $slate-gray-500;
 }
+
+.hc-button {
+    margin: 0 4px;
+}

--- a/docs/app/integration-testing/select-integration-test.component.ts
+++ b/docs/app/integration-testing/select-integration-test.component.ts
@@ -11,8 +11,8 @@ import { Component } from '@angular/core';
  */
 @Component({
     template: `<form [formGroup]="cityForm">
-                    <hc-select formControlName="city" placeholder="Select a City">
-                        <option *ngFor="let cityName of cities" [ngValue]="cityName">{{cityName}}</option>
+                    <hc-select formControlName="city" placeholder="Select a City" [(ngModel)]="selectVal">
+                        <option *ngFor="let cityName of cities" [value]="cityName" [selected]="cityName===selectVal">{{cityName}}</option>
                     </hc-select>
                </form>
               `,
@@ -23,6 +23,7 @@ export class SelectIntegrationTestComponent {
 
     cityForm: FormGroup;
     cities: Array<string> = ['Atlanta', 'SLC', 'NYC'];
+    selectVal: string = '';
 
     constructor(private fb: FormBuilder) {
         this.createTestForm();

--- a/docs/app/integration-testing/select-integration-test.component.ts
+++ b/docs/app/integration-testing/select-integration-test.component.ts
@@ -11,7 +11,9 @@ import { Component } from '@angular/core';
  */
 @Component({
     template: `<form [formGroup]="cityForm">
-                  <hc-select formControlName="city" placeholder="Select a City" [options]="cities"></hc-select>
+                    <hc-select formControlName="city" placeholder="Select a City">
+                        <option *ngFor="let cityName of cities" [ngValue]="cityName">{{cityName}}</option>
+                    </hc-select>
                </form>
               `,
     selector: `hc-integration-test-select`,
@@ -28,8 +30,7 @@ export class SelectIntegrationTestComponent {
 
     createTestForm(): void {
         this.cityForm = this.fb.group({
-            city: 'NYC',
-            state: 'New York'
+            city: 'NYC'
         });
     }
 

--- a/docs/app/styles/styles.component.html
+++ b/docs/app/styles/styles.component.html
@@ -2,7 +2,9 @@
     <div class="subnav-container">
         <span class="subnav-label">Styles: </span>
         <span class="subnav-select">
-            <hc-select [options]="selectOptions" [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)"></hc-select>
+            <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
+                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === value">{{option}}</option>
+            </hc-select>
         </span>
     </div>
 </hc-subnav>

--- a/docs/app/styles/styles.component.html
+++ b/docs/app/styles/styles.component.html
@@ -3,7 +3,7 @@
         <span class="subnav-label">Styles: </span>
         <span class="subnav-select">
             <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
-                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === value">{{option}}</option>
+                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === thisPage">{{option}}</option>
             </hc-select>
         </span>
     </div>

--- a/lib/src/button/button.component.scss
+++ b/lib/src/button/button.component.scss
@@ -32,7 +32,6 @@
     min-width: 150px;
     font-size: 15px;
     line-height: 35px;
-    margin: 0 4px 0 4px;
     font-weight: normal;
     text-align: center;
     white-space: nowrap;

--- a/lib/src/chip/chip.component.ts
+++ b/lib/src/chip/chip.component.ts
@@ -10,7 +10,7 @@ import { anyToBoolean } from '../util';
 
 export class ChipComponent {
 
-    @Input() _action: boolean = false;
+    _action: boolean = false;
     @Input() color: 'neutral' | 'yellow' | 'green' | 'red' = 'neutral';
 
     constructor() {}

--- a/lib/src/input/index.ts
+++ b/lib/src/input/index.ts
@@ -1,0 +1,4 @@
+export * from './input.component';
+export * from './input-errors.directive';
+export * from './input-required.directive';
+export * from './input.module';

--- a/lib/src/input/input-errors.directive.ts
+++ b/lib/src/input/input-errors.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, HostBinding } from '@angular/core';
+
+@Directive({
+    selector: '[hcInputErrors]'
+})
+export class InputErrorDirective {
+    @HostBinding('class.input-errors') hostClass = true;
+}

--- a/lib/src/input/input-required.directive.ts
+++ b/lib/src/input/input-required.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, HostBinding } from '@angular/core';
+
+@Directive({
+    selector: '[hcInputRequired]'
+})
+export class InputRequiredDirective {
+    @HostBinding('class.label-required') hostClass = true;
+}

--- a/lib/src/input/input.component.html
+++ b/lib/src/input/input.component.html
@@ -1,0 +1,8 @@
+<div [ngClass]="{'invalid': !_valid}">
+    <span [ngClass]="{'input-icon': inputicon.children.length != 0}">
+        <ng-content></ng-content>
+    </span>
+    <span #inputicon class="icon-container">
+        <ng-content select="hc-icon"></ng-content>
+    </span>
+</div>

--- a/lib/src/input/input.component.scss
+++ b/lib/src/input/input.component.scss
@@ -1,0 +1,60 @@
+@import '../sass/colors';
+@import '../sass/functions.scss';
+@import '../sass/mixins.scss';
+
+hc-input { position: relative; }
+
+hc-input label {
+    display: block;
+    color: $gray-500;
+    @include fontSize(15px);
+    margin-bottom: 8px;
+}
+
+hc-input input {
+    color: $text;
+    @include fontSize(14px);
+    line-height: 32px;
+    border: 1.5px solid $gray-300;
+    font-family: inherit;
+    padding: 0 12px;
+}
+
+hc-input input:disabled {
+    border: 1.5px solid $gray-200;
+    background-color: $slate-gray-100;
+    color: tint( $text, 60%);
+    cursor: not-allowed;
+}
+
+
+hc-input .invalid {
+    input { border: 2px solid $red; }
+    .input-errors { display: block; }
+}
+
+hc-input .input-errors {
+    margin-top: 8px;
+    color: $red;
+    font-weight: 600;
+    @include fontSize(12px);
+    display: none;
+}
+
+hc-input .label-required:after {
+    content: "*";
+    margin-left: 5px;
+    color: $red;
+}
+
+hc-input hc-icon {
+    color: $gray-400;
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    pointer-events: none;
+    padding-right: 30px;
+}
+
+.icon-container { position: relative; }
+.input-icon input { padding-right: 40px; }

--- a/lib/src/input/input.component.spec.ts
+++ b/lib/src/input/input.component.spec.ts
@@ -1,21 +1,21 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { SelectComponent } from './select.component';
+import { InputComponent } from './input.component';
 
 describe('SelectComponent', () => {
-    let component: SelectComponent;
-    let fixture: ComponentFixture<SelectComponent>;
+    let component: InputComponent;
+    let fixture: ComponentFixture<InputComponent>;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [],
             providers: [],
-            declarations: [SelectComponent]
+            declarations: [InputComponent]
         })
             .compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(SelectComponent);
+        fixture = TestBed.createComponent(InputComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
     });

--- a/lib/src/input/input.component.ts
+++ b/lib/src/input/input.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { anyToBoolean } from '../util';
+
+@Component({
+    selector: 'hc-input',
+    templateUrl: './input.component.html',
+    styleUrls: ['./input.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+
+export class InputComponent {
+
+    _valid: boolean = true;
+
+    constructor() {}
+
+    @Input() get valid(): boolean { return this._valid; }
+
+    set valid(validVal) { this._valid = anyToBoolean(validVal); }
+}

--- a/lib/src/input/input.module.ts
+++ b/lib/src/input/input.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { InputComponent } from './input.component';
+import { InputErrorDirective } from './input-errors.directive';
+import { InputRequiredDirective } from './input-required.directive';
+
+@NgModule({
+    imports: [
+        CommonModule
+    ],
+    exports: [
+        InputComponent,
+        InputErrorDirective,
+        InputRequiredDirective
+    ],
+    declarations: [
+        InputComponent,
+        InputErrorDirective,
+        InputRequiredDirective
+    ]
+})
+export class InputModule {
+}

--- a/lib/src/select/index.ts
+++ b/lib/src/select/index.ts
@@ -1,2 +1,4 @@
 export * from './select.component';
+export * from './select-errors.directive';
+export * from './select-required.directive';
 export * from './select.module';

--- a/lib/src/select/select-errors.directive.ts
+++ b/lib/src/select/select-errors.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, HostBinding } from '@angular/core';
+
+@Directive({
+    selector: '[hcSelectErrors]'
+})
+export class SelectErrorDirective {
+    @HostBinding('class.select-errors') hostClass = true;
+}

--- a/lib/src/select/select-required.directive.ts
+++ b/lib/src/select/select-required.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, HostBinding } from '@angular/core';
+
+@Directive({
+    selector: '[hcSelectRequired]'
+})
+export class SelectRequiredDirective {
+    @HostBinding('class.select-required') hostClass = true;
+}

--- a/lib/src/select/select.component.html
+++ b/lib/src/select/select.component.html
@@ -1,6 +1,10 @@
-<label [style.opacity]="alpha">
-    <select [disabled]="disabled" (change)="value = $event.target.value" required>
-        <option *ngIf="placeholder" [value]="null" selected disabled hidden>{{placeholder}}</option>
-        <option *ngFor="let option of options" [value]="option" [selected]="option === value">{{option}}</option>
-    </select>
-</label>
+<div [ngClass]="{'invalid': !_valid}">
+    <ng-content select="label"></ng-content>
+    <span [ngClass]="{'disabled': _disabled}" class="chevron">
+        <select [disabled]="_disabled" (change)="value = $event.target.value" required>
+            <option *ngIf="placeholder" [value]="null" selected disabled hidden>{{placeholder}}</option>
+            <ng-content select="option"></ng-content>
+        </select>
+    </span>
+    <ng-content></ng-content>
+</div>

--- a/lib/src/select/select.component.scss
+++ b/lib/src/select/select.component.scss
@@ -1,12 +1,14 @@
-@import '../sass/cashmere';
+@import '../sass/colors';
+@import '../sass/functions.scss';
+@import '../sass/mixins.scss';
 
-:host select {
+hc-select select {
     display: inline-block;
-    color: $offblack;
+    color: $text;
     background-color: $white;
     font-family: 'Open Sans', sans-serif;
-    font-size: 15px;
-    padding-left: 10px;
+    @include fontSize(14px);
+    padding-left: 7px;
     border: 1.5px solid $gray-300;
     border-radius: 0;
     height: 35px;
@@ -21,17 +23,24 @@
 
     &[disabled] {
         cursor: not-allowed;
+        border: 1.5px solid $gray-200;
+        background-color: $slate-gray-100;
+        color: tint( $text, 60%);
     }
 }
 
-:host label {
+hc-select .disabled.chevron:after {
+    color: tint( $primary-brand, 60%)
+}
+
+hc-select .chevron {
     overflow: hidden;
     height: 35px;
     position: relative;
     display: block;
 }
 
-:host label:after {
+hc-select .chevron:after {
     content: "\f078";
     font-family: FontAwesome;
     color: $primary-brand;
@@ -44,4 +53,30 @@
     height: 100%;
     pointer-events: none;
     box-sizing: border-box;
+}
+
+hc-select label {
+    display: block;
+    color: $gray-500;
+    @include fontSize(15px);
+    margin-bottom: 8px;
+}
+
+hc-select .select-errors {
+    margin-top: 8px;
+    color: $red;
+    font-weight: 600;
+    @include fontSize(12px);
+    display: none;
+}
+
+hc-select .invalid {
+    select { border: 2px solid $red; }
+    .select-errors { display: block; }
+}
+
+hc-select .select-required:after {
+    content: "*";
+    margin-left: 5px;
+    color: $red;
 }

--- a/lib/src/select/select.component.ts
+++ b/lib/src/select/select.component.ts
@@ -1,10 +1,12 @@
-import { Component, Input, OnInit, forwardRef } from '@angular/core';
+import { Component, Input, OnInit, forwardRef, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { anyToBoolean } from '../util';
 
 @Component({
     selector: 'hc-select',
     templateUrl: './select.component.html',
     styleUrls: ['./select.component.scss'],
+    encapsulation: ViewEncapsulation.None,
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
@@ -13,26 +15,30 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
         }
     ]
 })
+
 export class SelectComponent implements ControlValueAccessor {
 
-    @Input() placeholder: string;
-    @Input() options: Array<string> = [];
-    @Input() disabled: boolean = false;
-    disabledAlpha = 0.4;
-    enabledAlpha = 1.0;
-    _value: string;
-    onChange: any = () => {
-    };
-    onTouched: any = () => {
-    };
+    @Input() placeholder: string = '';
 
-    get alpha() {
-        return this.disabled ? this.disabledAlpha : this.enabledAlpha;
-    }
+    _disabled: boolean = false;
+    _valid: boolean = true;
+    _value: string = '';
 
-    get value() {
-        return this._value;
-    }
+    constructor() { }
+
+    @Input() get valid(): boolean { return this._valid; }
+
+    @Input() get disabled(): boolean { return this._disabled; }
+
+    set disabled(isDisabled) { this._disabled = anyToBoolean(isDisabled); }
+
+    set valid(validVal) { this._valid = anyToBoolean(validVal); }
+
+    onChange: any = () => { };
+
+    onTouched: any = () => { };
+
+    get value() { return this._value; }
 
     set value(val: string) {
         this._value = val;
@@ -40,16 +46,9 @@ export class SelectComponent implements ControlValueAccessor {
         this.onTouched();
     }
 
-    constructor() {
-    }
+    registerOnChange(fn: any) { this.onChange = fn; }
 
-    registerOnChange(fn: any) {
-        this.onChange = fn;
-    }
-
-    registerOnTouched(fn: any) {
-        this.onTouched = fn;
-    }
+    registerOnTouched(fn: any) { this.onTouched = fn; }
 
     writeValue(value: string) {
         if (value) {

--- a/lib/src/select/select.module.ts
+++ b/lib/src/select/select.module.ts
@@ -1,16 +1,22 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SelectComponent } from './select.component';
+import { SelectErrorDirective } from './select-errors.directive';
+import { SelectRequiredDirective } from './select-required.directive';
 
 @NgModule({
     imports: [
-        CommonModule,
+        CommonModule
     ],
     exports: [
-        SelectComponent
+        SelectComponent,
+        SelectErrorDirective,
+        SelectRequiredDirective
     ],
     declarations: [
-        SelectComponent
+        SelectComponent,
+        SelectErrorDirective,
+        SelectRequiredDirective
     ]
 })
 export class SelectModule {


### PR DESCRIPTION
Resolves #14. This was originally meant to only be a PR for a new Input text component, but as I got into it I realized that a significant number of our forms use both input text and select boxes.  So it's important our select component and our input components look and act very similarly.  Also, the select component was one of the first added to Cashmere, so it was missing some of our newer practices (ViewEncapsulation to none, not setting style elements directly, etc).

The markup for the Select component was a little odd too in hindsight.  An array of options was being passed to the component in the tag.  But that's pretty limiting because a dev can't set the select option values themselves, they were automatically being set to the array name.  So I've adjusted the markup to let the user set the `<option>` tags themselves.  And to make the input component, I've added the ability to add a label.

Last, the trickiest part of the input component was deciding how to do validation and warning messages.  HTML has a lot of ways to validate text fields directly, but I didn't really want to lock the component into any of them - because different apps will likely want to validate for different things.  It seems that most of our apps validate after a submit click, so I included a `valid` parameter on both the input and select components.  If set to false, it highlights the component and displays any appropriate warning messages.