### PR TITLE
fix(select.component): select inherits font instead of using system font

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 package.json
 package-lock.json
+cashmere-example.module.ts
 CHANGELOG.md
 /coverage
 dist/

--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -36,6 +36,8 @@
 }
 
 .hc-select-input {
+    // Font needs to be inherited, because by default <select> uses a system font
+    font: inherit;
     color: $text;
     background-color: $white;
     @include fontSize(14px);


### PR DESCRIPTION
fix #266