### PR TITLE
ci(guide-copy-assets.js): fix copying of assets for gh pages

### DIFF
--- a/scripts/guide-copy-assets.js
+++ b/scripts/guide-copy-assets.js
@@ -1,13 +1,16 @@
 const fs = require('fs-extra');
 const path = require('path');
 
+const sourceDir = '../dist/docs/';
+const destDir = process.env.TRAVIS ? '../dist/user-guide/assets/docs/' : '../src/assets/docs/';
+
 // Copy api documentation into UserGuide assets/
-fs.copySync(getAbsolutePath('../dist/docs/api'), getAbsolutePath('../src/assets/docs/api'));
+fs.copySync(getAbsolutePath(sourceDir + 'api'), getAbsolutePath(destDir + 'api'));
 
 // Copy examples source files(ts, css, html)
-fs.copySync(getAbsolutePath('../dist/docs/examples'), getAbsolutePath('../src/assets/docs/examples'));
+fs.copySync(getAbsolutePath(sourceDir + 'examples'), getAbsolutePath(destDir + 'examples'));
 
-fs.copySync(getAbsolutePath('../dist/docs/usage'), getAbsolutePath('../src/assets/docs/usage'));
+fs.copySync(getAbsolutePath(sourceDir + 'usage'), getAbsolutePath(destDir + 'usage'));
 
 function getAbsolutePath(relativePath) {
     return path.resolve(path.join(__dirname, relativePath));


### PR DESCRIPTION
copying of assets checks to see if TRAVIS environment variable is set to determine where assets need
to be copyied