### PR TITLE
style(checkbox): fixes hit area

### DIFF
--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -26,7 +26,7 @@
 }
 
 @mixin hc-checkbox-label() {
-    margin-left: 12px;
+    padding: 4px 0 4px 12px;
 }
 
 @mixin hc-checkbox-overlay() {


### PR DESCRIPTION
Space created by margin is considered outside the element, so it doesn't get a click event.  Switching to padding resolves that.

closes #604