### PR TITLE
fix(input): disabled state css

### DIFF
--- a/projects/cashmere/src/lib/input/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/input/hc-form-field.component.scss
@@ -118,7 +118,16 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 .hc-form-field-disabled {
-    cursor: not-allowed;
+    .hc-form-field-flex {
+        cursor: not-allowed;
+        border: 1.5px solid $gray-200;
+        background-color: $slate-gray-100;
+        color: tint($text, 60%);
+    }
+
+    .hc-input {
+        cursor: not-allowed;
+    }
 }
 
 .hc-required-marker {


### PR DESCRIPTION
Adds styling to make the input's disabled state more obvious.  Matches the disabled state of the select component.