### PR TITLE
fix(radio button): radio group orientation

### DIFF
--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.css
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.css
@@ -1,1 +1,11 @@
-/* No CSS rules defined for this example */
+.example-group {
+    display: flex;
+    align-items: center;
+    margin-bottom: 25px;
+    margin-top: 30px;
+}
+
+.group-label {
+    padding-right: 15px;
+    font-weight: 600;
+}

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.html
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.html
@@ -1,6 +1,10 @@
-<hc-radio-group [(ngModel)]="favoriteShow">
-    <hc-radio-button *ngFor="let show of shows" [value]="show">{{show}}</hc-radio-button>
-</hc-radio-group>
+<div class="example-group">
+    <span class="group-label">Select your favorite:</span>
+    <hc-radio-group vertical="false" [(ngModel)]="favoriteShow">
+        <hc-radio-button *ngFor="let show of shows" [value]="show">{{show}}</hc-radio-button>
+    </hc-radio-group>
+</div>
+
 <p>Current selection: {{favoriteShow ? favoriteShow : 'none'}}</p>
 <button hc-button title="Primary-Alt Button" buttonStyle="primary-alt" (click)="reset()">
     Clear Selection

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.ts
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 
 /**
- * @title Radio Buttons using Form Controls
+ * @title Horizontal Radio Buttons using Form Controls
  */
 @Component({
     selector: 'radio-button-forms-example',

--- a/projects/cashmere/src/lib/radio-button/radio-button.component.scss
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.scss
@@ -4,7 +4,7 @@
     display: block;
     position: relative;
     padding-left: 35px;
-    margin-bottom: 12px;
+    margin-bottom: 18px;
     cursor: pointer;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -39,6 +39,7 @@
         border: 2px solid $gray-300;
         background-color: $white;
         border-radius: 50%;
+        margin-top: -4px;
     }
 
     .hc-radio-overlay:after {
@@ -51,10 +52,6 @@
         content: '';
         position: absolute;
         display: none;
-    }
-
-    .hc-radio-content {
-        padding-top: 3px;
     }
 
     &.disabled {

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -35,6 +35,9 @@ let nextUniqueId = 0;
     exportAs: 'hcRadioGroup'
 })
 export class RadioGroupDirective implements ControlValueAccessor, AfterContentInit {
+    @HostBinding('class.hc-radio-group-vertical') _verticalClass: boolean = true;
+    @HostBinding('class.hc-radio-group-horizontal') _horizontalClass: boolean = false;
+
     /** Event emitted when the value of a radio button changes inside the group. */
     @Output() change: EventEmitter<RadioButtonChangeEvent> = new EventEmitter<RadioButtonChangeEvent>();
     @ContentChildren(forwardRef(() => RadioButtonComponent), {descendants: true})
@@ -43,6 +46,7 @@ export class RadioGroupDirective implements ControlValueAccessor, AfterContentIn
     private _name = `hc-radio-group-${nextUniqueId++}`;
     private _disabled = false;
     private _required = false;
+    private _vertical = true;
     private _initialized = false; // if value of radio group has been set to initial value
     private _selected: RadioButtonComponent | null = null; // the currently selected radio
     _onChangeFn: (value: any) => void = () => {};
@@ -104,6 +108,18 @@ export class RadioGroupDirective implements ControlValueAccessor, AfterContentIn
         this._selected = button;
         this.value = button ? button.value : null;
         this._checkSelectedRadio();
+    }
+
+    /** Sets the orientation of the radio button group; defaults to true */
+    @Input()
+    get vertical(): boolean {
+        return this._vertical;
+    }
+
+    set vertical(value) {
+        this._vertical = parseBooleanAttribute(value);
+        this._verticalClass = this._vertical;
+        this._horizontalClass = !this._vertical;
     }
 
     constructor(private _cdRef: ChangeDetectorRef) {}

--- a/projects/cashmere/src/lib/sass/_radio-group.scss
+++ b/projects/cashmere/src/lib/sass/_radio-group.scss
@@ -1,0 +1,16 @@
+.hc-radio-group-vertical {
+    display: flex;
+    flex-direction: column;
+}
+
+.hc-radio-group-horizontal {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    .hc-radio-container {
+        padding-left: 32px !important;
+        margin-bottom: 0px !important;
+        margin-right: 25px;
+    }
+}

--- a/projects/cashmere/src/lib/sass/cashmere.scss
+++ b/projects/cashmere/src/lib/sass/cashmere.scss
@@ -12,6 +12,7 @@
 @import './modals';
 @import './progress-spinner';
 @import './progress-dots';
+@import './radio-group';
 @import './subnav';
 @import './tables';
 @import './tabs';


### PR DESCRIPTION
Fixes the the margin/padding css on radio buttons so that the button circle is centered around the text - rather than the other way around.  The top and bottom of the circle should now extend equal amounts above and below the text.  Also added support for horizontal as well as vertical button groups via a boolean `vertical` input added to the radio group selector.  Updated the last example on the radio button page to illustrate a horizontal button group.

closes #452