### PR TITLE
fix(colors): fix mispelled color

### DIFF
--- a/projects/cashmere/src/lib/sass/_colors.scss
+++ b/projects/cashmere/src/lib/sass/_colors.scss
@@ -35,7 +35,7 @@ $red-orange: #f05323;
 $pink: #ef4767;
 $light-pink: #f8c8db;
 $brown: #553e36;
-$magneta: #a94c9d;
+$magenta: #a94c9d;
 $purple-gray: #776c7f;
 $azure: #007bff;
 $teal: #00acac;

--- a/projects/cashmere/src/lib/sass/_typography.scss
+++ b/projects/cashmere/src/lib/sass/_typography.scss
@@ -56,7 +56,7 @@ p,
 
 // for inline code
 code {
-    color: $magneta;
+    color: $magenta;
     font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
     background-color: $block-text-background;
     border-radius: 3px;

--- a/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
@@ -74,7 +74,7 @@
 
 .docs-api-method-table {
     th {
-        color: $magneta;
+        color: $magenta;
         font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
         padding-top: 20px;
     }

--- a/src/app/styles/code/code-demo.component.html
+++ b/src/app/styles/code/code-demo.component.html
@@ -30,7 +30,7 @@
                 <td>
                     <ul>
                         <li><span class="type-label">Weight</span>400</li>
-                        <li><span class="type-label">Color</span>$magneta</li>
+                        <li><span class="type-label">Color</span>$magenta</li>
                     </ul>
                 </td>
             </tr>

--- a/src/app/styles/color/color-demo.component.html
+++ b/src/app/styles/color/color-demo.component.html
@@ -58,7 +58,7 @@
             <hc-swatch-demo-component hex="#951c1e" name="ruby-red"></hc-swatch-demo-component>
             <hc-swatch-demo-component hex="#cc2027" name="deep-red"></hc-swatch-demo-component>
             <hc-swatch-demo-component hex="#f05323" name="red-orange"></hc-swatch-demo-component>
-            <hc-swatch-demo-component hex="#a94c9d" name="magneta"></hc-swatch-demo-component>
+            <hc-swatch-demo-component hex="#a94c9d" name="magenta"></hc-swatch-demo-component>
             <hc-swatch-demo-component hex="#ef4767" name="pink"></hc-swatch-demo-component>
             <hc-swatch-demo-component hex="#f8c8db" name="light-pink"></hc-swatch-demo-component>
         </div>


### PR DESCRIPTION
Just a typo, "magneta" isn't a color :)

BREAKING CHANGE: If using $magneta anywhere... you'll need to change to magenta