### PR TITLE
docs(cashmere-examples): moved styles for cashmere examples to css files

### DIFF
--- a/projects/cashmere-examples/src/lib/accordion-overview/accordion-overview-example.css
+++ b/projects/cashmere-examples/src/lib/accordion-overview/accordion-overview-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/accordion-overview/accordion-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/accordion-overview/accordion-overview-example.ts
@@ -6,7 +6,8 @@ import {Component} from '@angular/core';
 
 @Component({
     selector: 'accordion-overview-example',
-    templateUrl: 'accordion-overview-example.html'
+    templateUrl: 'accordion-overview-example.html',
+    styleUrls: ['accordion-overview-example.css']
 })
 export class AccordionOverviewExample {
     alignment = 'left';

--- a/projects/cashmere-examples/src/lib/button-disabled/button-disabled-example.css
+++ b/projects/cashmere-examples/src/lib/button-disabled/button-disabled-example.css
@@ -1,0 +1,3 @@
+button {
+    margin: 10px;
+}

--- a/projects/cashmere-examples/src/lib/button-disabled/button-disabled-example.ts
+++ b/projects/cashmere-examples/src/lib/button-disabled/button-disabled-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'button-disabled-example',
     templateUrl: 'button-disabled-example.html',
-    styles: ['button { margin: 10px; }']
+    styleUrls: ['button-disabled-example.css']
 })
 export class ButtonDisabledExample {}

--- a/projects/cashmere-examples/src/lib/button-icon/button-icon-example.css
+++ b/projects/cashmere-examples/src/lib/button-icon/button-icon-example.css
@@ -1,0 +1,11 @@
+button {
+    margin: 10px;
+}
+
+.icon-left {
+    margin-right: 5px;
+}
+
+.icon-right {
+    margin-left: 5px;
+}

--- a/projects/cashmere-examples/src/lib/button-icon/button-icon-example.ts
+++ b/projects/cashmere-examples/src/lib/button-icon/button-icon-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'button-icon-example',
     templateUrl: 'button-icon-example.html',
-    styles: ['button { margin: 10px; }', '.icon-left { margin-right: 5px; }', '.icon-right { margin-left: 5px; }']
+    styleUrls: ['button-icon-example.css']
 })
 export class ButtonIconExample {}

--- a/projects/cashmere-examples/src/lib/button-primary/button-primary-example.css
+++ b/projects/cashmere-examples/src/lib/button-primary/button-primary-example.css
@@ -1,0 +1,3 @@
+button {
+    margin: 10px;
+}

--- a/projects/cashmere-examples/src/lib/button-primary/button-primary-example.ts
+++ b/projects/cashmere-examples/src/lib/button-primary/button-primary-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'button-primary-example',
     templateUrl: 'button-primary-example.html',
-    styles: ['button { margin: 10px; }']
+    styleUrls: ['button-primary-example.css']
 })
 export class ButtonPrimaryExample {}

--- a/projects/cashmere-examples/src/lib/button-secondary/button-secondary-example.css
+++ b/projects/cashmere-examples/src/lib/button-secondary/button-secondary-example.css
@@ -1,0 +1,3 @@
+button {
+    margin: 10px;
+}

--- a/projects/cashmere-examples/src/lib/button-secondary/button-secondary-example.ts
+++ b/projects/cashmere-examples/src/lib/button-secondary/button-secondary-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'button-secondary-example',
     templateUrl: 'button-secondary-example.html',
-    styles: ['button { margin: 10px; }']
+    styleUrls: ['button-secondary-example.css']
 })
 export class ButtonSecondaryExample {}

--- a/projects/cashmere-examples/src/lib/button-split/button-split-example.css
+++ b/projects/cashmere-examples/src/lib/button-split/button-split-example.css
@@ -1,0 +1,3 @@
+hc-split-button {
+    margin: 10px;
+}

--- a/projects/cashmere-examples/src/lib/button-split/button-split-example.ts
+++ b/projects/cashmere-examples/src/lib/button-split/button-split-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'button-split-example',
     templateUrl: 'button-split-example.html',
-    styles: ['hc-split-button { margin: 10px; }']
+    styleUrls: ['button-split-example.css']
 })
 export class ButtonSplitExample {}

--- a/projects/cashmere-examples/src/lib/button-tertiary/button-tertiary-example.css
+++ b/projects/cashmere-examples/src/lib/button-tertiary/button-tertiary-example.css
@@ -1,0 +1,3 @@
+button {
+    margin: 10px;
+}

--- a/projects/cashmere-examples/src/lib/button-tertiary/button-tertiary-example.ts
+++ b/projects/cashmere-examples/src/lib/button-tertiary/button-tertiary-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'button-tertiary-example',
     templateUrl: 'button-tertiary-example.html',
-    styles: ['button { margin: 10px; }']
+    styleUrls: ['button-tertiary-example.css']
 })
 export class ButtonTertiaryExample {}

--- a/projects/cashmere-examples/src/lib/checkbox-disabled/checkbox-disabled-example.css
+++ b/projects/cashmere-examples/src/lib/checkbox-disabled/checkbox-disabled-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/checkbox-disabled/checkbox-disabled-example.ts
+++ b/projects/cashmere-examples/src/lib/checkbox-disabled/checkbox-disabled-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'checkbox-disabled-example',
-    templateUrl: 'checkbox-disabled-example.html'
+    templateUrl: 'checkbox-disabled-example.html',
+    styleUrls: ['checkbox-disabled-example.css']
 })
 export class CheckboxDisabledExample {}

--- a/projects/cashmere-examples/src/lib/checkbox-forms/checkbox-forms-example.css
+++ b/projects/cashmere-examples/src/lib/checkbox-forms/checkbox-forms-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/checkbox-forms/checkbox-forms-example.ts
+++ b/projects/cashmere-examples/src/lib/checkbox-forms/checkbox-forms-example.ts
@@ -5,7 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'checkbox-forms-example',
-    templateUrl: 'checkbox-forms-example.html'
+    templateUrl: 'checkbox-forms-example.html',
+    styleUrls: ['checkbox-forms-example.css']
 })
 export class CheckboxFormsExample {
     isChecked: boolean;

--- a/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.css
+++ b/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.ts
+++ b/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'checkbox-standard-example',
-    templateUrl: 'checkbox-standard-example.html'
+    templateUrl: 'checkbox-standard-example.html',
+    styleUrls: ['checkbox-standard-example.css']
 })
 export class CheckboxStandardExample {}

--- a/projects/cashmere-examples/src/lib/chip-action/chip-action-example.css
+++ b/projects/cashmere-examples/src/lib/chip-action/chip-action-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/chip-action/chip-action-example.ts
+++ b/projects/cashmere-examples/src/lib/chip-action/chip-action-example.ts
@@ -5,7 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'chip-action-example',
-    templateUrl: 'chip-action-example.html'
+    templateUrl: 'chip-action-example.html',
+    styleUrls: ['chip-action-example.css']
 })
 export class ChipActionExample {
     hideChip(event: any) {

--- a/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.css
+++ b/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.ts
+++ b/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'chip-basic-example',
-    templateUrl: 'chip-basic-example.html'
+    templateUrl: 'chip-basic-example.html',
+    styleUrls: ['chip-basic-example.css']
 })
 export class ChipBasicExample {}

--- a/projects/cashmere-examples/src/lib/chip-row/chip-row-example.css
+++ b/projects/cashmere-examples/src/lib/chip-row/chip-row-example.css
@@ -1,0 +1,3 @@
+.chip-row-wrapper {
+    display: flex;
+}

--- a/projects/cashmere-examples/src/lib/chip-row/chip-row-example.ts
+++ b/projects/cashmere-examples/src/lib/chip-row/chip-row-example.ts
@@ -6,7 +6,7 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'chip-row-example',
     templateUrl: 'chip-row-example.html',
-    styles: ['.chip-row-wrapper { display: flex; }']
+    styleUrls: ['chip-row-example.css']
 })
 export class ChipRowExample {
     hideChip(event: any) {

--- a/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.css
+++ b/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.css
@@ -1,0 +1,3 @@
+.chip-row-wrapper {
+    display: flex;
+}

--- a/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.ts
+++ b/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.ts
@@ -6,7 +6,7 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'chip-singlerow-example',
     templateUrl: 'chip-singlerow-example.html',
-    styles: ['.chip-row-wrapper { display: flex; }']
+    styleUrls: ['chip-singlerow-example.css']
 })
 export class ChipSinglerowExample {
     hideChip(event: any) {

--- a/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.css
+++ b/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.css
@@ -1,0 +1,4 @@
+.hc-drawer {
+    background-color: #6e6f71;
+    color: #b9babb;
+}

--- a/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.ts
+++ b/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'drawer-basic-example',
     templateUrl: 'drawer-basic-example.html',
-    styles: ['.hc-drawer { background-color: #6e6f71; color: #b9babb;}']
+    styleUrls: ['drawer-basic-example.css']
 })
 export class DrawerBasicExample {}

--- a/projects/cashmere-examples/src/lib/drawer-overlay/drawer-overlay-example.css
+++ b/projects/cashmere-examples/src/lib/drawer-overlay/drawer-overlay-example.css
@@ -1,0 +1,4 @@
+.hc-drawer {
+    background-color: #6e6f71;
+    color: #b9babb;
+}

--- a/projects/cashmere-examples/src/lib/drawer-overlay/drawer-overlay-example.ts
+++ b/projects/cashmere-examples/src/lib/drawer-overlay/drawer-overlay-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'drawer-overlay-example',
     templateUrl: 'drawer-overlay-example.html',
-    styles: ['.hc-drawer { background-color: #6e6f71; color: #b9babb;}']
+    styleUrls: ['drawer-overlay-example.css']
 })
 export class DrawerOverlayExample {}

--- a/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.css
+++ b/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.css
@@ -1,0 +1,4 @@
+.hc-drawer {
+    background-color: #6e6f71;
+    color: #b9babb;
+}

--- a/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.ts
+++ b/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'drawer-side-example',
     templateUrl: 'drawer-side-example.html',
-    styles: ['.hc-drawer { background-color: #6e6f71; color: #b9babb;}']
+    styleUrls: ['drawer-side-example.css']
 })
 export class DrawerSideExample {}

--- a/projects/cashmere-examples/src/lib/input-disabled/input-disabled-example.css
+++ b/projects/cashmere-examples/src/lib/input-disabled/input-disabled-example.css
@@ -1,0 +1,7 @@
+.form-container {
+    width: 300px;
+}
+
+.hc-form-field {
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/input-disabled/input-disabled-example.ts
+++ b/projects/cashmere-examples/src/lib/input-disabled/input-disabled-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'input-disabled-example',
     templateUrl: 'input-disabled-example.html',
-    styles: ['.form-container { width: 300px; }', '.hc-form-field { width: 100%; }']
+    styleUrls: ['input-disabled-example.css']
 })
 export class InputDisabledExample {}

--- a/projects/cashmere-examples/src/lib/input-prefix/input-prefix-example.css
+++ b/projects/cashmere-examples/src/lib/input-prefix/input-prefix-example.css
@@ -1,0 +1,7 @@
+.form-container {
+    width: 300px;
+}
+
+.hc-form-field {
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/input-prefix/input-prefix-example.ts
+++ b/projects/cashmere-examples/src/lib/input-prefix/input-prefix-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'input-prefix-example',
     templateUrl: 'input-prefix-example.html',
-    styles: ['.form-container { width: 300px; }', '.hc-form-field { width: 100%; }']
+    styleUrls: ['input-prefix-example.css']
 })
 export class InputPrefixExample {}

--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.css
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.css
@@ -1,0 +1,7 @@
+.form-container {
+    width: 300px;
+}
+
+.hc-form-field {
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.ts
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.ts
@@ -7,7 +7,7 @@ import {FormControl, Validators} from '@angular/forms';
 @Component({
     selector: 'input-required-example',
     templateUrl: 'input-required-example.html',
-    styles: ['.form-container { width: 300px; }', '.hc-form-field { width: 100%; }']
+    styleUrls: ['input-required-example.css']
 })
 export class InputRequiredExample {
     formDemo = new FormControl('', Validators.required);

--- a/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.css
+++ b/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.css
@@ -1,0 +1,7 @@
+.form-container {
+    width: 300px;
+}
+
+.hc-form-field {
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.ts
+++ b/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'input-suffix-example',
     templateUrl: 'input-suffix-example.html',
-    styles: ['.form-container { width: 300px; }', '.hc-form-field { width: 100%; }']
+    styleUrls: ['input-suffix-example.css']
 })
 export class InputSuffixExample {}

--- a/projects/cashmere-examples/src/lib/list-overview/list-overview-example.css
+++ b/projects/cashmere-examples/src/lib/list-overview/list-overview-example.css
@@ -1,0 +1,7 @@
+.hc-list-avatar {
+    background-color: aliceblue;
+}
+
+h4 {
+    margin: 0 !important;
+}

--- a/projects/cashmere-examples/src/lib/list-overview/list-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/list-overview/list-overview-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'list-overview-example',
     templateUrl: 'list-overview-example.html',
-    styles: ['.hc-list-avatar { background-color: aliceblue; }', 'h4 { margin: 0 !important; }']
+    styleUrls: ['list-overview-example.css']
 })
 export class ListOverviewExample {}

--- a/projects/cashmere-examples/src/lib/modal-overview/modal-overview-example.css
+++ b/projects/cashmere-examples/src/lib/modal-overview/modal-overview-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/modal-overview/modal-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/modal-overview/modal-overview-example.ts
@@ -8,7 +8,8 @@ import {Component, TemplateRef} from '@angular/core';
  */
 @Component({
     selector: 'modal-overview-example',
-    templateUrl: 'modal-overview-example.html'
+    templateUrl: 'modal-overview-example.html',
+    styleUrls: ['modal-overview-example.css']
 })
 export class ModalOverviewExample {
     result: any;

--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.css
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'navbar-overview-example',
-    templateUrl: 'navbar-overview-example.html'
+    templateUrl: 'navbar-overview-example.html',
+    styleUrls: ['navbar-overview-example.css']
 })
 export class NavbarOverviewExample {}

--- a/projects/cashmere-examples/src/lib/pagination-overview/pagination-overview-example.css
+++ b/projects/cashmere-examples/src/lib/pagination-overview/pagination-overview-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/pagination-overview/pagination-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/pagination-overview/pagination-overview-example.ts
@@ -5,7 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'pagination-overview-example',
-    templateUrl: 'pagination-overview-example.html'
+    templateUrl: 'pagination-overview-example.html',
+    styleUrls: ['pagination-overview-example.css']
 })
 export class PaginationOverviewExample {
     totalPages = 16;

--- a/projects/cashmere-examples/src/lib/picklist-simple/picklist-simple-example.css
+++ b/projects/cashmere-examples/src/lib/picklist-simple/picklist-simple-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/picklist-simple/picklist-simple-example.ts
+++ b/projects/cashmere-examples/src/lib/picklist-simple/picklist-simple-example.ts
@@ -5,7 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'picklist-simple-example',
-    templateUrl: 'picklist-simple-example.html'
+    templateUrl: 'picklist-simple-example.html',
+    styleUrls: ['picklist-simple-example.css']
 })
 export class PicklistSimpleExample {
     public mySimpleModel: string[];

--- a/projects/cashmere-examples/src/lib/picklist-valueset/picklist-valueset-example.css
+++ b/projects/cashmere-examples/src/lib/picklist-valueset/picklist-valueset-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/picklist-valueset/picklist-valueset-example.ts
+++ b/projects/cashmere-examples/src/lib/picklist-valueset/picklist-valueset-example.ts
@@ -5,7 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'picklist-valueset-example',
-    templateUrl: 'picklist-valueset-example.html'
+    templateUrl: 'picklist-valueset-example.html',
+    styleUrls: ['picklist-valueset-example.css']
 })
 export class PicklistValuesetExample {
     public myModel: {values: null; valueset: null};

--- a/projects/cashmere-examples/src/lib/popover-dynamic/popover-dynamic-example.css
+++ b/projects/cashmere-examples/src/lib/popover-dynamic/popover-dynamic-example.css
@@ -1,0 +1,4 @@
+button {
+    vertical-align: baseline;
+    margin-left: 20px;
+}

--- a/projects/cashmere-examples/src/lib/popover-dynamic/popover-dynamic-example.ts
+++ b/projects/cashmere-examples/src/lib/popover-dynamic/popover-dynamic-example.ts
@@ -6,7 +6,7 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'popover-dynamic-example',
     templateUrl: 'popover-dynamic-example.html',
-    styles: ['button { vertical-align: baseline; margin-left: 20px; }']
+    styleUrls: ['popover-dynamic-example.css']
 })
 export class PopoverDynamicExample {
     body: string = 'dynamic content';

--- a/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.css
+++ b/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.css
@@ -1,0 +1,3 @@
+.icon-right {
+    margin-left: 5px;
+}

--- a/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'popover-overview-example',
     templateUrl: 'popover-overview-example.html',
-    styles: ['.icon-right { margin-left: 5px; }']
+    styleUrls: ['popover-overview-example.css']
 })
 export class PopoverOverviewExample {}

--- a/projects/cashmere-examples/src/lib/popover-placement/popover-placement-example.css
+++ b/projects/cashmere-examples/src/lib/popover-placement/popover-placement-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/popover-placement/popover-placement-example.ts
+++ b/projects/cashmere-examples/src/lib/popover-placement/popover-placement-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'popover-placement-example',
-    templateUrl: 'popover-placement-example.html'
+    templateUrl: 'popover-placement-example.html',
+    styleUrls: ['popover-placement-example.css']
 })
 export class PopoverPlacementExample {}

--- a/projects/cashmere-examples/src/lib/progress-dots/progress-dots-example.css
+++ b/projects/cashmere-examples/src/lib/progress-dots/progress-dots-example.css
@@ -1,0 +1,27 @@
+.progress-example {
+    display: flex;
+    margin-top: 20px;
+}
+
+.col-2 {
+    flex: 1 0 auto;
+    margin-left: 20px;
+}
+
+.progress-component-container {
+    height: 100%;
+    width: 100%;
+    position: relative;
+    padding: 15px;
+    border: 1px solid #e5e5e5;
+}
+
+.progress-component-container.dark-bg {
+    background-color: #384655;
+}
+
+label,
+hc-checkbox {
+    margin: 20px 0 5px;
+    display: block;
+}

--- a/projects/cashmere-examples/src/lib/progress-dots/progress-dots-example.ts
+++ b/projects/cashmere-examples/src/lib/progress-dots/progress-dots-example.ts
@@ -6,13 +6,7 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'progress-dots-example',
     templateUrl: 'progress-dots-example.html',
-    styles: [
-        `.progress-example { display: flex; margin-top: 20px; }
-        .col-2 { flex: 1 0 auto; margin-left: 20px; }
-        .progress-component-container { height: 100%; width: 100%; position: relative; padding: 15px; border: 1px solid #e5e5e5; }
-        .progress-component-container.dark-bg { background-color: #384655; }
-        label, hc-checkbox { margin: 20px 0 5px; display: block; }`
-    ]
+    styleUrls: ['progress-dots-example.css']
 })
 export class ProgressDotsExample {
     dotsColor = 'dark';

--- a/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.css
+++ b/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.css
@@ -1,0 +1,27 @@
+.progress-example {
+    display: flex;
+    margin-top: 20px;
+}
+
+.col-2 {
+    flex: 1 0 auto;
+    margin-left: 20px;
+}
+
+.progress-component-container {
+    height: 100%;
+    width: 100%;
+    position: relative;
+    padding: 15px;
+    border: 1px solid #e5e5e5;
+}
+
+.progress-component-container.dark-bg {
+    background-color: #384655;
+}
+
+label,
+hc-checkbox {
+    margin: 20px 0 5px;
+    display: block;
+}

--- a/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.ts
+++ b/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.ts
@@ -6,13 +6,7 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'progress-spinner-example',
     templateUrl: 'progress-spinner-example.html',
-    styles: [
-        `.progress-example { display: flex; margin-top: 20px; }
-        .col-2 { flex: 1 0 auto; margin-left: 20px; }
-        .progress-component-container { height: 100%; width: 100%; position: relative; padding: 15px; border: 1px solid #e5e5e5; }
-        .progress-component-container.dark-bg { background-color: #384655; }
-        label, hc-checkbox { margin: 20px 0 5px; display: block; }`
-    ]
+    styleUrls: ['progress-spinner-example.css']
 })
 export class ProgressSpinnerExample {
     spinnerIsDeterminate = false;

--- a/projects/cashmere-examples/src/lib/radio-button-disabled/radio-button-disabled-example.css
+++ b/projects/cashmere-examples/src/lib/radio-button-disabled/radio-button-disabled-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/radio-button-disabled/radio-button-disabled-example.ts
+++ b/projects/cashmere-examples/src/lib/radio-button-disabled/radio-button-disabled-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'radio-button-disabled-example',
-    templateUrl: 'radio-button-disabled-example.html'
+    templateUrl: 'radio-button-disabled-example.html',
+    styleUrls: ['radio-button-disabled-example.css']
 })
 export class RadioButtonDisabledExample {}

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.css
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.ts
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.ts
@@ -5,7 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'radio-button-forms-example',
-    templateUrl: 'radio-button-forms-example.html'
+    templateUrl: 'radio-button-forms-example.html',
+    styleUrls: ['radio-button-forms-example.css']
 })
 export class RadioButtonFormsExample {
     favoriteShow: string | null = 'Silicon Valley';

--- a/projects/cashmere-examples/src/lib/radio-button-standard/radio-button-standard-example.css
+++ b/projects/cashmere-examples/src/lib/radio-button-standard/radio-button-standard-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/radio-button-standard/radio-button-standard-example.ts
+++ b/projects/cashmere-examples/src/lib/radio-button-standard/radio-button-standard-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'radio-button-standard-example',
-    templateUrl: 'radio-button-standard-example.html'
+    templateUrl: 'radio-button-standard-example.html',
+    styleUrls: ['radio-button-standard-example.css']
 })
 export class RadioButtonStandardExample {}

--- a/projects/cashmere-examples/src/lib/select-disabled/select-disabled-example.css
+++ b/projects/cashmere-examples/src/lib/select-disabled/select-disabled-example.css
@@ -1,0 +1,4 @@
+select-sample {
+    max-width: 350px;
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/select-disabled/select-disabled-example.ts
+++ b/projects/cashmere-examples/src/lib/select-disabled/select-disabled-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'select-disabled-example',
     templateUrl: 'select-disabled-example.html',
-    styles: ['select-sample { max-width: 350px; width: 100%; }']
+    styleUrls: ['select-disabled-example.css']
 })
 export class SelectDisabledExample {}

--- a/projects/cashmere-examples/src/lib/select-standard/select-standard-example.css
+++ b/projects/cashmere-examples/src/lib/select-standard/select-standard-example.css
@@ -1,0 +1,4 @@
+select-sample {
+    max-width: 350px;
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/select-standard/select-standard-example.ts
+++ b/projects/cashmere-examples/src/lib/select-standard/select-standard-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'select-standard-example',
     templateUrl: 'select-standard-example.html',
-    styles: ['select-sample { max-width: 350px; width: 100%; }']
+    styleUrls: ['select-standard-example.css']
 })
 export class SelectStandardExample {}

--- a/projects/cashmere-examples/src/lib/select-validation/select-validation-example.css
+++ b/projects/cashmere-examples/src/lib/select-validation/select-validation-example.css
@@ -1,0 +1,4 @@
+select-sample {
+    max-width: 350px;
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/select-validation/select-validation-example.ts
+++ b/projects/cashmere-examples/src/lib/select-validation/select-validation-example.ts
@@ -7,7 +7,7 @@ import {FormControl} from '@angular/forms';
 @Component({
     selector: 'select-validation-example',
     templateUrl: 'select-validation-example.html',
-    styles: ['select-sample { max-width: 350px; width: 100%; }']
+    styleUrls: ['select-validation-example.css']
 })
 export class SelectValidationExample {
     private validCheck = false;

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.css
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.css
@@ -1,0 +1,7 @@
+.tab-content {
+    padding: 15px;
+}
+
+.tab-demo {
+    border: 1px solid #e0e0e0;
+}

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'tabs-horizontal-example',
     templateUrl: 'tabs-horizontal-example.html',
-    styles: ['.tab-content { padding: 15px; }', '.tab-demo { border: 1px solid #e0e0e0; }']
+    styleUrls: ['tabs-horizontal-example.css']
 })
 export class TabsHorizontalExample {}

--- a/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.css
+++ b/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.css
@@ -1,0 +1,7 @@
+.tab-content {
+    padding: 15px;
+}
+
+.tab-demo {
+    border: 1px solid #e0e0e0;
+}

--- a/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.ts
+++ b/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.ts
@@ -6,6 +6,6 @@ import {Component} from '@angular/core';
 @Component({
     selector: 'tabs-vertical-example',
     templateUrl: 'tabs-vertical-example.html',
-    styles: ['.tab-content { padding: 15px; }', '.tab-demo { border: 1px solid #e0e0e0; }']
+    styleUrls: ['tabs-vertical-example.css']
 })
 export class TabsVerticalExample {}

--- a/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.css
+++ b/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.ts
@@ -5,6 +5,7 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'tile-overview-example',
-    templateUrl: 'tile-overview-example.html'
+    templateUrl: 'tile-overview-example.html',
+    styleUrls: ['tile-overview-example.css']
 })
 export class TileOverviewExample {}

--- a/projects/cashmere-examples/src/lib/typeform-survey-overview/typeform-survey-overview-example.css
+++ b/projects/cashmere-examples/src/lib/typeform-survey-overview/typeform-survey-overview-example.css
@@ -1,0 +1,1 @@
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/typeform-survey-overview/typeform-survey-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/typeform-survey-overview/typeform-survey-overview-example.ts
@@ -5,7 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
     selector: 'typeform-survey-overview-example',
-    templateUrl: 'typeform-survey-overview-example.html'
+    templateUrl: 'typeform-survey-overview-example.html',
+    styleUrls: ['typeform-survey-overview-example.css']
 })
 export class TypeformSurveyOverviewExample {
     surveyUri = 'https://healthcatalyst.typeform.com/to/bGDyIK?productname=Fabric.Cashmere';

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
@@ -1,7 +1,7 @@
 <div class="hc-tile">
-    <h3 class="docs-api-h3" >{{exampleTitle}}</h3>
+    <h3 class="docs-api-h3">{{exampleTitle}}</h3>
     <hc-tab-set direction="horizontal">
-        <hc-tab [tabTitle]="ext" *ngFor="let ext of ['Example', 'HTML', 'Typescript']">
+        <hc-tab [tabTitle]="ext" *ngFor="let ext of ['Example', 'HTML', 'Typescript', 'CSS']">
 
             <div class="example-buffer" *ngIf="ext == 'Example'"></div>
 


### PR DESCRIPTION
users can now view css for a cashmere example on a separate page rather than it being embedded in
the typescript

close #372