### PR TITLE
docs: doc styling

### DIFF
--- a/projects/cashmere/src/lib/sass/_tabs.scss
+++ b/projects/cashmere/src/lib/sass/_tabs.scss
@@ -54,6 +54,8 @@
     padding: 10px 20px;
     text-decoration: none;
     display: block;
+    min-width: 100px;
+    text-align: center;
     &:hover {
         cursor: pointer;
     }

--- a/src/app/components/component-list/components-list-router.module.ts
+++ b/src/app/components/component-list/components-list-router.module.ts
@@ -14,9 +14,9 @@ const routes: Route[] = [
                 path: ':id',
                 component: ComponentViewerComponent,
                 children: [
-                    {path: 'API', component: ComponentApiComponent, pathMatch: 'full'},
-                    {path: 'Examples', component: ComponentExamplesComponent, pathMatch: 'full'},
-                    {path: '**', redirectTo: 'API'}
+                    {path: 'api', component: ComponentApiComponent, pathMatch: 'full'},
+                    {path: 'examples', component: ComponentExamplesComponent, pathMatch: 'full'},
+                    {path: '**', redirectTo: 'api'}
                 ]
             }
         ]

--- a/src/app/components/component-list/components-list-router.module.ts
+++ b/src/app/components/component-list/components-list-router.module.ts
@@ -14,9 +14,9 @@ const routes: Route[] = [
                 path: ':id',
                 component: ComponentViewerComponent,
                 children: [
-                    {path: 'api', component: ComponentApiComponent, pathMatch: 'full'},
-                    {path: 'examples', component: ComponentExamplesComponent, pathMatch: 'full'},
-                    {path: '**', redirectTo: 'api'}
+                    {path: 'API', component: ComponentApiComponent, pathMatch: 'full'},
+                    {path: 'Examples', component: ComponentExamplesComponent, pathMatch: 'full'},
+                    {path: '**', redirectTo: 'API'}
                 ]
             }
         ]

--- a/src/app/components/component-viewer/component-api/component-api.component.scss
+++ b/src/app/components/component-viewer/component-api/component-api.component.scss
@@ -1,3 +1,0 @@
-.content {
-    padding: 10px 20px;
-}

--- a/src/app/components/component-viewer/component-api/component-api.component.ts
+++ b/src/app/components/component-viewer/component-api/component-api.component.ts
@@ -2,8 +2,7 @@ import {Component} from '@angular/core';
 import {ComponentViewerComponent} from '../component-viewer.component';
 
 @Component({
-    templateUrl: 'component-api.component.html',
-    styleUrls: ['component-api.component.scss']
+    templateUrl: 'component-api.component.html'
 })
 export class ComponentApiComponent {
     constructor(public componentViewer: ComponentViewerComponent) {}

--- a/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
@@ -1,10 +1,96 @@
+@import 'scss/cashmere';
+
 .hc-doc-viewer {
     display: block;
 }
 
-.docs-api {
-    background-color: #fff;
-    border-radius: 5px;
-    margin-top: 10px;
-    padding: 10px 25px;
+.hc-tile:first-of-type {
+    margin-top: 20px;
+}
+
+.docs-api-h3 {
+    font-size: 1.07142857rem;
+    text-transform: uppercase;
+    color: #006d9a;
+    font-weight: 600;
+    margin-bottom: 20px;
+}
+
+.docs-api-h4 {
+    font-size: 1.571rem;
+    font-weight: 600;
+}
+
+.docs-api-h5 {
+    text-transform: unset;
+    color: $text;
+    font-weight: 600;
+    font-size: 1.14285714rem;
+    margin: 30px 0 5px 0;
+}
+
+.docs-api-class-extends-clauses {
+    font-size: 1.429rem;
+    font-weight: 300;
+}
+
+.docs-api-directive-selectors {
+    margin: 20px 0 20px 0;
+}
+
+.docs-api-properties-table {
+    font-size: 0.9286rem;
+    margin-bottom: 40px;
+
+    p {
+        font-size: 0.9286rem;
+    }
+}
+
+.docs-api-properties-header-row th {
+    padding-bottom: 8px;
+}
+
+.docs-api-properties-name-cell {
+    font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
+
+    code {
+        font-size: 0.9286rem;
+        background-color: unset;
+        border-radius: unset;
+        padding: unset;
+        font-weight: unset;
+        line-height: unset;
+    }
+}
+
+.directive-spacer {
+    display: block;
+    height: 40px;
+}
+
+.docs-api-method-table {
+    th {
+        color: #a94c9d;
+        font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
+        padding-top: 20px;
+    }
+
+    td {
+        padding-top: 5px;
+    }
+
+    p {
+        font-size: 0.9286rem;
+    }
+
+    code {
+        font-size: 0.9286rem;
+        color: $text;
+        background-color: unset;
+        border-radius: unset;
+        padding: unset;
+        font-weight: unset;
+        line-height: unset;
+    }
 }

--- a/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
@@ -1,5 +1,3 @@
-@import 'scss/cashmere';
-
 .hc-doc-viewer {
     display: block;
 }
@@ -13,7 +11,7 @@
     text-transform: uppercase;
     color: #006d9a;
     font-weight: 600;
-    margin-bottom: 20px;
+    margin: 0 0 20px 0;
 }
 
 .docs-api-h4 {
@@ -23,7 +21,7 @@
 
 .docs-api-h5 {
     text-transform: unset;
-    color: $text;
+    color: #333333;
     font-weight: 600;
     font-size: 1.14285714rem;
     margin: 30px 0 5px 0;
@@ -86,7 +84,7 @@
 
     code {
         font-size: 0.9286rem;
-        color: $text;
+        color: #333333;
         background-color: unset;
         border-radius: unset;
         padding: unset;

--- a/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
@@ -21,13 +21,14 @@
 .docs-api-h4 {
     @include fontSize(22px);
     font-weight: 600;
+    margin: 20px 0 0 0;
 }
 
 .docs-api-h5 {
     text-transform: unset;
     color: $text;
     font-weight: 600;
-    @include fontSize(20px);
+    @include fontSize(16px);
     margin: 30px 0 5px 0;
 }
 

--- a/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/component-api/document-viewer/document-viewer.component.scss
@@ -1,3 +1,7 @@
+@import 'scss/colors';
+@import 'scss/functions';
+@import 'scss/mixins.scss';
+
 .hc-doc-viewer {
     display: block;
 }
@@ -7,28 +11,28 @@
 }
 
 .docs-api-h3 {
-    font-size: 1.07142857rem;
+    @include fontSize(15px);
     text-transform: uppercase;
-    color: #006d9a;
+    color: $dark-blue;
     font-weight: 600;
     margin: 0 0 20px 0;
 }
 
 .docs-api-h4 {
-    font-size: 1.571rem;
+    @include fontSize(22px);
     font-weight: 600;
 }
 
 .docs-api-h5 {
     text-transform: unset;
-    color: #333333;
+    color: $text;
     font-weight: 600;
-    font-size: 1.14285714rem;
+    @include fontSize(20px);
     margin: 30px 0 5px 0;
 }
 
 .docs-api-class-extends-clauses {
-    font-size: 1.429rem;
+    @include fontSize(20px);
     font-weight: 300;
 }
 
@@ -37,11 +41,11 @@
 }
 
 .docs-api-properties-table {
-    font-size: 0.9286rem;
+    @include fontSize(13px);
     margin-bottom: 40px;
 
     p {
-        font-size: 0.9286rem;
+        @include fontSize(13px);
     }
 }
 
@@ -53,7 +57,7 @@
     font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
 
     code {
-        font-size: 0.9286rem;
+        @include fontSize(13px);
         background-color: unset;
         border-radius: unset;
         padding: unset;
@@ -69,7 +73,7 @@
 
 .docs-api-method-table {
     th {
-        color: #a94c9d;
+        color: $magneta;
         font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
         padding-top: 20px;
     }
@@ -79,12 +83,12 @@
     }
 
     p {
-        font-size: 0.9286rem;
+        @include fontSize(13px);
     }
 
     code {
-        font-size: 0.9286rem;
-        color: #333333;
+        @include fontSize(13px);
+        color: $text;
         background-color: unset;
         border-radius: unset;
         padding: unset;

--- a/src/app/components/component-viewer/component-examples/component-examples.component.scss
+++ b/src/app/components/component-viewer/component-examples/component-examples.component.scss
@@ -1,3 +1,3 @@
-.content {
-    padding: 10px 20px;
+.hc-tile:first-of-type {
+    margin-top: 20px;
 }

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
@@ -1,5 +1,5 @@
 <div class="hc-tile">
-    <h3 class="docs-api-h3" >Example Name Header</h3>
+    <h3 class="docs-api-h3" >{{exampleTitle}}</h3>
     <hc-tab-set direction="horizontal">
         <hc-tab [tabTitle]="ext" *ngFor="let ext of ['Example', 'HTML', 'Typescript']">
 

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
@@ -1,10 +1,14 @@
-<hc-tab-set direction="horizontal">
-    <hc-tab [tabTitle]="ext" *ngFor="let ext of ['html', 'ts']">
-        <pre>
-            <hc-doc-viewer [documentUrl]="exampleFileUrl(ext)">
-            </hc-doc-viewer>
-        </pre>
-    </hc-tab>
-</hc-tab-set>
+<div class="hc-tile">
+    <h3 class="docs-api-h3" >Example Name Header</h3>
+    <hc-tab-set direction="horizontal">
+        <hc-tab [tabTitle]="ext" *ngFor="let ext of ['Example', 'HTML', 'Typescript']">
 
-<ng-container #vc></ng-container>
+            <ng-container #vc></ng-container>
+
+            <pre class="html hljs xml" *ngIf="ext != 'Example'">
+                <hc-doc-viewer [documentUrl]="exampleFileUrl(ext)">
+                </hc-doc-viewer>
+            </pre>
+        </hc-tab>
+    </hc-tab-set>
+</div>

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.ts
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.ts
@@ -38,6 +38,9 @@ export class ExampleViewerComponent {
     }
 
     exampleFileUrl(ext: string): string {
+        if (ext === 'Typescript') {
+            ext = 'ts';
+        }
         return `/assets/docs/examples/${this.example}-example-${ext.toLowerCase()}.html`;
     }
 }

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.ts
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.ts
@@ -24,6 +24,10 @@ export class ExampleViewerComponent {
         return this._example;
     }
 
+    get exampleTitle() {
+        return this._exampleData.title;
+    }
+
     private _example: string;
 
     constructor(private _componentFactoryResolver: ComponentFactoryResolver, private httpClient: HttpClient) {}

--- a/src/app/components/component-viewer/component-viewer.component.html
+++ b/src/app/components/component-viewer/component-viewer.component.html
@@ -1,3 +1,6 @@
-<hc-tab-set direction="horizontal">
-    <hc-tab *ngFor="let section of sections" [tabTitle]="section" [routerLink]="section"></hc-tab>
-</hc-tab-set>
+<div class="demo-content">
+    <h1>{{docItem.name}}</h1>
+    <hc-tab-set direction="horizontal">
+        <hc-tab *ngFor="let section of sections" [tabTitle]="section" [routerLink]="section"></hc-tab>
+    </hc-tab-set>
+</div>

--- a/src/app/components/component-viewer/component-viewer.component.scss
+++ b/src/app/components/component-viewer/component-viewer.component.scss
@@ -1,0 +1,4 @@
+h1 {
+    margin-top: 20px;
+    margin-bottom: 15px;
+}

--- a/src/app/components/component-viewer/component-viewer.component.ts
+++ b/src/app/components/component-viewer/component-viewer.component.ts
@@ -4,11 +4,12 @@ import {map} from 'rxjs/operators';
 import {ActivatedRoute} from '@angular/router';
 
 @Component({
-    templateUrl: 'component-viewer.component.html'
+    templateUrl: 'component-viewer.component.html',
+    styleUrls: ['component-viewer.component.scss']
 })
 export class ComponentViewerComponent implements OnInit {
     docItem: DocItem | undefined;
-    sections: Set<string> = new Set(['api']);
+    sections: Set<string> = new Set(['API']);
 
     constructor(private activatedRoute: ActivatedRoute, private docItems: DocumentItemsService) {}
 
@@ -19,9 +20,9 @@ export class ComponentViewerComponent implements OnInit {
             if (this.docItem) {
                 const examples = this.docItem.examples;
                 if (examples && examples.length > 0) {
-                    this.sections.add('examples');
+                    this.sections.add('Examples');
                 } else {
-                    this.sections.delete('examples');
+                    this.sections.delete('Examples');
                 }
             }
         });

--- a/src/app/components/component-viewer/component-viewer.component.ts
+++ b/src/app/components/component-viewer/component-viewer.component.ts
@@ -9,7 +9,7 @@ import {ActivatedRoute} from '@angular/router';
 })
 export class ComponentViewerComponent implements OnInit {
     docItem: DocItem | undefined;
-    sections: Set<string> = new Set(['API']);
+    sections: Set<string> = new Set(['api']);
 
     constructor(private activatedRoute: ActivatedRoute, private docItems: DocumentItemsService) {}
 
@@ -20,9 +20,9 @@ export class ComponentViewerComponent implements OnInit {
             if (this.docItem) {
                 const examples = this.docItem.examples;
                 if (examples && examples.length > 0) {
-                    this.sections.add('Examples');
+                    this.sections.add('examples');
                 } else {
-                    this.sections.delete('Examples');
+                    this.sections.delete('examples');
                 }
             }
         });

--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -24,7 +24,7 @@
 
 <h4 id="{$ class.name $}" class="docs-header-link docs-api-h4 docs-api-class-name">
   <span header-link="{$ class.name $}"></span>
-  <code>{$ class.name $}</code>
+  {$ class.name $}
   {% if class.extendedDoc %}
   <span class="docs-api-class-extends-clauses">
     <span class="docs-api-class-extends-label">extends</span>
@@ -41,14 +41,14 @@
 <p class="docs-api-directive-selectors">
   <span class="docs-api-class-selector-label">Selector:</span>
   {% for selector in class.directiveSelectors %}
-    <span class="docs-api-class-selector-name">{$ selector $}</span>
+    <code><span class="docs-api-class-selector-name">{$ selector $}</span></code>
   {% endfor %}
 </p>
 {%- endif -%}
 
 {%- if class.directiveExportAs -%}
 <span class="docs-api-class-export-label">Exported as:</span>
-<span class="docs-api-class-export-name">{$ class.directiveExportAs $}</span>
+<code><span class="docs-api-class-export-name">{$ class.directiveExportAs $}</span></code>
 {%- endif -%}
 
 {%- if class.isDeprecated -%}

--- a/tools/dgeni/templates/componentGroup.template.html
+++ b/tools/dgeni/templates/componentGroup.template.html
@@ -45,55 +45,63 @@
   {% include 'interface.template.html' %}
 {% endmacro %}
 
-<div class="docs-api">
-  <h2>
-    API reference for Angular {$ doc.packageDisplayName $} {$ doc.displayName $}
-  </h2>
+<div class="hc-tile">
+    <h3 class="docs-header-link docs-api-h3">
+        Module Import
+    </h3>
 
-  <p class="docs-api-module-import">
-    <code>
-      import {{$ doc.ngModule.name $}} from '{$ doc.moduleImportPath $}';
-    </code>
-  </p>
+    <p class="docs-api-module-import">
+        <code>
+            import {{$ doc.ngModule.name $}} from '{$ doc.moduleImportPath $}';
+        </code>
+    </p>
+</div>
 
-  {%- if doc.services.length -%}
+{%- if doc.services.length -%}
+<div class="hc-tile">
     <h3 id="services" class="docs-header-link docs-api-h3">
-      <span header-link="services"></span>
-      Services
+        <span header-link="services"></span>
+        Services
     </h3>
     {% for service in doc.services %}
-      {$ class(service) $}
+        {$ class(service) $}
     {% endfor %}
-  {%- endif -%}
+</div>
+{%- endif -%}
 
-
-  {%- if doc.directives.length -%}
+{%- if doc.directives.length -%}
+<div class="hc-tile">
     <h3 id="directives" class="docs-header-link docs-api-h3">
-      <span header-link="directives"></span>
-      Directives
+        <span header-link="directives"></span>
+        Directives
     </h3>
     {% for directive in doc.directives %}
-      {$ class(directive) $}
+        {$ class(directive) $}
     {% endfor %}
-  {%- endif -%}
+</div>
+{%- endif -%}
 
-  {%- if doc.additionalClasses.length -%}
+{%- if doc.additionalClasses.length -%}
+<div class="hc-tile">
     <h3 id="additional_classes" class="docs-header-link docs-api-h3">
-      <span header-link="additional_classes"></span>
-      Additional classes
+        <span header-link="additional_classes"></span>
+        Additional classes
     </h3>
     {% for other in doc.additionalClasses %}
-      {$ class(other) $}
+        {$ class(other) $}
     {% endfor %}
-  {%- endif -%}
+</div>
+{%- endif -%}
 
-  {%- if doc.additionalInterfaces.length -%}
+{%- if doc.additionalInterfaces.length -%}
+<div class="hc-tile">
     <h3 id="additional_interfaces" class="docs-header-link docs-api-h3">
-      <span header-link="additional_interfaces"></span>
-      Additional interfaces
+        <span header-link="additional_interfaces"></span>
+        Additional interfaces
     </h3>
     {% for item in doc.additionalInterfaces %}
-      {$ interface(item) $}
+        {$ interface(item) $}
     {% endfor %}
-  {%- endif -%}
 </div>
+{%- endif -%}
+

--- a/tools/dgeni/templates/method-list.template.html
+++ b/tools/dgeni/templates/method-list.template.html
@@ -25,4 +25,5 @@
   {% for m in methodList %}
     {$ method(m) $}
   {% endfor %}
+  <div class="directive-spacer"></div>
 {%- endif -%}


### PR DESCRIPTION
Updates to the style of the dgeni templates following [the prototype](https://xd.adobe.com/view/7a081799-3095-46c2-b22b-3b9f6393eb1d/screen/9f562696-4bae-4b0f-9b89-fd07a33fe5b4/Components-API) that was vetted with the community.

Styling the dgeni docs was actually really nice, they give unique classes to just about everything, so I was happy how smoothly that went.  @corykon - I'd love to have your eye on my changes and see if there's anything you'd do differently from a design perspective.  

A few next steps for us to look at if you guys are good with this update:

1. **Style Resets** - There is something weird since we did this dgeni update going on with the css when you go between "Styles" or "Guides" and "Components".  It's almost like the css gets reset or overridden now when you go back to "Styles" after visiting "Components".  Could use some help debugging that.
2. **Examples** - I've got the Examples section roughed in, but there is still some work to be done there.  For one, the tabs at the top of the tile don't display an active state.  And I need to do some cleanup on all the demo html now that they are in that format.  But @jtrujill mentioned that we might split them up, so I figured we should talk that through first.
3.  **Usage** - we had also talked about adding a third tab to the components where we could store markdown, and I believe that was on your radar, Jeremy.  So let me know what you think about how we can attack that.