### PR TITLE
fix(hc-form-field): fixes input element overflow

### DIFF
--- a/projects/cashmere/src/lib/input/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/input/hc-form-field.component.scss
@@ -58,8 +58,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     display: block;
     position: relative;
     flex: auto;
-    min-width: 0;
-    width: $mat-form-field-default-infix-width;
+    min-width: $mat-form-field-default-infix-width;
 
     padding: $infix-padding 10px;
 }


### PR DESCRIPTION
sets a minimum width for input element and removes the explicit width

fix #363