### PR TITLE
docs(naming): adds naming convention guide

### DIFF
--- a/guides/naming-conventions.md
+++ b/guides/naming-conventions.md
@@ -1,0 +1,54 @@
+# Source Code Naming Conventions
+
+###### Last updated August 22, 2018
+
+:::
+
+##### Overview
+
+For the highest degree of consistency across the library, the naming conventions below should be followed when creating new components or classes. This will reduce the effort needed to read and understand code from multiple contributors to the library.
+:::
+
+:::
+
+##### CSS Classes
+
+The following general format should be followed when naming classes:
+
+`{company-scope}-{block-modifier}-{element}`
+
+*   {company scope} scopes all of our css to our company
+*   {block modifier} is an element that can standalone within our company scope
+*   {element} is element that can't standalone and requires the block modifier
+
+&nbsp;
+
+Example class name: `.hc-form-field-label-wrapper`
+
+*   **company-scope**: hc
+*   **block-modifier**: form-field (component name)
+*   **element**: label-wrapper (css put on element within the component)
+
+:::
+
+:::
+
+##### Angular Components
+
+Components typically have a one word name following generally accepted descriptions of the item you are creating. If you're looking for examples of how similar elements are named, [Google's Material Design](https://material.io/develop/web/) system is a good baseline. If multiple words are needed in the name, they should be separated by a hyphen ("-") in their filename.
+
+Class names should be written as follows:
+
+`{component-name}-{component-type}`
+
+*   **component-name**: Same as the file name; upper camel case should be used for component definitions with multiple words ("RadioButton")
+*   **component-type**: "Component", "Directive", etc
+
+&nbsp;
+
+Below is an example of component naming following the above rules:
+
+*   Filename: `app-switcher.component.ts`
+*   Class name: `AppSwitcherComponent`
+
+:::

--- a/src/app/guides/guides.service.ts
+++ b/src/app/guides/guides.service.ts
@@ -25,6 +25,11 @@ export class GuidesService {
             document: require('raw-loader!../../../guides/help-menu.md')
         },
         {
+            title: 'Naming Conventions',
+            route: 'naming-conventions',
+            document: require('raw-loader!../../../guides/naming-conventions.md')
+        },
+        {
             title: 'Submit an Issue',
             route: 'submit-an-issue',
             document: require('raw-loader!../../../guides/submit-an-issue.md')


### PR DESCRIPTION
I'm just the scribe on this one.  Turned the conversation from the thread into a markdown file for our naming conventions guide.  Let me know if any of the content is unclear or needs to change.

@jtrujill - I know you said you are opposed to the "Component" or "Directive" in the component names.  I still included it in this guide because that's how everything is currently named in the library, so I don't want to create confusion.  Seems like that change should be submitted as an issue to wholesale remove those labels from the components in the library.  And then if we do that we can change the guide to match.

closes #411