### PR TITLE
feat(radiobutton): form field support

### DIFF
--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.css
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.css
@@ -6,3 +6,7 @@
 .flex-column {
     flex-direction: column;
 }
+
+.form-padding {
+    padding-bottom: 1.525em;
+}

--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.html
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.html
@@ -7,6 +7,16 @@
         </hc-form-field>
     </div>
 
+    <hc-form-field inline="true" class="form-padding">
+        <hc-label>Data Source:</hc-label>
+        <hc-radio-group [formControl]="radioControl" inline="true">
+            <hc-radio-button value="SM">Source Mart</hc-radio-button>
+            <hc-radio-button value="SAM">Subject Area Mart</hc-radio-button>
+            <hc-radio-button value="Other">Other</hc-radio-button>
+        </hc-radio-group>
+        <hc-error>Specified data source does not match description</hc-error>
+    </hc-form-field>
+
     <div class="form-sample">
         <hc-form-field>
             <hc-label>Run Frequency:</hc-label>

--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.ts
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.ts
@@ -12,11 +12,13 @@ import {FormControl} from '@angular/forms';
 export class FormFieldOverviewExample {
     selectControl = new FormControl('daily');
     inputControl = new FormControl('');
+    radioControl = new FormControl('SM');
     checkControl = new FormControl('');
 
     invalidForm() {
         this.inputControl.setErrors({incorrect: true});
         this.selectControl.setErrors({incorrect: true});
         this.checkControl.setErrors({incorrect: true});
+        this.radioControl.setErrors({incorrect: true});
     }
 }

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.css
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.css
@@ -1,11 +1,1 @@
-.example-group {
-    display: flex;
-    align-items: center;
-    margin-bottom: 25px;
-    margin-top: 30px;
-}
-
-.group-label {
-    padding-right: 15px;
-    font-weight: 600;
-}
+/* No CSS rules defined for this example */

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.html
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.html
@@ -1,9 +1,9 @@
-<div class="example-group">
-    <span class="group-label">Select your favorite:</span>
-    <hc-radio-group vertical="false" [(ngModel)]="favoriteShow">
+<hc-form-field inline="true">
+    <hc-label>Select your favorite:</hc-label>
+    <hc-radio-group [(ngModel)]="favoriteShow" inline="true">
         <hc-radio-button *ngFor="let show of shows" [value]="show">{{show}}</hc-radio-button>
     </hc-radio-group>
-</div>
+</hc-form-field>
 
 <p>Current selection: {{favoriteShow ? favoriteShow : 'none'}}</p>
 <button hc-button title="Primary-Alt Button" buttonStyle="primary-alt" (click)="reset()">

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.ts
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 
 /**
- * @title Horizontal Radio Buttons using Form Controls
+ * @title Inline Radio Buttons using Form Controls
  */
 @Component({
     selector: 'radio-button-forms-example',

--- a/projects/cashmere/src/lib/checkbox/checkbox.md
+++ b/projects/cashmere/src/lib/checkbox/checkbox.md
@@ -1,0 +1,10 @@
+hc-checkbox components may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.
+
+```html
+<hc-form-field>
+    <hc-label>Requested Notifications:</hc-label>
+    <hc-checkbox [formControl]="checkControl">On failure</hc-checkbox>
+    <hc-checkbox [formControl]="checkControl">On sucess</hc-checkbox>
+    <hc-error>At least one notification must be selected</hc-error>
+</hc-form-field>
+```

--- a/projects/cashmere/src/lib/radio-button/radio-button.component.scss
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.scss
@@ -4,7 +4,8 @@
     display: block;
     position: relative;
     padding-left: 35px;
-    margin-bottom: 18px;
+    margin: 7px 0;
+    line-height: 1.5;
     cursor: pointer;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -39,7 +40,6 @@
         border: 2px solid $gray-300;
         background-color: $white;
         border-radius: 50%;
-        margin-top: -4px;
     }
 
     .hc-radio-overlay:after {

--- a/projects/cashmere/src/lib/radio-button/radio-button.md
+++ b/projects/cashmere/src/lib/radio-button/radio-button.md
@@ -1,0 +1,12 @@
+RadioButtonComponents are contained in a RadioGroupDirective which may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.
+
+```html
+<hc-form-field>
+    <hc-label>Select your favorite:</hc-label>
+    <hc-radio-group>
+        <hc-radio-button value="one">Button One</hc-radio-button>
+        <hc-radio-button value="two">Button One</hc-radio-button>
+    </hc-radio-group>
+    <hc-error>The radio button selection is not valid</hc-error>
+</hc-form-field>
+```

--- a/projects/cashmere/src/lib/sass/_radio-group.scss
+++ b/projects/cashmere/src/lib/sass/_radio-group.scss
@@ -10,7 +10,12 @@
 
     .hc-radio-container {
         padding-left: 32px !important;
-        margin-bottom: 0px !important;
-        margin-right: 25px;
+        margin-right: 25px !important;
+    }
+}
+
+.hc-form-field-invalid {
+    .hc-radio-overlay {
+        border-color: $error !important;
     }
 }

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -32,10 +32,11 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 @mixin hc-form-field-wrapper-inline() {
     display: inline-flex;
     width: 100%;
+    padding-bottom: inherit;
 }
 
 @mixin hc-form-field-content-wrapper() {
-    display: inherit;
+    display: grid;
     flex-direction: inherit;
     width: 100%;
 }
@@ -126,9 +127,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 @mixin hc-form-field-label-wrapper-inline() {
-    padding-right: 15px;
-    display: flex;
-    align-items: center;
+    padding: 7px 15px 0 0;
 }
 
 @mixin hc-form-field-label-wrapper-icon() {

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -18,7 +18,8 @@ const docs: DocItem[] = [
     {
         id: 'checkbox',
         name: 'Checkbox',
-        examples: ['checkbox-standard', 'checkbox-disabled', 'checkbox-forms']
+        examples: ['checkbox-standard', 'checkbox-disabled', 'checkbox-forms'],
+        usageDoc: true
     },
     {
         id: 'chip',
@@ -62,7 +63,8 @@ const docs: DocItem[] = [
     {
         id: 'radio-button',
         name: 'Radio Button',
-        examples: ['radio-button-standard', 'radio-button-disabled', 'radio-button-forms']
+        examples: ['radio-button-standard', 'radio-button-disabled', 'radio-button-forms'],
+        usageDoc: true
     },
     {
         id: 'select',


### PR DESCRIPTION
Adds support for `hc-form-field` to `hc-radio-group`.  Note the name change on the parameter `vertical` in RadioGroupDirective to `inline`.  That just came out in the last release, so I think it's still new enough to change safely, but I've asked on the Slack channel to see if I'm wrong.  `inline` is a better descriptor and matches the naming convention used in `hc-form-field`.

closes #566