### PR TITLE
remove types/moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -298,15 +298,6 @@
         "@types/jasmine": "2.5.54"
       }
     },
-    "@types/moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
-      "dev": true,
-      "requires": {
-        "moment": "2.19.4"
-      }
-    },
     "@types/node": {
       "version": "6.0.92",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
@@ -6164,12 +6155,6 @@
           "dev": true
         }
       }
-    },
-    "moment": {
-      "version": "2.19.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz",
-      "integrity": "sha512-1xFTAknSLfc47DIxHDUbnJWC+UwgWxATmymaxIPQpmMh7LBm7ZbwVEsuushqwL2GYZU0jie4xO+TK44hJPjNSQ==",
-      "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "@angular/language-service": "5.1.0",
         "@types/jasmine": "~2.5.53",
         "@types/jasminewd2": "~2.0.2",
-        "@types/moment": "^2.13.0",
         "@types/node": "6.0.92",
         "@types/popper.js": "^1.11.0",
         "chalk": "^2.3.0",


### PR DESCRIPTION
This should fix the vulnerability notification we've been getting. types/moment was listed as a devDependency in package.json but It wasn't being used anywhere. 