### PR TITLE
add core-js/es6/object poly fill to fix IE11 popover bug

### DIFF
--- a/docs/polyfills.ts
+++ b/docs/polyfills.ts
@@ -20,7 +20,7 @@
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
 // import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
+import 'core-js/es6/object';
 // import 'core-js/es6/function';
 // import 'core-js/es6/parse-int';
 // import 'core-js/es6/parse-float';


### PR DESCRIPTION
IE 11 doesn't have object.assign, a quick google led to this very simple solution. Tested the popover now triggers properly 😄 

Closes #199