### PR TITLE
style(select): firefox focus

### DIFF
--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -15,6 +15,19 @@
 
 .hc-select-container {
     position: relative;
+
+    //Firefox specific CSS to correct highlight on focus that does not cover the entire select box
+    select:-moz-focusring {
+        color: transparent;
+        text-shadow: 0 0 0 #000;
+    }
+
+    @-moz-document url-prefix() {
+        select:focus {
+            outline: $gray-500 dotted 1px;
+            outline-offset: -3px;
+        }
+    }
 }
 
 .hc-select-chevron {
@@ -50,6 +63,7 @@
     width: 100%;
     -webkit-appearance: none;
     -moz-appearance: none;
+    line-height: normal;
     cursor: pointer;
 
     &::-ms-expand {


### PR DESCRIPTION
@corykon - ended up writing a little bit of Firefox specific CSS to get around that focus highlight issue where the dotted line wasn't covering the whole box.  Basically that's just the way Firefox handles their bounding box - it doesn't include padding.  So I'm hiding Firefox's highlight, and adding a dotted line styled the same way within :focus to still follow the overall browser style - but cover the whole box.

I also added `line-height: normal;` to correct the issue where the bottom of text was still getting cropped on Mac Chrome.

closes #506, #478