### PR TITLE
"Code Display" - Styles section

### DIFF
--- a/docs/app/styles/code/code-demo.component.html
+++ b/docs/app/styles/code/code-demo.component.html
@@ -1,0 +1,59 @@
+<div class="demo-content">
+    <h1>Code Display Guidelines</h1>
+    <h6>Last updated {{lastModified | date:'longDate'}}</h6>
+
+    <hc-tile>
+        <h5>Overview</h5>
+        <p>Source code often needs to be included within app documentation or within apps themselves.
+            The following are guidelines on how to style code used in these instances, both inline or
+            within larger code blocks. </p>
+    </hc-tile>
+
+    <hc-tile>
+        <h5>Elements</h5>
+        <table class="api-table">
+            <tr>
+                <td>
+                    <code>Inline code</code>
+                </td>
+                <td>
+                    <code>&lt;code&gt;&lt;/code&gt;</code>
+                </td>
+                <td>
+                    <ul>
+                        <li><span class="type-label">Font-size</span>inherit</li>
+                        <li><span class="type-label">Line Height</span>inherit</li>
+                    </ul>
+                </td>
+                <td>
+                    <ul>
+                        <li><span class="type-label">Weight</span>inherit</li>
+                        <li><span class="type-label">Color</span>$magneta</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <pre><code style="width: 250px">Code blocks</code></pre>
+                </td>
+                <td>
+                    <code>&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;</code>
+                </td>
+                <td>
+                    <ul>
+                        <li><span class="type-label">Font-size</span>1rem</li>
+                        <li><span class="type-label">Line Height</span>140%</li>
+                    </ul>
+                </td>
+                <td>
+                    <ul>
+                        <li><span class="type-label">Weight</span>inherit</li>
+                        <li><span class="type-label">Color</span>$text</li>
+                    </ul>
+                </td>
+            </tr>
+        </table>
+    </hc-tile>
+
+    <div [hcMarkdown]="document"></div>
+</div>

--- a/docs/app/styles/code/code-demo.component.html
+++ b/docs/app/styles/code/code-demo.component.html
@@ -6,7 +6,7 @@
         <h5>Overview</h5>
         <p>Source code often needs to be included within app documentation or within apps themselves.
             The following are guidelines on how to style code used in these instances, both inline or
-            within larger code blocks. </p>
+            within larger code blocks.</p>
     </hc-tile>
 
     <hc-tile>

--- a/docs/app/styles/code/code-demo.component.html
+++ b/docs/app/styles/code/code-demo.component.html
@@ -6,7 +6,9 @@
         <h5>Overview</h5>
         <p>Source code often needs to be included within app documentation or within apps themselves.
             The following are guidelines on how to style code used in these instances, both inline or
-            within larger code blocks.</p>
+            within larger code blocks. The primary goal of code styling is differentiate it from the
+            surrounding body copy and ensure it is easily readable. Both types of code have a background-color
+            set to <code>$block-text-background</code>.</p>
     </hc-tile>
 
     <hc-tile>
@@ -21,13 +23,13 @@
                 </td>
                 <td>
                     <ul>
-                        <li><span class="type-label">Font-size</span>inherit</li>
+                        <li><span class="type-label">Font-size</span>1rem</li>
                         <li><span class="type-label">Line Height</span>inherit</li>
                     </ul>
                 </td>
                 <td>
                     <ul>
-                        <li><span class="type-label">Weight</span>inherit</li>
+                        <li><span class="type-label">Weight</span>400</li>
                         <li><span class="type-label">Color</span>$magneta</li>
                     </ul>
                 </td>
@@ -47,7 +49,7 @@
                 </td>
                 <td>
                     <ul>
-                        <li><span class="type-label">Weight</span>inherit</li>
+                        <li><span class="type-label">Weight</span>400</li>
                         <li><span class="type-label">Color</span>$text</li>
                     </ul>
                 </td>

--- a/docs/app/styles/code/code-demo.component.ts
+++ b/docs/app/styles/code/code-demo.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'hc-code',
+    templateUrl: './code-demo.component.html'
+})
+
+export class CodeDemoComponent {
+
+    lastModified: Date = new Date( document.lastModified );
+    public document: string = require('raw-loader!../../../../guides/styles/code.md');
+}

--- a/docs/app/styles/styles-routes.ts
+++ b/docs/app/styles/styles-routes.ts
@@ -3,6 +3,7 @@ import { StylesComponent } from './styles.component';
 import { ColorDemoComponent } from './color/color-demo.component';
 import { TableDemoComponent } from './table/table-demo.component';
 import { TypographyDemoComponent } from './typography/typography-demo.component';
+import { CodeDemoComponent } from './code/code-demo.component';
 
 export const routes: Routes = [
     {
@@ -23,6 +24,11 @@ export const routes: Routes = [
                 path: 'typography',
                 component: TypographyDemoComponent,
                 data: { title: 'Typography' }
+            },
+            {
+                path: 'code',
+                component: CodeDemoComponent,
+                data: { title: 'Code' }
             },
             {
                 path: '**',

--- a/docs/app/styles/styles.component.html
+++ b/docs/app/styles/styles.component.html
@@ -16,4 +16,7 @@
     <hc-tab tabTitle="Typography" routerLink="/styles/typography">
         Typography
     </hc-tab>
+    <hc-tab tabTitle="Code" routerLink="/styles/code">
+        Code
+    </hc-tab>
 </hc-tab-set>

--- a/docs/app/styles/styles.component.ts
+++ b/docs/app/styles/styles.component.ts
@@ -30,7 +30,6 @@ export class StylesComponent {
                 }
             }
         }
-        this.selectOptions.sort();
     }
 
     // Handle changes to the select component and navigate

--- a/docs/app/styles/styles.module.ts
+++ b/docs/app/styles/styles.module.ts
@@ -13,6 +13,8 @@ import { TableDemoComponent } from './table/table-demo.component';
 import { SwatchDemoComponent } from './color/swatch-demo.component';
 import { routes } from './styles-routes';
 import { TypographyDemoComponent } from './typography/typography-demo.component';
+import { CodeDemoComponent } from './code/code-demo.component';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
     imports: [
@@ -22,6 +24,7 @@ import { TypographyDemoComponent } from './typography/typography-demo.component'
         SubnavModule,
         TileModule,
         SelectModule,
+        SharedModule,
         RouterModule.forRoot(routes)
     ],
     declarations: [
@@ -29,7 +32,8 @@ import { TypographyDemoComponent } from './typography/typography-demo.component'
         ColorDemoComponent,
         TableDemoComponent,
         SwatchDemoComponent,
-        TypographyDemoComponent
+        TypographyDemoComponent,
+        CodeDemoComponent
     ]
 })
 export class StylesModule {

--- a/docs/app/styles/typography/typography-demo.component.html
+++ b/docs/app/styles/typography/typography-demo.component.html
@@ -185,46 +185,6 @@
                     </ul>
                 </td>
             </tr>
-            <tr>
-                <td>
-                    <code>code. Code</code>
-                </td>
-                <td>
-                    <code>&lt;code&gt;&lt;/code&gt;</code>
-                </td>
-                <td>
-                    <ul>
-                        <li><span class="type-label">Font-size</span>inherit</li>
-                        <li><span class="type-label">Line Height</span>inherit</li>
-                    </ul>
-                </td>
-                <td>
-                    <ul>
-                        <li><span class="type-label">Weight</span>inherit</li>
-                        <li><span class="type-label">Color</span>$magneta</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <pre><code style="width: 250px">Preformatted + Code</code></pre>
-                </td>
-                <td>
-                    <code>&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;</code>
-                </td>
-                <td>
-                    <ul>
-                        <li><span class="type-label">Font-size</span>1.2rem</li>
-                        <li><span class="type-label">Line Height</span>140%</li>
-                    </ul>
-                </td>
-                <td>
-                    <ul>
-                        <li><span class="type-label">Weight</span>inherit</li>
-                        <li><span class="type-label">Color</span>$text</li>
-                    </ul>
-                </td>
-            </tr>
         </table>
     </hc-tile>
 

--- a/docs/styles.scss
+++ b/docs/styles.scss
@@ -197,6 +197,6 @@ ol {
         margin-right: 5px;
         color: rgba($gray-600,0.5);
         @include fontSize(14px);
-        line-height: 22px;
+        font-family: Consolas, Menlo, "Ubuntu Mono", monospace;
     }
 }

--- a/guides/styles/code.md
+++ b/guides/styles/code.md
@@ -1,4 +1,9 @@
 :::
+##### Code Font
+Source code should always be displayed using a monospace font. This is the font family used by this Cashmere site: `font-family: Consolas, Menlo, "Ubuntu Mono", monospace;`.
+:::
+
+:::
 ##### Code Blocks
 For blocks of code larger than than three lines, it is recommended that line numbers be included.  The line numbers should be the same font size as the code, but in a light gray color so they aren't distracting.
 

--- a/guides/styles/code.md
+++ b/guides/styles/code.md
@@ -1,11 +1,13 @@
 :::
 ##### Code Font
-Source code should always be displayed using a monospace font. This is the font family used by this Cashmere site: `font-family: Consolas, Menlo, "Ubuntu Mono", monospace;`.
+Display source code in a monospace font. The Cashmere site uses the following: `font-family: Consolas, Menlo, "Ubuntu Mono", monospace;`
 :::
 
 :::
 ##### Code Blocks
-For blocks of code larger than than three lines, it is recommended that line numbers be included.  The line numbers should be the same font size as the code, but in a light gray color so they aren't distracting.
+Include line numbers for blocks of code longer than than three lines. Line numbers should be:
+- The same font size as the code
+- In a light gray color so they aren't distracting
 
 ``` html
     <hc-list>
@@ -20,6 +22,6 @@ For blocks of code larger than than three lines, it is recommended that line num
 
 :::
 ##### Syntax Highlighting
-Syntax highlighting can be useful to make blocks of code more readable.  The highlight.js library is our recommended highligher, using the **"GitHub Gist"** theme.  Visit [https://highlightjs.org/static/demo/](https://highlightjs.org/static/demo/) for more details.
+Syntax highlighting makes blocks of code more readable. The **"GitHub Gist"** theme in the highlight.js library is our recommended highlighter. Visit [https://highlightjs.org/static/demo](https://highlightjs.org/static/demo) for details.
 
 :::

--- a/guides/styles/code.md
+++ b/guides/styles/code.md
@@ -1,0 +1,20 @@
+:::
+##### Code Blocks
+For blocks of code larger than than three lines, it is recommended that line numbers be included.  The line numbers should be the same font size as the code, but in a light gray color so they aren't distracting.
+
+``` html
+    <hc-list>
+        <hc-list-item>
+            <hc-icon fontSet="fa" fontIcon="fa-snowflake-o" hcListIcon></hc-icon>
+            <h4 hcListLine>SnowFlake</h4>
+            <span hcListLine>Second Line</span>
+        </hc-list-item>
+    </hc-list>
+```
+:::
+
+:::
+##### Syntax Highlighting
+Syntax highlighting can be useful to make blocks of code more readable.  The highlight.js library is our recommended highligher, using the **"GitHub Gist"** theme.  Visit [https://highlightjs.org/static/demo/](https://highlightjs.org/static/demo/) for more details.
+
+:::

--- a/lib/src/sass/_typography.scss
+++ b/lib/src/sass/_typography.scss
@@ -52,6 +52,11 @@ p,.p {
 code {
     color: $magneta;
     font-family: Consolas, Menlo, "Ubuntu Mono", monospace;
+    background-color: $block-text-background;
+    border-radius: 3px;
+    padding: 3px 7px;
+    @include fontSize(14px);
+    font-weight: 400;
 }
 
 // for code blocks
@@ -62,9 +67,10 @@ pre {
     border-radius: 5px;
     display: block;
     background-color: $block-text-background;
+    font-weight: 400;
 
     > span {
-        @include fontSize(16px);
+        @include fontSize(14px);
         line-height: 1.4;
         padding: $code-padding 0;
         background-color: $block-text-background;
@@ -78,6 +84,8 @@ pre {
         line-height: 1.4;
         background-color: $block-text-background;
         color: $text;
+        border: unset;
+        border-radius: unset;
     }
 }
 

--- a/lib/src/sass/_typography.scss
+++ b/lib/src/sass/_typography.scss
@@ -64,7 +64,7 @@ pre {
     background-color: $block-text-background;
 
     > span {
-        @include fontSize(16px);    
+        @include fontSize(16px);
         line-height: 1.4;
         padding: $code-padding 0;
         background-color: $block-text-background;
@@ -73,7 +73,7 @@ pre {
     > code {
         overflow-x: auto;
         display: block;
-        @include fontSize(16px);
+        @include fontSize(14px);
         padding: $code-padding;
         line-height: 1.4;
         background-color: $block-text-background;


### PR DESCRIPTION
Resolves #119.  Splits the two code elements out from the Typography section and adds additional information around syntax highlighting.  @cedar-ave - let me know if you'd suggest any additional content or guidelines in this section.