### PR TITLE
no hover on disabled row

### DIFF
--- a/lib/src/sass/tables.scss
+++ b/lib/src/sass/tables.scss
@@ -56,7 +56,7 @@ table.hc-table {
                 background-color: $row-color-alt;
             }
 
-            &:hover {
+            &:not([disabled]):hover {
                 background-color: $row-color-hover;
             }
 
@@ -91,7 +91,7 @@ table.hc-table {
 
     // Actionable table/row
     &.hc-action-table {
-        tr {
+        tr:not([disabled]) {
             &:hover {
                 background-color: $row-color-action-hover;
                 cursor: pointer;
@@ -100,7 +100,7 @@ table.hc-table {
         }
     }
 
-    tr.hc-action-row, {
+    tr.hc-action-row:not([disabled]) {
         &:hover {
             background-color: $row-color-action-hover;
             cursor: pointer;


### PR DESCRIPTION
In a module I was working on I wanted a way to disable hover states on the .hc-table. This will allow that to happen by doing the following
```
<tr disabled><tr>
// or in angular 
<tr [attr.disabled]="disabled ? '' : null"></tr>
```