### PR TITLE
fix(button): import cashmere colors/fns to the mixins file

### DIFF
--- a/projects/cashmere/src/lib/button/button.component.scss
+++ b/projects/cashmere/src/lib/button/button.component.scss
@@ -1,5 +1,3 @@
-@import '../sass/colors';
-@import '../sass/functions.scss';
 @import '../sass/button.scss';
 
 .hc-button {

--- a/projects/cashmere/src/lib/sass/button.scss
+++ b/projects/cashmere/src/lib/sass/button.scss
@@ -1,3 +1,6 @@
+@import '../sass/colors';
+@import '../sass/functions.scss';
+
 $btn-icon-sz: 18px;
 
 /// Sets up colors for a button


### PR DESCRIPTION
Cashmere colors and functions were being imported to the component scss file instead of the mixins
file where they were used. This was a bug and it was my bad. It is now fixed.