### PR TITLE
fix(radio): remove circular dependency

### DIFF
--- a/projects/cashmere/src/lib/radio-button/index.ts
+++ b/projects/cashmere/src/lib/radio-button/index.ts
@@ -1,3 +1,3 @@
-export {RadioButtonComponent} from './radio-button.component';
+export {RadioButtonComponent, RadioButtonChangeEvent} from './radio-button.component';
 export {RadioButtonModule} from './radio-button.module';
 export {RadioGroupDirective} from './radio-group.directive';

--- a/projects/cashmere/src/lib/radio-button/radio-button.component.ts
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.ts
@@ -15,12 +15,12 @@ import {parseBooleanAttribute} from '../util';
 
 let nextUniqueId = 0;
 
- /** Event type that is emitted when a radio button or radio button group changes */
+/** Event type that is emitted when a radio button or radio button group changes */
 export class RadioButtonChangeEvent {
     /**
-    * @param source the radio button that fired the event
-    * @param value the value of that radio button
-    */
+     * @param source the radio button that fired the event
+     * @param value the value of that radio button
+     */
     constructor(public source: RadioButtonComponent | null, public value: any) {}
 }
 

--- a/projects/cashmere/src/lib/radio-button/radio-button.component.ts
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.ts
@@ -11,12 +11,16 @@ import {
     Optional,
     Output
 } from '@angular/core';
-import {RadioGroupDirective} from './radio-group.directive';
 import {parseBooleanAttribute} from '../util';
 
 let nextUniqueId = 0;
 
+ /** Event type that is emitted when a radio button or radio button group changes */
 export class RadioButtonChangeEvent {
+    /**
+    * @param source the radio button that fired the event
+    * @param value the value of that radio button
+    */
     constructor(public source: RadioButtonComponent | null, public value: any) {}
 }
 
@@ -39,7 +43,6 @@ export class RadioButtonComponent implements OnInit {
     private _value: any = null;
     private _required: boolean = false;
     private _disabled: boolean = false;
-    private readonly radioGroup: RadioGroupDirective;
 
     /** Value of radio buttons */
     @Input()
@@ -50,11 +53,6 @@ export class RadioButtonComponent implements OnInit {
     set value(value: any) {
         if (this._value !== value) {
             this._value = value;
-            if (this.radioGroup !== null && !this.checked) {
-                this.checked = this.radioGroup.value === value;
-            } else if (this.radioGroup !== null && this.checked) {
-                this.radioGroup.selected = this;
-            }
         }
     }
 
@@ -66,7 +64,7 @@ export class RadioButtonComponent implements OnInit {
     /** Boolean value of whether the radio button is required */
     @Input()
     get required(): boolean {
-        return this._required || (this.radioGroup && this.radioGroup.required);
+        return this._required;
     }
 
     set required(required) {
@@ -76,7 +74,7 @@ export class RadioButtonComponent implements OnInit {
     /** Boolean value that enables/disables the radio button */
     @Input()
     get disabled(): boolean {
-        return this._disabled || (this.radioGroup && this.radioGroup.disabled);
+        return this._disabled;
     }
 
     set disabled(isDisabled) {
@@ -93,11 +91,6 @@ export class RadioButtonComponent implements OnInit {
         let newCheckedState = parseBooleanAttribute(value);
         if (this._checked !== newCheckedState) {
             this._checked = newCheckedState;
-            if (newCheckedState && this.radioGroup && this.radioGroup.value !== this.value) {
-                this.radioGroup.selected = this;
-            } else if (!newCheckedState && this.radioGroup && this.radioGroup.value === this.value) {
-                this.radioGroup.selected = null;
-            }
             this.cdRef.markForCheck();
         }
     }
@@ -109,21 +102,9 @@ export class RadioButtonComponent implements OnInit {
         return `${this._uniqueId}-input`;
     }
 
-    constructor(
-        @Optional()
-        @Inject(forwardRef(() => RadioGroupDirective))
-        radioGroup: RadioGroupDirective,
-        private cdRef: ChangeDetectorRef
-    ) {
-        this.radioGroup = radioGroup;
-    }
+    constructor(private cdRef: ChangeDetectorRef) {}
 
-    ngOnInit() {
-        if (this.radioGroup !== null) {
-            this.checked = this.radioGroup.value === this._value;
-            this.name = this.radioGroup.name;
-        }
-    }
+    ngOnInit() {}
 
     _onInputClick(event: Event) {
         event.stopPropagation();
@@ -131,16 +112,8 @@ export class RadioButtonComponent implements OnInit {
 
     _onInputChange(event: Event) {
         event.stopPropagation();
-        const valueChanged = this.radioGroup && this.value !== this.radioGroup.value;
         this.checked = true;
         this._emitChangeEvent();
-        if (this.radioGroup !== null) {
-            this.radioGroup._onChangeFn(this.value);
-            this.radioGroup._touch();
-            if (valueChanged) {
-                this.radioGroup._emitChangeEvent();
-            }
-        }
     }
 
     private _emitChangeEvent(): void {

--- a/projects/cashmere/src/lib/radio-button/radio-group.directive.ts
+++ b/projects/cashmere/src/lib/radio-button/radio-group.directive.ts
@@ -33,7 +33,8 @@ let nextUniqueId = 0;
 export class RadioGroupDirective implements ControlValueAccessor, AfterContentInit, OnChanges, OnDestroy {
     /** Event emitted when the value of a radio button changes inside the group. */
     @Output() change: EventEmitter<RadioButtonChangeEvent> = new EventEmitter<RadioButtonChangeEvent>();
-    @ContentChildren(RadioButtonComponent, {descendants: true}) _radios: QueryList<RadioButtonComponent>;
+    @ContentChildren(RadioButtonComponent, {descendants: true})
+    _radios: QueryList<RadioButtonComponent>;
 
     private _value: any = null;
     private _name = `hc-radio-group-${nextUniqueId++}`;


### PR DESCRIPTION
Removed radio-group attributes from radio-button. The group now subscribes to events emitted by the individual buttons.  All the tests pass and the examples work, but I'd feel better if those of you with engineering skills greater than mine could check my work.

closes #237