### PR TITLE
Set `z-index` of popover so it pops... over.

### DIFF
--- a/lib/src/drawer/drawer.component.scss
+++ b/lib/src/drawer/drawer.component.scss
@@ -1,3 +1,5 @@
+@import '../sass/_variables.scss';
+
 $drawer-background-color: #6E6F71;
 $drawer-font-color: #b9babb;
 
@@ -18,7 +20,7 @@ $drawer-font-color: #b9babb;
     position: absolute;
     top: 0;
     bottom: 0;
-    z-index: 5;
+    z-index: $zindex-drawer;
     min-width: 100px;
     outline: 0;
     box-sizing: border-box;

--- a/lib/src/modal/modal.service.ts
+++ b/lib/src/modal/modal.service.ts
@@ -23,8 +23,8 @@ export type ModalContentType = Type<{}> | TemplateRef<any>;
 
 @Injectable()
 export class ModalService {
-    // start at 1040 because navbar is at 1030
-    public zIndexCounter = 1040;
+    // start at 2000 (reserved range for modals, see _variables.scss)
+    public zIndexCounter = 2000;
     private renderer: Renderer2;
 
     constructor(

--- a/lib/src/navbar/navbar-menu/navbar-menu.component.scss
+++ b/lib/src/navbar/navbar-menu/navbar-menu.component.scss
@@ -1,14 +1,11 @@
-@import 'colors';
-@import 'mixins';
-
-$menu-z-index: 1025 !default;
+@import '../../sass/cashmere';
 
 .menu-dropdown {
     width: 100%;
     background-color: $slate-blue;
     margin-top: 53px;
     position: fixed;
-    z-index: $menu-z-index;
+    z-index: $zindex-navbar-menu;
     padding-top: 15px;
     display: none;
     transition: top 0.7s ease;

--- a/lib/src/navbar/navbar.component.scss
+++ b/lib/src/navbar/navbar.component.scss
@@ -6,7 +6,6 @@ $navbar-height: 53px !default;
 $navbar-app-padding: 0 75px 0 25px !default;
 $navbar-text: $white !default;
 $navbar-text-inactive: $gray-300 !default;
-$navbar-z-index: 1030 !default;
 $navbar-fixed-shadow: 0px 2px 6px $shadow;
 
 .navbar.fixed-top::ng-deep {
@@ -14,7 +13,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     position: fixed;
     right: 0;
     left: 0;
-    z-index: $navbar-z-index;
+    z-index: $zindex-navbar;
     box-shadow: $navbar-fixed-shadow;
 }
 

--- a/lib/src/popover/popoverContent.component.scss
+++ b/lib/src/popover/popoverContent.component.scss
@@ -17,6 +17,7 @@ $popover-arrow-outer-color: fade_in($popover-border-color, 0.05) !default;
     border: 1px solid $popover-border-color;
     border-radius: 6px;
     box-shadow: 0 2px 10px $gray-400;
+    z-index: 999;
 
     &.animation {
         animation: fadein 150ms ease-out;

--- a/lib/src/popover/popoverContent.component.scss
+++ b/lib/src/popover/popoverContent.component.scss
@@ -17,7 +17,7 @@ $popover-arrow-outer-color: fade_in($popover-border-color, 0.05) !default;
     border: 1px solid $popover-border-color;
     border-radius: 6px;
     box-shadow: 0 2px 10px $gray-400;
-    z-index: 999;
+    z-index: $zindex-popover;
 
     &.animation {
         animation: fadein 150ms ease-out;

--- a/lib/src/sass/_variables.scss
+++ b/lib/src/sass/_variables.scss
@@ -9,3 +9,16 @@ $grid-breakpoints: (
   lg: 992px,
   xl: 1200px
 ) !default;
+
+/* set standard relative layering for components */
+$zindex-dropdown:           1000 !default;
+$zindex-sticky:             1020 !default;
+$zindex-fixed:              1030 !default;
+$zindex-drawer:             1040 !default;
+$zindex-subnav:             1050 !default;
+$zindex-navbar-menu:        1060 !default;
+$zindex-navbar:             1070 !default;
+// z-index for modals is set in code as an incrementing
+// amount, starting at 2000, see modal.service.ts
+$zindex-popover:            3000 !default;
+$zindex-tooltip:            3010 !default;

--- a/lib/src/select/select.component.scss
+++ b/lib/src/select/select.component.scss
@@ -48,7 +48,7 @@ hc-select .chevron:after {
     position: absolute;
     right: 0;
     top: 0;
-    z-index: 1;
+    z-index: $zindex-dropdown + 1;
     text-align: center;
     height: 100%;
     pointer-events: none;

--- a/lib/src/subnav/subnav.component.scss
+++ b/lib/src/subnav/subnav.component.scss
@@ -1,7 +1,5 @@
 @import '../sass/cashmere';
 
-$subnav-z-index: 1020 !default;
-
 :host {
     width: 100%;
     min-height: 52px;
@@ -12,7 +10,7 @@ $subnav-z-index: 1020 !default;
     border-bottom: 1px solid $slate-gray-300;
     display: flex;
     align-items: center;
-    z-index: $subnav-z-index;
+    z-index: $zindex-navbar;
 
     &.fixed-top::ng-deep {
         top: 53px;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "allowSyntheticDefaultImports": true,
         "strictNullChecks": true,
         "target": "es5",
+        "skipLibCheck": true,
         "typeRoots": [
             "node_modules/@types"
         ],
@@ -24,7 +25,7 @@
         "lib/**/*.ts"
     ],
     "exclude": [
-        "node_modules/",
-        "lib/node_modules/"
+        "node_modules/**/*.ts",
+        "lib/node_modules/**/*.ts"
     ]
 }


### PR DESCRIPTION
When integrating the current Cashmere as an NPM package into Fabric.Auth.AccessControl, I found that the popover likes to pop under:

![image](https://user-images.githubusercontent.com/12286274/37666747-ec5ad3c2-2c25-11e8-8aeb-e8a427f6961b.png)

This solved the issue.