### PR TITLE
docs(css): webkit th text alignment

### DIFF
--- a/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
@@ -52,6 +52,7 @@
 
 .docs-api-properties-header-row th {
     padding-bottom: 8px;
+    text-align: left;
 }
 
 .docs-api-properties-name-cell {
@@ -77,6 +78,7 @@
         color: $magenta;
         font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
         padding-top: 20px;
+        text-align: left;
     }
 
     td {


### PR DESCRIPTION
corrects `<th>` elements from being centered in webkit browsers

closes #429