### PR TITLE
fix(input): highlight on invalid

### DIFF
--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.html
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.html
@@ -1,7 +1,10 @@
-<div class="form-container">
-    <hc-form-field>
-        <hc-label>Validate an email address</hc-label>
-        <input hcInput [formControl]="formDemo" required>
-        <hc-error>Email address is required</hc-error>
-    </hc-form-field>
-</div>
+<form>
+    <div class="form-container">
+        <hc-form-field>
+            <hc-label>Validate an email address</hc-label>
+            <input hcInput [formControl]="formDemo" required>
+            <hc-error>A valid email address is required</hc-error>
+        </hc-form-field>
+    </div>
+    <button hc-button title="Submit Form" buttonStyle="primary" type="submit">Submit</button>
+</form>

--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.ts
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.ts
@@ -10,5 +10,5 @@ import {FormControl, Validators} from '@angular/forms';
     styleUrls: ['input-required-example.css']
 })
 export class InputRequiredExample {
-    formDemo = new FormControl('', Validators.required);
+    formDemo = new FormControl('', [Validators.email, Validators.required]);
 }

--- a/projects/cashmere/src/lib/input/hc-form-field.component.html
+++ b/projects/cashmere/src/lib/input/hc-form-field.component.html
@@ -8,7 +8,7 @@
 
                 </label>
             </span>
-    <div class="hc-form-field-flex">
+    <div [ngClass]="{ 'hc-form-field-flex': true, 'hc-form-field-invalid': _shouldShowErrorMessages() }">
         <div class="hc-form-field-prefix" *ngIf="_prefixChildren.length">
             <ng-content select="[hcPrefix]"></ng-content>
         </div>

--- a/projects/cashmere/src/lib/input/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/input/hc-form-field.component.scss
@@ -41,6 +41,10 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     background: $white;
 }
 
+.hc-form-field-invalid {
+    border: 1.5px solid $error;
+}
+
 .hc-form-field-prefix,
 .hc-form-field-suffix {
     white-space: nowrap;
@@ -104,7 +108,6 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 .hc-form-field-error-wrapper {
-    position: absolute;
     box-sizing: border-box;
     width: 100%;
     overflow: hidden;
@@ -127,5 +130,5 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 .hc-required-marker {
-    color: $red;
+    color: $error;
 }


### PR DESCRIPTION
Highlight in $error red an input field that is invalid.  Also adds the ability to demonstrate this functionality in the required input example.

closes #497