### PR TITLE
Tab Event Handling

### DIFF
--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.css
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.css
@@ -5,3 +5,7 @@
 .tab-demo {
     border: 1px solid #e0e0e0;
 }
+
+.selection-text {
+    margin-left: 40px;
+}

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
@@ -1,5 +1,5 @@
 <div class="tab-demo">
-    <hc-tab-set direction="horizontal" (selectChange)="selectionChanged($event)" #tabSet>
+    <hc-tab-set direction="horizontal" (selectedTabChange)="selectionChanged($event)" #tabSet>
         <hc-tab tabTitle='Pending Tasks'>
             <div class="tab-content">
                 This is where pending tasks would go.

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
@@ -1,5 +1,5 @@
 <div class="tab-demo">
-    <hc-tab-set direction="horizontal" (selectChange)="selectionChanged($event)">
+    <hc-tab-set direction="horizontal" (selectChange)="selectionChanged($event)" #tabSet>
         <hc-tab tabTitle='Pending Tasks'>
             <div class="tab-content">
                 This is where pending tasks would go.
@@ -24,4 +24,7 @@
     </hc-tab-set>
 </div>
 <br>
-Currently Selected Tab Index: {{selectedIndex}}
+<button hc-button title="Set Selection" buttonStyle="primary" (click)="tabSet.selectTabByIndex(1)">
+    Select Complete Tasks
+</button>
+<span class="selection-text">Currently Selected Tab Index: {{selectedIndex}}</span>

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
@@ -21,10 +21,18 @@
                 Incomplete tasks belong here.
             </div>
         </hc-tab>
+        <hc-tab (tabClick)="addTask($event)">
+            <hc-tab-title>
+                <span style="color: #00aeff; font-weight: 600;"><i class="fa fa-plus"></i> Add Task</span>
+            </hc-tab-title>
+            <div class="tab-content">
+                This is an example of a click handler on a tab.
+            </div>
+        </hc-tab>
     </hc-tab-set>
 </div>
 <br>
-<button hc-button title="Set Selection" buttonStyle="primary" (click)="tabSet.selectTabByIndex(1)">
+<button hc-button title="Set Selection" buttonStyle="primary" (click)="tabSet.selectTab(1)">
     Select Complete Tasks
 </button>
 <span class="selection-text">Currently Selected Tab Index: {{selectedIndex}}</span>

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.html
@@ -1,5 +1,5 @@
 <div class="tab-demo">
-    <hc-tab-set direction="horizontal">
+    <hc-tab-set direction="horizontal" (selectChange)="selectionChanged($event)">
         <hc-tab tabTitle='Pending Tasks'>
             <div class="tab-content">
                 This is where pending tasks would go.
@@ -23,3 +23,5 @@
         </hc-tab>
     </hc-tab-set>
 </div>
+<br>
+Currently Selected Tab Index: {{selectedIndex}}

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import { TabChangeEvent } from '@healthcatalyst/cashmere';
+import {TabChangeEvent} from '@healthcatalyst/cashmere';
 
 /**
  * @title Horizontal Tabs with Event Handling

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
@@ -15,4 +15,8 @@ export class TabsHorizontalExample {
     selectionChanged(event: TabChangeEvent) {
         this.selectedIndex = event.index;
     }
+
+    addTask(event: Event) {
+        window.alert('The "Add Task" tab was clicked.');
+    }
 }

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.ts
@@ -1,11 +1,18 @@
 import {Component} from '@angular/core';
+import { TabChangeEvent } from '@healthcatalyst/cashmere';
 
 /**
- * @title Horizontal Tabs
+ * @title Horizontal Tabs with Event Handling
  */
 @Component({
     selector: 'tabs-horizontal-example',
     templateUrl: 'tabs-horizontal-example.html',
     styleUrls: ['tabs-horizontal-example.css']
 })
-export class TabsHorizontalExample {}
+export class TabsHorizontalExample {
+    selectedIndex: number = 0;
+
+    selectionChanged(event: TabChangeEvent) {
+        this.selectedIndex = event.index;
+    }
+}

--- a/projects/cashmere/src/lib/tabs/index.ts
+++ b/projects/cashmere/src/lib/tabs/index.ts
@@ -1,4 +1,4 @@
 export {TabComponent} from './tab.component';
-export {TabSetComponent} from './tab-set.component';
+export {TabSetComponent, TabChangeEvent} from './tab-set.component';
 export {HcTabTitleComponent} from './tab-title.component';
 export {TabsModule} from './tabs.module';

--- a/projects/cashmere/src/lib/tabs/tab-set.component.html
+++ b/projects/cashmere/src/lib/tabs/tab-set.component.html
@@ -4,13 +4,13 @@
             <a *ngIf="_routerEnabled" class="hc-tab-{{direction}} hc-text-ellipsis"
                [routerLink]="tab.routerLink"
                routerLinkActive="active"
-               (click)="_setActive(tab)">
+               (click)="_setActive(tab, $event)">
                 <ng-container *ngIf="tab._htmlTitle" [ngTemplateOutlet]="tab._htmlTitle.tabTitle"></ng-container>
                 {{tab.tabTitle}}
             </a>
             <a *ngIf="!_routerEnabled" class="hc-tab-{{direction}} hc-text-ellipsis"
                [class.active]="tab._active"
-               (click)="_setActive(tab)">
+               (click)="_setActive(tab, $event)">
                 <ng-container *ngIf="tab._htmlTitle" [ngTemplateOutlet]="tab._htmlTitle.tabTitle"></ng-container>
                 {{tab.tabTitle}}
             </a>

--- a/projects/cashmere/src/lib/tabs/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set.component.ts
@@ -64,12 +64,29 @@ export class TabSetComponent implements AfterContentInit {
         });
     }
 
+    /** Sets the currently selected tab by its numerical index  */
+    selectTabByIndex(index: number) {
+        let i: number = 0;
+
+        this._tabs.forEach(t => {
+            if (i === index) {
+                this._setActive(t);
+            }
+            i++;
+        });
+    }
+
+    /** Sets the currently selected tab by its `TabComponent` object  */
+    selectTabByObject(tab: TabComponent) {
+        this._setActive(tab);
+    }
+
     _setActive(tab: TabComponent) {
         let selectedTab: number = 0;
         let index: number = 0;
 
         this._tabs.forEach(t => {
-            if( t === tab) {
+            if (t === tab) {
                 selectedTab = index;
             }
             t._active = false;

--- a/projects/cashmere/src/lib/tabs/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set.component.ts
@@ -64,24 +64,23 @@ export class TabSetComponent implements AfterContentInit {
         });
     }
 
-    /** Sets the currently selected tab by its numerical index  */
-    selectTabByIndex(index: number) {
-        let i: number = 0;
+    /** Sets the currently selected tab by either its numerical index or `TabComponent` object  */
+    selectTab(tab: number | TabComponent) {
+        if (typeof tab === 'number') {
+            let i: number = 0;
 
-        this._tabs.forEach(t => {
-            if (i === index) {
-                this._setActive(t);
-            }
-            i++;
-        });
+            this._tabs.forEach(t => {
+                if (i === tab) {
+                    this._setActive(t);
+                }
+                i++;
+            });
+        } else {
+            this._setActive(tab);
+        }
     }
 
-    /** Sets the currently selected tab by its `TabComponent` object  */
-    selectTabByObject(tab: TabComponent) {
-        this._setActive(tab);
-    }
-
-    _setActive(tab: TabComponent) {
+    _setActive(tab: TabComponent, event?: Event) {
         let selectedTab: number = 0;
         let index: number = 0;
 
@@ -93,6 +92,7 @@ export class TabSetComponent implements AfterContentInit {
             index++;
         });
 
+        tab.tabClick.emit(event);
         tab._active = true;
         this.selectChange.emit(new TabChangeEvent(selectedTab, tab));
     }

--- a/projects/cashmere/src/lib/tabs/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set.component.ts
@@ -35,7 +35,7 @@ export class TabSetComponent implements AfterContentInit {
     @ContentChildren(TabComponent) _tabs: QueryList<TabComponent>;
 
     /** Emits when the selected tab is changed */
-    @Output() selectChange: EventEmitter<TabChangeEvent> = new EventEmitter();
+    @Output() selectedTabChange: EventEmitter<TabChangeEvent> = new EventEmitter();
 
     /** Specify direction of tabs as either `horizontal` or `vertical`. Defaults to `vertical` */
     @Input()
@@ -94,7 +94,7 @@ export class TabSetComponent implements AfterContentInit {
 
         tab.tabClick.emit(event);
         tab._active = true;
-        this.selectChange.emit(new TabChangeEvent(selectedTab, tab));
+        this.selectedTabChange.emit(new TabChangeEvent(selectedTab, tab));
     }
 
     private defaultToFirstTab() {

--- a/projects/cashmere/src/lib/tabs/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set.component.ts
@@ -1,6 +1,10 @@
-import {AfterContentInit, Component, ContentChildren, Input, QueryList} from '@angular/core';
+import {AfterContentInit, Component, ContentChildren, Input, QueryList, Output, EventEmitter} from '@angular/core';
 import {TabComponent} from './tab.component';
 import {ActivatedRoute, Router} from '@angular/router';
+
+export class TabChangeEvent {
+    constructor(public index: number, public tab: TabComponent) {}
+}
 
 export function throwErrorForMissingRouterLink(tabsWithoutRouterLink: TabComponent[]) {
     const tabTitles = tabsWithoutRouterLink.map(tab => tab.tabTitle);
@@ -30,6 +34,9 @@ export class TabSetComponent implements AfterContentInit {
 
     @ContentChildren(TabComponent) _tabs: QueryList<TabComponent>;
 
+    /** Emits when the selected tab is changed */
+    @Output() selectChange: EventEmitter<TabChangeEvent> = new EventEmitter();
+
     /** Specify direction of tabs as either `horizontal` or `vertical`. Defaults to `vertical` */
     @Input()
     get direction(): string {
@@ -58,8 +65,19 @@ export class TabSetComponent implements AfterContentInit {
     }
 
     _setActive(tab: TabComponent) {
-        this._tabs.forEach(t => (t._active = false));
+        let selectedTab: number = 0;
+        let index: number = 0;
+
+        this._tabs.forEach(t => {
+            if( t === tab) {
+                selectedTab = index;
+            }
+            t._active = false;
+            index++;
+        });
+
         tab._active = true;
+        this.selectChange.emit(new TabChangeEvent(selectedTab, tab));
     }
 
     private defaultToFirstTab() {

--- a/projects/cashmere/src/lib/tabs/tab.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ContentChildren, QueryList, AfterViewChecked, AfterContentInit} from '@angular/core';
+import {Component, Input, ContentChildren, QueryList, AfterContentInit, Output, EventEmitter} from '@angular/core';
 import {HcTabTitleComponent} from './tab-title.component';
 
 @Component({
@@ -16,8 +16,11 @@ export class TabComponent implements AfterContentInit {
      * Can be specified as '/path/2' or ['path', '2']
      */
     @Input() routerLink: any[] | string;
-    _active: boolean = false;
 
+    /** Emits when this tab is selected; use instead of `(click)` for click binding  */
+    @Output() tabClick: EventEmitter<Event> = new EventEmitter();
+
+    _active: boolean = false;
     _htmlTitle: HcTabTitleComponent;
 
     @ContentChildren(HcTabTitleComponent) _tabTitle: QueryList<HcTabTitleComponent>;


### PR DESCRIPTION
- Adds a `selectChange` emitter to `TabSetComponent` that fires when the select tab in the set is changed.  
- Add a `selectTab` function to `hc-tab-set` that allows the selected tab to be set programmatically via either a numerical index or a `TabComponent` object
- Adds a `tabClick` emitter on `TabComponent` that fires when the tab is clicked.  `(click)` doesn't work because the tabs are generated in the tab-set template separately from the content.  So the click is being attached to something that doesn't exist.  But this emitter gets around that and will allow apps to bind events to tab clicks.
- Updated the Horizontal Tab example to illustrate all of the above.

closes #255, closes #556, closes #548 