### PR TITLE
fix(modal): access to ActiveModal.data now allowed in constructor

### DIFF
--- a/projects/cashmere/src/lib/modal/modal-options.ts
+++ b/projects/cashmere/src/lib/modal/modal-options.ts
@@ -1,14 +1,14 @@
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
-export class ModalOptions {
+export interface ModalOptions {
     /** size of the modal window. Defaults to medium */
-    public size: ModalSize = 'md';
+    size: ModalSize;
     /** Optional. Specify data that will be available on the active modal context */
-    public data?: any;
+    data?: any;
     /** Optional. Specify a different HTML element to append the modal overlay and modal window.
      * If not specified the modal elements will be added to the body */
-    public container?: HTMLElement;
+    container?: HTMLElement;
     /** Defaults to false. Set to true to disable the closure of a modal by clicking on the overlay. */
-    public ignoreOverlayClick?: boolean;
+    ignoreOverlayClick?: boolean;
     /** Defaults to false. Set to true to disable the closure of a modal by pressing the escape key. */
-    public ignoreEscapeKey?: boolean;
+    ignoreEscapeKey?: boolean;
 }

--- a/projects/cashmere/src/lib/modal/modal.service.ts
+++ b/projects/cashmere/src/lib/modal/modal.service.ts
@@ -7,13 +7,12 @@ import {
     ComponentRef,
     Injectable,
     Injector,
-    ReflectiveInjector,
     Renderer2,
     RendererFactory2,
     TemplateRef,
     Type
 } from '@angular/core';
-import {ModalOptions} from './modal-options';
+import {ModalOptions, ModalSize} from './modal-options';
 import {ActiveModal} from './active-modal';
 
 export type ModalContentType = Type<{}> | TemplateRef<any>;
@@ -25,89 +24,95 @@ export class ModalService {
     private _renderer: Renderer2;
 
     constructor(
-        private componentFactoryResolver: ComponentFactoryResolver,
-        private injector: Injector,
-        private applicationRef: ApplicationRef,
-        rendererFactory: RendererFactory2
+        private _componentFactory: ComponentFactoryResolver,
+        private _injector: Injector,
+        private _applicationRef: ApplicationRef,
+        _rendererFactory: RendererFactory2
     ) {
-        this._renderer = rendererFactory.createRenderer(null, null);
+        this._renderer = _rendererFactory.createRenderer(null, null);
     }
 
     /** Opens a new modal either from a Component or a TemplateRef with the options specified in ModalOptions
      * In order to use a component, it must be specified in your module's EntryComponents.
      */
-    public open<T>(modalContent: ModalContentType, modalOptions?: ModalOptions): HcModal<T> {
-        let container: HTMLElement | null = document.querySelector('body');
-        if (modalOptions) {
-            if (modalOptions.container) {
-                container = modalOptions.container;
-            }
+    open<T>(modalContent: ModalContentType, modalOptions?: ModalOptions): HcModal<T> {
+        let container = document.querySelector('body') as HTMLElement;
+
+        const defaultOptions = {
+            container,
+            data: {},
+            ignoreEscapeKey: false,
+            size: 'md',
+            ignoreOverlayClick: false
+        };
+        const options = {...defaultOptions, ...modalOptions};
+        if (options.container) {
+            container = options.container;
         }
 
-        let hcModal = new HcModal<T>();
-        let activeModalContext = new ActiveModal();
-        const modalContextInjector = ReflectiveInjector.resolveAndCreate(
-            [{provide: ActiveModal, useValue: activeModalContext}],
-            this.injector
-        );
-        if (container) {
-            // disable scrolling when overlay is present
-            this._renderer.addClass(container, 'hc-modal-open');
-            hcModal._removeOpenClass = () => this._renderer.removeClass(container, 'hc-modal-open');
-
-            // Create, attach, and append overlay to container
-            let overlay = this.componentFactoryResolver.resolveComponentFactory(ModalOverlayComponent).create(modalContextInjector);
-            this._renderer.setStyle(overlay.location.nativeElement, 'z-index', this._zIndexCounter);
-            if (modalOptions) {
-                overlay.instance._ignoreEscapeKey = modalOptions.ignoreEscapeKey || false;
-            }
-            this.applicationRef.attachView(overlay.hostView);
-            container.appendChild(overlay.location.nativeElement);
-            hcModal.overlay = overlay;
-
-            // Create and attach content views; prepare nodes to be
-            // transcluded with the window ComponentRef
-            let projectableNodes;
-            if (modalContent instanceof TemplateRef) {
-                const embeddedViewRef = modalContent.createEmbeddedView(activeModalContext);
-                this.applicationRef.attachView(embeddedViewRef);
-                projectableNodes = [embeddedViewRef.rootNodes];
-            } else {
-                const componentRef = this.componentFactoryResolver.resolveComponentFactory(modalContent).create(modalContextInjector);
-
-                // Set host component style to 100% to allow collapsing of body but not header/footer
-                this._renderer.addClass(componentRef.location.nativeElement, 'hc-modal-center-component');
-                this.applicationRef.attachView(componentRef.hostView);
-                hcModal.componentRef = <ComponentRef<T>>componentRef;
-                projectableNodes = [[componentRef.location.nativeElement]];
-            }
-
-            // Create, attach, and append Window to container
-            // Apply options
-            let window = this.componentFactoryResolver
-                .resolveComponentFactory(ModalWindowComponent)
-                .create(modalContextInjector, projectableNodes);
-            this._renderer.setStyle(window.location.nativeElement, 'z-index', this._zIndexCounter + 1);
-            if (modalOptions) {
-                window.instance._size = modalOptions.size;
-                window.instance._ignoreOverlayClick = modalOptions.ignoreOverlayClick || false;
-                if (modalOptions.data) {
-                    hcModal.data = modalOptions.data;
-                    activeModalContext.data = modalOptions.data;
-                }
-            }
-
-            this.applicationRef.attachView(window.hostView);
-            container.appendChild(window.location.nativeElement);
-            hcModal.window = window;
+        if (!container) {
+            throw new Error('Modal requires that a container be set in the modal options');
         }
-        activeModalContext.close = (result: any) => {
-            hcModal.close(result);
+
+        // TODO: HcModal and ActiveModal essentially are the same object with HcModal having refs. Might as well merge them to simplify
+        let modal = new HcModal<T>();
+        let activeModalRef = new ActiveModal();
+        modal.data = options.data;
+        activeModalRef.data = options.data;
+
+        const modalInjector = Injector.create({
+            providers: [{provide: ActiveModal, useValue: activeModalRef}],
+            parent: this._injector
+        });
+
+        // disable scrolling when overlay is present
+        this._renderer.addClass(container, 'hc-modal-open');
+        modal._removeOpenClass = () => this._renderer.removeClass(container, 'hc-modal-open');
+
+        // Create, attach, and append overlay to container
+        let overlay = this._componentFactory.resolveComponentFactory(ModalOverlayComponent).create(modalInjector);
+        this._renderer.setStyle(overlay.location.nativeElement, 'z-index', this._zIndexCounter);
+        overlay.instance._ignoreEscapeKey = options.ignoreEscapeKey;
+
+        this._applicationRef.attachView(overlay.hostView);
+        container.appendChild(overlay.location.nativeElement);
+        modal.overlay = overlay;
+
+        // Create and attach content views; prepare nodes to be
+        // transcluded with the window ComponentRef
+        let projectableNodes;
+        if (modalContent instanceof TemplateRef) {
+            const embeddedViewRef = modalContent.createEmbeddedView(activeModalRef);
+            this._applicationRef.attachView(embeddedViewRef);
+            projectableNodes = [embeddedViewRef.rootNodes];
+        } else {
+            const componentRef = this._componentFactory.resolveComponentFactory(modalContent).create(modalInjector);
+
+            // Set host component style to 100% to allow collapsing of body but not header/footer
+            this._renderer.addClass(componentRef.location.nativeElement, 'hc-modal-center-component');
+            this._applicationRef.attachView(componentRef.hostView);
+            modal.componentRef = <ComponentRef<T>>componentRef;
+            projectableNodes = [[componentRef.location.nativeElement]];
+        }
+
+        // Create, attach, and append Window to container
+        // Apply options
+        let window = this._componentFactory.resolveComponentFactory(ModalWindowComponent).create(modalInjector, projectableNodes);
+        this._renderer.setStyle(window.location.nativeElement, 'z-index', this._zIndexCounter + 1);
+        window.instance._size = options.size as ModalSize;
+        window.instance._ignoreOverlayClick = options.ignoreOverlayClick;
+
+        this._applicationRef.attachView(window.hostView);
+        container.appendChild(window.location.nativeElement);
+        modal.window = window;
+
+        activeModalRef.close = (result: any) => {
+            modal.close(result);
         };
 
-        activeModalContext.dismiss = () => hcModal.dismiss();
+        activeModalRef.dismiss = () => modal.dismiss();
 
         this._zIndexCounter += 2;
-        return hcModal;
+        return modal;
     }
 }


### PR DESCRIPTION
sets ActiveModal.data earlier so that when a modal component instance is created it's available in
the constructor. Replaced deprecated ReflectiveInjector with Injector.create. ModalOptions is now
an interface since it wasn't being used as a class anywhere.

fixes #476