### PR TITLE
docs: add jsdocs for subnav & tile components

### DIFF
--- a/projects/cashmere/src/lib/subnav/subnav-right.directive.ts
+++ b/projects/cashmere/src/lib/subnav/subnav-right.directive.ts
@@ -1,8 +1,9 @@
 import {Directive, HostBinding} from '@angular/core';
 
+/** Can be added to a div or individual component to align it to the right side of the subnav  */
 @Directive({
     selector: '[hcSubnavRight]'
 })
 export class SubnavRightDirective {
-    @HostBinding('class.subnav-right') true;
+    @HostBinding('class.subnav-right') _hostClass: boolean = true;
 }

--- a/projects/cashmere/src/lib/subnav/subnav.component.ts
+++ b/projects/cashmere/src/lib/subnav/subnav.component.ts
@@ -1,14 +1,16 @@
 import {Component, HostBinding, Input} from '@angular/core';
 
+/** Secondary navigation bar appearing below the primary navbar  */
 @Component({
     selector: 'hc-subnav',
     template: `<ng-content></ng-content>`
 })
 export class SubnavComponent {
+    @HostBinding('class.subnav') _hostClass: boolean = true;
+
     @HostBinding('class.fixed-top')
-    @Input()
-    fixedTop: boolean = false;
-    @HostBinding('class.subnav') hostClass: boolean = true;
+    /** If true, statically positions the subnav below the navbar (stays pinned on scroll) */
+    @Input() public fixedTop: boolean = false;
 
     constructor() {}
 }

--- a/projects/cashmere/src/lib/subnav/subnav.component.ts
+++ b/projects/cashmere/src/lib/subnav/subnav.component.ts
@@ -8,9 +8,10 @@ import {Component, HostBinding, Input} from '@angular/core';
 export class SubnavComponent {
     @HostBinding('class.subnav') _hostClass: boolean = true;
 
-    @HostBinding('class.fixed-top')
     /** If true, statically positions the subnav below the navbar (stays pinned on scroll) */
-    @Input() public fixedTop: boolean = false;
+    @HostBinding('class.fixed-top')
+    @Input()
+    public fixedTop: boolean = false;
 
     constructor() {}
 }

--- a/projects/cashmere/src/lib/tile/tile.component.ts
+++ b/projects/cashmere/src/lib/tile/tile.component.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 
+/** Container element to help segment content visually against a gray background. The tile will expand to the height and width of the content it contains. */
 @Component({
     selector: 'hc-tile',
     template: `<ng-content></ng-content>`,

--- a/projects/cashmere/src/lib/tile/tile.component.ts
+++ b/projects/cashmere/src/lib/tile/tile.component.ts
@@ -1,6 +1,7 @@
 import {Component} from '@angular/core';
 
-/** Container element to help segment content visually against a gray background. The tile will expand to the height and width of the content it contains. */
+/** Container element to help segment content visually against a gray background.
+ * The tile will expand to the height and width of the content it contains. */
 @Component({
     selector: 'hc-tile',
     template: `<ng-content></ng-content>`,


### PR DESCRIPTION
documents subnav and tile components' public api while hiding fields/methods that are private

closes #310 & #312