### PR TITLE
User feedback guide

### DIFF
--- a/docs/app/components/typeform-survey/typeform-survey-demo.component.html
+++ b/docs/app/components/typeform-survey/typeform-survey-demo.component.html
@@ -23,21 +23,8 @@
                     Any survey created in Typeform may be linked using this component.  For Health Catalyst app developers,
                     please contact the Customer Feedback team for the correct survey to link to within your app.  The typeform survey
                     component should be used in conjunction with application specific logic that prompts the user to take
-                    a survey at predetermined intervals (every 30 days is a good rule of thumb).
+                    a survey at predetermined intervals. See the <a href="http://cashmere.healthcatalyst.net/guides/user-feedback">User Feedback Guide</a> for more information and best practices.
                 </p>
-            </hc-tile>
-
-            <hc-tile>
-                <h5>Survey Prompt Recommendations</h5>
-                <p>The following is recommended copy for use within the application specific modal that prompts the user to complete a survey:</p>
-                <h4>Prompt header</h4>
-                <p>Help us improve [app name]</p>
-                <h4>Body text:</h4>
-                <p>We'd love to hear about your experience with [app name].  Please take 1-2 minutes to share your feedback and help us improve the application.</p>
-                <h4>Confirm button text</h4>
-                <p>Provide Feedback</p>
-                <h4>Dismiss button text</h4>
-                <p>No thanks</p>
             </hc-tile>
 
         </hc-tab>

--- a/docs/app/guides/guides.service.ts
+++ b/docs/app/guides/guides.service.ts
@@ -30,6 +30,11 @@ export class GuidesService {
             document: require('raw-loader!../../../guides/submit-an-issue.md')
         },
         {
+            title: 'User Feedback',
+            route: 'user-feedback',
+            document: require('raw-loader!../../../guides/user-feedback.md')
+        },
+        {
             title: 'Supported Browsers',
             route: 'supported-browsers',
             document: require('raw-loader!../../../guides/supported-browsers.md')

--- a/docs/app/guides/guides.service.ts
+++ b/docs/app/guides/guides.service.ts
@@ -30,14 +30,14 @@ export class GuidesService {
             document: require('raw-loader!../../../guides/submit-an-issue.md')
         },
         {
-            title: 'User Feedback',
-            route: 'user-feedback',
-            document: require('raw-loader!../../../guides/user-feedback.md')
-        },
-        {
             title: 'Supported Browsers',
             route: 'supported-browsers',
             document: require('raw-loader!../../../guides/supported-browsers.md')
+        },
+        {
+            title: 'User Feedback',
+            route: 'user-feedback',
+            document: require('raw-loader!../../../guides/user-feedback.md')
         }
     ];
 }

--- a/guides/contribution-guide.md
+++ b/guides/contribution-guide.md
@@ -27,4 +27,4 @@ Before you submit your pull request (PR), consider the following guidelines:
     *   Unit tests demonstrating that it functions as intended
 *   A new component should adhere to the [Health Catalyst style](http://cashmere.healthcatalyst.net).
 *   "Squash and merge" a PR to complete it.
-    :::
+:::

--- a/guides/submit-an-issue.md
+++ b/guides/submit-an-issue.md
@@ -30,4 +30,4 @@ Request a new feature by submitting an issue to our [GitHub Repository](https://
 
 *   For a major feature, first open an issue and outline your proposal so it can be discussed. This also allows us to better coordinate our efforts, prevent duplicate work, and help you craft the change so it is successfully accepted into the project.
 *   Small features can be crafted and directly submitted as a pull request.
-    :::
+:::

--- a/guides/user-feedback.md
+++ b/guides/user-feedback.md
@@ -1,0 +1,82 @@
+# User Feedback Guide
+
+###### Last updated May 21, 2018
+
+:::
+
+##### Overview
+
+The purpose of this guide is to explain the methodologies and mechanisms for gathering qualitative user feedback.  It will also provide general templates for body copy that can be used for user prompts.
+:::
+
+:::
+
+##### Why Collect User Feedback?
+
+Implementing a feedback mechanism into the product is critical to continually striving to build a better product that best meets the needs of your users. It is important to have a couple different feedback mechanisms within a product, including a volunteered mechanism (where they can click on “Give Feedback” from the Help menu or somewhere else) and a timed mechanism (a pop up that appears in the product on some cadence such as every X number of logins). These can be the same questions or different ones. In addition, users can be invited to provide feedback via email by providing a link to the same survey as the in-page popup survey. This is more personal and can yield higher response rates in certain situations.
+:::
+
+:::
+
+##### Qualitative Feedback vs. Quantitative Telemetry
+
+Quantitative usage metrics and qualitative customer satisfaction data are complimentary and should be used hand in hand. The usage data helps us understand the overall volume of use as well as what aspects/features of the product are being used and how. Qualitative data can help fill in the “why” behind quantitative metrics.
+:::
+
+:::
+
+##### User Satisfaction
+
+After a user has had enough time to explore and utilize the product, they will then be able to provide a meaningful satisfaction rating (asking too soon will yield inaccurate results). A 7 point scale is often used to gauge user satisfaction, and many also opt for a 9 or 11 point scale. The scale you choose comes down to a tradeoff between ease of use for the respondent (generally it’s easier to answer on a 7 point scale than an 11 point one) and robustness of results (an 11 point scale gives a larger continuum so over time you can more easily see if the needle is moving). User satisfaction is often rolled up to a “satisfaction score” for the product and tracked by the organization as a key metric for sustainability and growth. This can be represented as an average score or “top two box” score (percent of users who are “very” and “extremely” satisfied).
+:::
+
+:::
+
+##### Net Promoter Score®
+
+The Net Promoter Score® (NPS) is likely the most widely utilized approach to gathering feedback for digital products. The question under the NPS methodology is “How likely are you to recommend [insert product or service name] to a friend or colleague?” This methodology is founded upon a lot of research showing that people will go so far as to recommend a product when they are satisfied with it themselves. So it takes satisfaction one step further. It is a metric of enthusiasm and happiness with a product. Oftentimes a second free text question is used following the NPS® question. This question asks the user why they gave the rating they did, which reveals what’s making them very happy or unhappy. The NPS methodology uses a 0 to 11-point scale, where respondents scoring 0 to 6 are considered “Detractors”, 7 and 8 are considered “Passives” and 9 and 10 are considered “Promoters”. To calculate NPS, the percent of Detractors is subtracted from the percent of Promoters. This score is represented as a negative or positive number (not a percent; a common error). This score can then be used to compare a company or product to past performance or benchmarks. One caution regarding NPS is that small sample sizes can result in volatility when tracked over time which can raise red flags unnecessarily. Arguably, several hundred respondents are a necessary guidepost to be able to reliably track the NPS metric. However, on an individual level or with smaller sample sizes, it is still highly useful to understand whether an individual is a Promoter, Passive or Detractor or to track the percent who are likely to recommend the product (e.g., percent who answer 8,9 or 10).
+:::
+
+:::
+
+##### Frequency of Gathering Feedback
+
+There is no rule of thumb that applies to all situations in terms of how often to gather feedback. In general, a team should make meaningful changes or improvements to the product in between surveying users. It also depends on the length of the survey. If it is a longer form, more comprehensive satisfaction survey that will take a user 5-10 minutes to complete, perhaps asking annually is best. But if the survey is brief and more of a “pulse” that takes respondents 2 minutes or less, asking **monthly or quarterly** could be acceptable without giving respondents fatigue.
+:::
+
+:::
+
+##### Asking for Feedback in App
+
+It has become common practice to ask users to complete a short form satisfaction survey directly within an application.  Guidelines for frequency are explained in the above tile.  An app will typically prompt their users via a modal dialog on launch.  A basic template for the prompt is as follows:
+
+**Prompt header:**
+Help us improve [product name]
+
+**Body text:**
+We'd love to hear about your experience with [product name]. Please take 1-2 minutes to share your feedback and help us improve the application.
+
+**Confirm button text:**
+Provide Feedback
+
+**Dismiss button text:**
+No thanks
+
+After agreeing to provide user feedback, it is recommended that the [Typeform Survey](https://cashmere.healthcatalyst.net/components/typeform-survey) component be used to collect in app feedback.
+:::
+
+:::
+
+##### Asking for Feedback via Email
+
+With any survey it is important to achieve the highest response rate possible. A personalized invitation to take the survey is generally going to yield the highest response rate. If the product is in alpha or beta phases at a client, for example, having the product team reach out to users directly on an individual level may be best. If you choose to send the users a personal email asking them to click through to the survey, here is a template as a starting point:
+
+*Health Catalyst would like your feedback to help inform improvements to [product name]. It is very important that we hear from you to ensure that [product name] is meeting your needs and helping you to continue to excel as a data-driven organization. Health Catalyst will use your feedback to inform necessary upgrades. The [product name] Survey is anonymous and will take you about 1-3 minutes to complete.*
+
+*Please click here to take the survey: {link}*
+
+*If you have any questions, please feel free to reach out to me. Thank you for completing the survey by {date}.*
+
+However, it is not always practical to take this personalized approach, especially with more mature products that have a lot of users. In that case MailChimp or another centralized tool that can send automated emails are a good option.
+
+:::


### PR DESCRIPTION
This is content I requested from the Operations team back when @corytak built the [Typeform component](https://cashmere.healthcatalyst.net/components/typeform-survey).  So they wrote this, I've just converted it into markdown.  Catalyst is asking our apps to prompt the user for feedback on regular intervals, and this guide is a place to explain why and how we're doing that.  It also allows us to pull body copy recommendations out of the component documentation and into the guide.

Also fixed an issue where the `:::` was indented in two of the current guides and the interpreter was reading that as creating another `hc-tile` inside the current tile.