### PR TITLE
style(label): remove style collision

### DIFF
--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.css
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.css
@@ -1,11 +1,3 @@
 form {
     max-width: 350px;
 }
-
-button {
-    margin: 5px;
-}
-
-.action-wrapper:first-child {
-    margin-left: 0;
-}

--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.html
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.html
@@ -6,12 +6,10 @@
     </hc-select>
 </form>
 
-<div class="action-wrapper">
-    <button hc-button (click)="setTaters()">
-        Yummy Taters
-    </button>
+<button hc-button class="demo-button" (click)="setTaters()">
+    Yummy Taters
+</button>
 
-    <button hc-button (click)="toggleActive()">
-        Enable/Disable Select
-    </button>
-</div>
+<button hc-button class="demo-button" (click)="toggleActive()">
+    Enable/Disable Select
+</button>

--- a/projects/cashmere/src/lib/input/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/input/hc-form-field.component.scss
@@ -5,7 +5,7 @@ $mat-form-field-default-infix-width: 120px;
 $line-height: 1.5;
 $label-font-scale: 1;
 $error-font-scale: 0.75;
-$infix-margin-top: 1em * $line-height * $label-font-scale;
+$infix-margin-top: 1.143em * $line-height * $label-font-scale;
 $prefix-suffix-icon-font-size: 125%;
 
 $infix-padding: 0.393em;
@@ -93,7 +93,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
     font: inherit;
     font-size: calculateRem(14px);
-    color: rgba(0, 0, 0, 0.6);
+    color: $gray-500;
     pointer-events: none; // We shouldn't catch mouse events (let them through).
 
     width: 100%;

--- a/projects/cashmere/src/lib/label/label.component.scss
+++ b/projects/cashmere/src/lib/label/label.component.scss
@@ -2,15 +2,15 @@
 @import '../sass/functions.scss';
 @import '../sass/mixins.scss';
 
-.hc-label {
+.hc-label-text {
     display: block;
     color: $gray-500;
-    @include fontSize(15px);
-    margin-bottom: 8px;
+    @include fontSize(14px);
+    margin-bottom: 7px;
 }
 
 .label-required:after {
     content: '*';
     margin-left: 5px;
-    color: $red;
+    color: $error;
 }

--- a/projects/cashmere/src/lib/label/label.component.ts
+++ b/projects/cashmere/src/lib/label/label.component.ts
@@ -12,7 +12,7 @@ import {parseBooleanAttribute} from '../util';
     encapsulation: ViewEncapsulation.None
 })
 export class LabelComponent {
-    @HostBinding('class.hc-label') hostClass = true;
+    @HostBinding('class.hc-label-text') hostClass = true;
 
     _required: boolean = false;
 

--- a/projects/cashmere/src/lib/sass/_typography.scss
+++ b/projects/cashmere/src/lib/sass/_typography.scss
@@ -171,9 +171,8 @@ em,
 // error text
 .form-errors {
     margin-top: 8px;
-    color: $red;
-    font-weight: 600;
-    @include fontSize(12px);
+    color: $error;
+    font-size: 75%;
 }
 
 // Articles

--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -8,7 +8,7 @@
 
     &.ng-invalid {
         .hc-select-input {
-            border: 2px solid $red;
+            border: 1.5px solid $error;
         }
     }
 }


### PR DESCRIPTION
Mostly a temporary fix until hc-label is deprecated and hc-select can use hc-form-field.  But this ensures that they don't have css styles colliding, and it brings the colors, font sizes, etc in line with each other.

closes #507