### PR TITLE
fix(navbar): removed app switcher from component example

### DIFF
--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.html
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.html
@@ -1,5 +1,4 @@
 <hc-navbar appIcon="./assets/CashmereAppLogo.svg" brandIcon="./assets/TriFlame.svg" user="Christine K." [homeUri]="undefined" [fixedTop]="false">
-    <hc-app-switcher></hc-app-switcher>
     <hc-navbar-link [active]="true" uri="undefined" linkText="Home"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Oncology"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Surgery"></hc-navbar-link>


### PR DESCRIPTION
Including the app switcher in the example made it fail because the app switcher needs to be provided. I was thinking of getting a non app switcher navbar out for now and eventually getting another example with it later