### PR TITLE
style(app-switcher): thumbnail sizing

### DIFF
--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.html
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.html
@@ -15,7 +15,7 @@
         <div class="apps">
             <div class="app" *ngFor="let app of applications">
                 <a class="thumbnail" title="{{app.Description}}" href="{{app.ServiceUrl}}" target="_blank">
-                    <img class="popover-icon img-responsive" src={{app.Icon}}>
+                    <div class="thumbnail-img" style="background-image: url('{{app.Icon}}')"></div>
                     <div class="title">{{app?.FriendlyName | ellipsis:18}}</div>
                 </a>
             </div>

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.scss
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.scss
@@ -36,8 +36,12 @@
                 padding: 10px;
                 text-decoration: none;
 
-                & > img {
+                & > .thumbnail-img {
                     width: 100px;
+                    height: 100px;
+                    background-size: contain;
+                    background-repeat: no-repeat;
+                    background-position: 50%, 50%;
                 }
             }
 
@@ -46,6 +50,7 @@
                 color: $offblack;
                 padding-top: 8px;
                 font-weight: 600;
+                width: 100px;
             }
         }
     }

--- a/projects/cashmere/src/lib/navbar/navbar.component.scss
+++ b/projects/cashmere/src/lib/navbar/navbar.component.scss
@@ -78,6 +78,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         }
         display: flex;
         align-items: center;
+        justify-content: center;
         height: 100%;
     }
 


### PR DESCRIPTION
app switcher thumbnails are now proportionally constrained in 100px box.  Switched from an `<img>` to a `<div>` with a background-img.  This takes advantage of CSS' ability to proportionally resize an image within our bounding box so it won't be stretched.

closes #503