### PR TITLE
refactor(navbar): separates app switcher

### DIFF
--- a/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.html
+++ b/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.html
@@ -1,5 +1,4 @@
 <hc-navbar appIcon="./assets/CashmereAppLogo.svg" brandIcon="./assets/TriFlame.svg" [homeUri]="undefined" [fixedTop]="false">
-    <hc-app-switcher brandIcon="./assets/TriFlame.svg"></hc-app-switcher>
     <hc-navbar-link [active]="true" uri="undefined" linkText="Home"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Oncology"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Surgery"></hc-navbar-link>
@@ -7,7 +6,7 @@
     <hc-navbar-link [active]="false" uri="undefined" linkText="Cardiovascular"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Rehabilition"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Intensive Care"></hc-navbar-link>
-    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-search"></hc-icon>
+    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-th" [hcPopover]="appSwitcher" popperPlacement="bottom"></hc-icon>
     <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-question-circle-o" [hcPopover]="options" popperPlacement="bottom"></hc-icon>
     <span class="hc-navbar-vertical-separator"></span>
     <div class="hc-navbar-username" *ngIf="user" [hcPopover]="user" popperPlacement="bottom">
@@ -49,6 +48,10 @@
         <hc-app-switcher-links></hc-app-switcher-links>
     </hc-navbar-mobile-menu>
 </hc-navbar>
+
+<hc-popover-content #appSwitcher>
+    <hc-app-switcher></hc-app-switcher>
+</hc-popover-content>
 
 <hc-popover-content #options>
     <ul class="list-options">

--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.html
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.html
@@ -6,7 +6,6 @@
     <hc-navbar-link [active]="false" uri="undefined" linkText="Cardiovascular"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Rehabilition"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Intensive Care"></hc-navbar-link>
-    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-search"></hc-icon>
     <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-question-circle-o" [hcPopover]="options" popperPlacement="bottom"></hc-icon>
     <span class="hc-navbar-vertical-separator"></span>
     <div class="hc-navbar-username" *ngIf="user" [hcPopover]="user" popperPlacement="bottom">

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.html
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.html
@@ -1,21 +1,15 @@
-<div #brand [popperTarget]="brand" [hcPopover]="appSwitcherContent" popperPlacement="bottom-start" [className]="brandBg"
-    (popperOnShown)="buttonOn()" (popperOnHidden)="buttonOff()">
-    <img [src]="brandIcon">
+<div class="popover-content">
+    <h4>Applications</h4>
+    <pre *ngIf="!applications">loading applications...</pre>
+    <div class="apps">
+        <div class="app" *ngFor="let app of applications">
+            <a class="thumbnail" [title]="app.Description" [href]="app.ServiceUrl" target="_blank">
+                <img class="thumbnail-img" [src]="app.Icon">
+                <div class="title">{{app?.FriendlyName | ellipsis:18}}</div>
+            </a>
+        </div>
+    </div>
+    <a class="all-apps-link" [href]="appSwitcherService.allApplicationsUri" target="_blank">View all my
+        applications</a>
 </div>
 
-<hc-popover-content #appSwitcherContent>
-    <div class="popover-content">
-        <h4>Applications</h4>
-        <pre *ngIf="!applications">loading applications...</pre>
-        <div class="apps">
-            <div class="app" *ngFor="let app of applications">
-                <a class="thumbnail" [title]="app.Description" [href]="app.ServiceUrl" target="_blank">
-                    <img class="thumbnail-img" [src]="app.Icon">
-                    <div class="title">{{app?.FriendlyName | ellipsis:18}}</div>
-                </a>
-            </div>
-        </div>
-        <a class="all-apps-link" [href]="appSwitcherService.allApplicationsUri" target="_blank">View all my
-            applications</a>
-    </div>
-</hc-popover-content>

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.scss
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.scss
@@ -5,11 +5,6 @@
     width: 100%;
 }
 
-.brand {
-    cursor: pointer;
-    transition: background-color 0.25s ease;
-}
-
 .popover-content {
     max-width: 410px;
     & > h4 {

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.ts
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.ts
@@ -10,10 +10,6 @@ import {IAppSwitcherService, IDiscoveryApplication, APP_SWITCHER_SERVICE} from '
     styleUrls: ['./app-switcher.component.scss']
 })
 export class AppSwitcherComponent implements OnInit, OnDestroy {
-    /** Image of brand icon */
-    @Input()
-    brandIcon: string = '';
-
     public applications: IDiscoveryApplication[];
     public subscription: Subscription;
     public brandBg = 'brand';
@@ -34,13 +30,5 @@ export class AppSwitcherComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         this.ngUnsubscribe.next();
         this.ngUnsubscribe.complete();
-    }
-
-    buttonOn() {
-        this.brandBg = 'brand brandOn';
-    }
-
-    buttonOff() {
-        this.brandBg = 'brand';
     }
 }

--- a/projects/cashmere/src/lib/navbar/navbar.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar.component.html
@@ -1,17 +1,13 @@
 <nav class="hc-navbar" [ngClass]="{'fixed-top': fixedTop}">
-    <div #defaultbrand class="navbar-brand" *ngIf="appswitcherbrand.children.length == 0">
-        <a [routerLink]="homeUri" class="brand no-switcher">
+    <div class="navbar-brand">
+        <a [routerLink]="homeUri" class="brand">
             <img src="{{brandIcon}}">
         </a>
-    </div>
-    <div #appswitcherbrand class="navbar-brand">
-        <ng-content select="hc-app-switcher">
-        </ng-content>
     </div>
     <div class="navbar-app" [ngClass]="{'logo-condense': _logoCondense}">
         <a [routerLink]="homeUri" class="app" *ngIf="appIcon">
             <img src="{{appIcon}}">
-        </a> 
+        </a>
     </div>
     <div class="hc-navbar-link-container">
         <ng-content select="hc-navbar-link"></ng-content>
@@ -21,7 +17,7 @@
     </div>
 
     <div class="hc-navbar-right-container">
-        <ng-content></ng-content>        
+        <ng-content></ng-content>
     </div>
     <div class="hc-navbar-mobile-menu" (click)="_toggleMobileMenu()">
         <hc-icon fontSet="fa" [fontIcon]="_mobileMenuIcon" hcIconMd></hc-icon>

--- a/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
+++ b/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
@@ -8,14 +8,13 @@ import {Component} from '@angular/core';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {NavbarModule} from './navbar.module';
 import {ListModule} from '../list/list.module';
-import {AppSwitcherService, APP_SWITCHER_SERVICE} from '../app-switcher';
 
 @Component({
     template: `
     <hc-navbar brandIcon="./assets/TriFlame.svg" user="Christine K."
         [homeUri]="undefined" [fixedTop]="false">
     <hc-navbar-link [active]="true" uri="undefined" linkText="Home"></hc-navbar-link>
-    <hc-navbar-mobile-menu appSwitcher="false">
+    <hc-navbar-mobile-menu>
         <hc-list>
             <hc-list-item routerLink="/home" routerLinkActive="active-link">
                 <span hcListLine>Home</span>
@@ -42,9 +41,5 @@ describe('NavbarComponent', () => {
         fixture = TestBed.createComponent(TestAppComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
-    });
-
-    it('should create without IAppSwitcher', () => {
-        expect(component).toBeTruthy();
     });
 });

--- a/projects/cashmere/src/lib/navbar/navbar.md
+++ b/projects/cashmere/src/lib/navbar/navbar.md
@@ -15,11 +15,11 @@ All Health Catalyst apps should include a help menu in their navbar. This guide 
 
 You may not have all these items available. However, include what you have in this order:
 
--   **Help Topics** (if available—reach out to the Content Team for support)
--   **Release Notes** (if applicable, again reach out to the Content Team for support)
--   **About** (a modal containing app reference information - see the [associated style page](https://cashmere.healthcatalyst.net/styles/about) for guidelines)
--   **Health Catalyst Community** (link to community space specific to the app)
--   **Send us your feedback** (see the [User Feedback Guide](https://cashmere.healthcatalyst.net/components/typeform-survey/usage))
+*   **Help Topics** (if available—reach out to the Content Team for support)
+*   **Release Notes** (if applicable, again reach out to the Content Team for support)
+*   **About** (a modal containing app reference information - see the [associated style page](https://cashmere.healthcatalyst.net/styles/about) for guidelines)
+*   **Health Catalyst Community** (link to community space specific to the app)
+*   **Send us your feedback** (see the [User Feedback Guide](https://cashmere.healthcatalyst.net/components/typeform-survey/usage))
 
 ```html
 <hc-popover-content #helpMenu>
@@ -43,18 +43,25 @@ You may not have all these items available. However, include what you have in th
 </hc-popover-content>
 ```
 
+&nbsp;
+
 ##### App Switcher
 
-To enabled application switcher functionality within the navbar include the `<hc-app-switcher>` and `<hc-app-switcher-links>` in the navbar. See the navbar with app switcher for a complete example
+In addition to the help menu, all Heath Catalyst applications should also include the app switcher in their navbar to the left of the help menu. The app switcher allows users to easily switch between the Health Catalyst apps that they have access to.
 
 ```html
 <hc-navbar>
-    <hc-app-switcher brandIcon="./assets/TriFlame.svg"></hc-app-switcher>
+    ...
+    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-th" [hcPopover]="appSwitcher" popperPlacement="bottom"></hc-icon>
     ...
     <hc-navbar-mobile-menu>
         ...
         <hc-app-switcher-links></hc-app-switcher-links>
     </hc-navbar-mobile-menu>
+    ...
+    <hc-popover-content #appSwitcher>
+        <hc-app-switcher></hc-app-switcher>
+    </hc-popover-content>
 </hc-navbar>
 ```
 

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -34,10 +34,6 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     display: flex;
     justify-content: center;
     align-items: center;
-    // if <hc-app-switcher> is not present, hide it
-    & + .navbar-brand {
-        display: none;
-    }
     .brand {
         & > img {
             height: 37px;
@@ -48,10 +44,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         justify-content: center;
         align-items: center;
         height: 100%;
-
-        &.no-switcher {
-            cursor: default;
-        }
+        cursor: default;
     }
 
     @include media-breakpoint-down(sm) {


### PR DESCRIPTION
Based on consistent feedback from a variety of sources, we had a UX problem with the location of our app switcher.  It was previously activated by clicking on the tri-flame box in the top left, but there was no visual indication to the user to click there. As a result, the app switcher was getting lost.

After reviewing other industry practices regarding app switching, it was decided that including it as an icon next to the help menu would be a significant improvement.  It groups all global app functionality together on the right side of the navbar, and drastically improves the discoverability of the button.

This *BREAKING CHANGE* removes the app switcher from the navbar's template and allows the user to attach it to a `hc-icon` (or anywhere else for that matter).  Component examples and usage markdown has also been updated to reflect the change.

closes #593