### PR TITLE
Set accordion currentlyAnimating prior to emitting

### DIFF
--- a/projects/cashmere/src/lib/accordion/accordion.component.ts
+++ b/projects/cashmere/src/lib/accordion/accordion.component.ts
@@ -114,14 +114,14 @@ export class AccordionComponent implements AfterContentInit {
     }
 
     _animationEnd(event: AnimationEvent): void {
+        this._currentlyAnimating = false;
+
         const {fromState, toState} = event;
         if (fromState === 'void' && toState === 'open') {
             this.opened.emit();
         } else if (fromState === 'open' && toState === 'void') {
             this.closed.emit();
         }
-
-        this._currentlyAnimating = false;
     }
 
     @HostBinding('class.hc-accordion-opened')


### PR DESCRIPTION
Simple change so that when we check the isOpened and isClosed getters in an emitted opened or closed event, they return true.