### PR TITLE
Disabled buttons drop to 35% opacity

### DIFF
--- a/lib/src/button/button.component.scss
+++ b/lib/src/button/button.component.scss
@@ -18,8 +18,8 @@
         color: $white;
     }
     &[disabled], &[disabled]:hover, &[disabled]:focus, &[disabled]:active {
-        background-color: $gray-100;
-        color: $gray-300;
+        background-color: $color;
+        opacity: 0.35;
     }
 }
 
@@ -82,9 +82,8 @@
         line-height: 33px;
         padding-right: 19px;
 
-        &:hover {
-            color: $offblack;
-        }
+        &:hover { color: $offblack; }
+        &[disabled]:hover { color: $gray-600; }
     }
 
     &.hc-tertiary {
@@ -99,8 +98,9 @@
             color: darken($primary-brand, 10%);
         }
 
-        &[disabled] {
-            color: $gray-500;
+        &[disabled], &[disabled]:hover, &[disabled]:focus, &[disabled]:active {
+            opacity: 0.35;
+            color: $primary-brand;
         }
     }
 


### PR DESCRIPTION
Thanks for catching this @isaaclyman.  Disabled buttons currently were switching to a gray color that was lost when placed directly against our gray page background.  As @corykon pointed out, the switch to gray also loses any context from the color of the button (ie red for destructive).  To address both these issues, switching to a 35% drop in opacity when a button is disabled instead.