### PR TITLE
fix(tabs): remove multiline

### DIFF
--- a/projects/cashmere/src/lib/sass/_tabs.scss
+++ b/projects/cashmere/src/lib/sass/_tabs.scss
@@ -47,6 +47,10 @@
     border-bottom: 1px solid $slate-gray-300;
 }
 
+.hc-tab-width {
+    min-width: 0;
+}
+
 .hc-tab-horizontal {
     background-color: inherit;
     color: $offblack;

--- a/projects/cashmere/src/lib/tabs/tab-set.component.html
+++ b/projects/cashmere/src/lib/tabs/tab-set.component.html
@@ -1,13 +1,13 @@
 <div class="hc-{{direction}}-tab-container">
     <div class="hc-tab-bar-{{direction}}">
-        <div *ngFor="let tab of _tabs">
-            <a *ngIf="_routerEnabled" class="hc-tab-{{direction}}"
+        <div *ngFor="let tab of _tabs" class="hc-tab-width">
+            <a *ngIf="_routerEnabled" class="hc-tab-{{direction}} hc-text-ellipsis"
                [routerLink]="tab.routerLink"
                routerLinkActive="active"
                (click)="_setActive(tab)">
                 {{tab.tabTitle}}
             </a>
-            <a *ngIf="!_routerEnabled" class="hc-tab-{{direction}}"
+            <a *ngIf="!_routerEnabled" class="hc-tab-{{direction}} hc-text-ellipsis"
                [class.active]="tab._active"
                (click)="_setActive(tab)">
                 {{tab.tabTitle}}


### PR DESCRIPTION
Removes text wrap from tab titles and truncates if the title is too long for the space (thanks for the `hc-text-ellipsis` class, @corykon) .  I agree with @jtrujill that for layout purposes, the tabs shouldn't go multi-line.  Obviously for the best UX, tabs shouldn't normally be truncated, but this gives a way for them to compress elegantly when screen real estate is limited.  See example:

<img width="840" alt="screen shot 2018-08-10 at 6 49 00 pm" src="https://user-images.githubusercontent.com/22795893/43986590-65e20bdc-9cd0-11e8-986a-1cdc6e67dfb0.png">

closes #257