### PR TITLE
fix(split button): fixes split-button onClick issue

### DIFF
--- a/projects/cashmere/src/lib/button/split-button/split-button.component.html
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.html
@@ -14,11 +14,11 @@
         class="hc-split-button-toggle"
         type="button"
         [color]="color"
-        (click)="stopMenuClick($event)"
+        (click)="_stopClick($event)"
         [disabled]="disabled"
         [hcPopover]="buttonMenu"
         popperPlacement="bottom">
 </button>
-<hc-popover-content #buttonMenu>
+<hc-popover-content #buttonMenu (click)="_stopClick($event)">
     <ng-content select="[hcButtonItem]"></ng-content>
 </hc-popover-content>

--- a/projects/cashmere/src/lib/button/split-button/split-button.component.spec.ts
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.spec.ts
@@ -1,25 +1,74 @@
+/* tslint:disable:no-use-before-declare component-class-suffix */
+
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {SplitButtonComponent} from './split-button.component';
 import {ButtonModule} from '../button.module';
+import {Component, DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {ButtonItemDirective} from './button-item.directive';
 
 describe('SplitButtonComponent', () => {
-    let component: SplitButtonComponent;
-    let fixture: ComponentFixture<SplitButtonComponent>;
+    let fixture: ComponentFixture<any>;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [ButtonModule]
+            imports: [ButtonModule],
+            declarations: [TestComponent]
         }).compileComponents();
     }));
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(SplitButtonComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+    describe('basic behaviors', () => {
+        let testComponent: TestComponent;
+        let splitButtonDebugElement: DebugElement;
+        let splitButtonNative: HTMLElement;
+        let triggerButton: HTMLButtonElement;
+        let buttonItems: DebugElement[];
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
+        beforeEach(() => {
+            fixture = TestBed.createComponent(TestComponent);
+            fixture.detectChanges();
+
+            testComponent = fixture.debugElement.componentInstance;
+            splitButtonDebugElement = fixture.debugElement.query(By.directive(SplitButtonComponent));
+            splitButtonNative = splitButtonDebugElement.nativeElement;
+            buttonItems = splitButtonDebugElement.queryAll(By.directive(ButtonItemDirective));
+            triggerButton = splitButtonDebugElement.query(By.css('.hc-split-button-toggle')).nativeElement;
+        });
+
+        it('should not trigger primary button click when menu item is clicked', () => {
+            expect(testComponent.isPrimaryClicked).toBe(false);
+            expect(testComponent.isMenuItemClicked).toBe(false);
+
+            triggerButton.click();
+            fixture.detectChanges();
+
+            buttonItems[0].nativeElement.click();
+            fixture.detectChanges();
+
+            expect(testComponent.isPrimaryClicked).toBe(false);
+            expect(testComponent.isMenuItemClicked).toBe(true);
+        });
     });
 });
+
+@Component({
+    template: `
+        <hc-split-button (click)="primaryButtonClick()">
+            Button Text
+            <div hcButtonItem (click)="menuItemClick()">Menu Item</div>
+        </hc-split-button>
+    `
+})
+class TestComponent {
+    isPrimaryClicked = false;
+    isMenuItemClicked = false;
+
+    primaryButtonClick() {
+        this.isPrimaryClicked = true;
+    }
+
+    menuItemClick() {
+        this.isMenuItemClicked = true;
+    }
+}

--- a/projects/cashmere/src/lib/button/split-button/split-button.component.ts
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.ts
@@ -60,19 +60,19 @@ export class SplitButtonComponent {
 
     constructor(private elementRef: ElementRef) {}
 
+    _stopClick($event: MouseEvent) {
+        $event.stopPropagation();
+    }
+
     focus(): void {
         this.elementRef.nativeElement.focus();
     }
 
-    mainBtnClick(event: Event): void {
+    mainBtnClick(event: MouseEvent): void {
         event.stopPropagation();
 
         if (!this.disabled) {
             this.click.emit(new SplitButtonClickEvent(this));
         }
-    }
-
-    stopMenuClick(event: Event): void {
-        event.stopPropagation();
     }
 }


### PR DESCRIPTION
split-button captures menu clicks and calls stopPropagation to prevent primary button from being
triggered

fix #345