### PR TITLE
fix(pagination): display `all` when length < page size

### DIFF
--- a/projects/cashmere/src/lib/pagination/pagination.component.html
+++ b/projects/cashmere/src/lib/pagination/pagination.component.html
@@ -1,40 +1,59 @@
 <div class="hc-pagination-container">
     <div *ngIf="!hidePageSize" class="hc-font-sm hc-page-detail-container">
         <label>Showing:</label>
-        <hc-select [value]="pageSize" (change)="_changePageSize($event.target.value)">
+        <hc-select [value]="pageSize" (change)="_changePageSize($event.target.value)" (focus)="isFocused = true" (blur)="isFocused = false">
             <option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
-                {{pageSizeOption}}
+                {{ isFocused ? pageSizeOption : pageSize === pageSizeOption && pageSizeOption > length ? 'all' : pageSizeOption }}
             </option>
         </hc-select>
-        <label>of <strong>{{length}}</strong> entries</label>
+        <label
+            >of <strong>{{ length }}</strong> entries</label
+        >
     </div>
 
     <div class="hc-page-btns-container">
-        <button hc-button color="secondary" class="hc-page-button hc-left-button" (click)="_previousPage()" [disabled]="!totalPages || _isFirstPage">
-            <hc-icon fontSet="fa" fontIcon="fa-chevron-left"></hc-icon>&nbsp;
-            <span>PREV</span>
+        <button
+            hc-button
+            color="secondary"
+            class="hc-page-button hc-left-button"
+            (click)="_previousPage()"
+            [disabled]="!totalPages || _isFirstPage"
+        >
+            <hc-icon fontSet="fa" fontIcon="fa-chevron-left"></hc-icon>&nbsp; <span>PREV</span>
         </button>
         <!-- page navigation buttons to appear normally -->
-        <button hc-button color="secondary"
-                class="hc-page-button hc-inner-button expanded-page-button"
-                *ngFor="let page of _visiblePages"
-                [disabled]="!page"
-                [class.currentPage]="page === pageNumber"
-                (click)="_goToPage(page)">
-            <span *ngIf="!!page">{{page}}</span>
+        <button
+            hc-button
+            color="secondary"
+            class="hc-page-button hc-inner-button expanded-page-button"
+            *ngFor="let page of _visiblePages"
+            [disabled]="!page"
+            [class.currentPage]="page === pageNumber"
+            (click)="_goToPage(page)"
+        >
+            <span *ngIf="!!page">{{ page }}</span>
             <hc-icon *ngIf="!page" fontSet="fa" fontIcon="fa-ellipsis-h"></hc-icon>
         </button>
         <!-- page navigation buttons to appear when space is limited -->
-        <button hc-button color="secondary"
-                class="hc-page-button hc-inner-button collapsed-page-button"
-                *ngFor="let page of _collapsedVisiblePages"
-                [disabled]="!page"
-                [class.currentPage]="page === pageNumber"
-                (click)="_goToPage(page)">
-            <span *ngIf="!!page">{{page}}</span>
+        <button
+            hc-button
+            color="secondary"
+            class="hc-page-button hc-inner-button collapsed-page-button"
+            *ngFor="let page of _collapsedVisiblePages"
+            [disabled]="!page"
+            [class.currentPage]="page === pageNumber"
+            (click)="_goToPage(page)"
+        >
+            <span *ngIf="!!page">{{ page }}</span>
             <hc-icon *ngIf="!page" fontSet="fa" fontIcon="fa-ellipsis-h"></hc-icon>
         </button>
-        <button hc-button color="secondary" class="hc-page-button hc-right-button" (click)="_nextPage()" [disabled]="!totalPages || _isLastPage">
+        <button
+            hc-button
+            color="secondary"
+            class="hc-page-button hc-right-button"
+            (click)="_nextPage()"
+            [disabled]="!totalPages || _isLastPage"
+        >
             <span>NEXT</span>&nbsp;
             <hc-icon fontSet="fa" fontIcon="fa-chevron-right"></hc-icon>
         </button>

--- a/projects/cashmere/src/lib/pagination/pagination.component.ts
+++ b/projects/cashmere/src/lib/pagination/pagination.component.ts
@@ -23,6 +23,8 @@ export class PaginationComponent extends BasePaginationComponent implements OnIn
     }
     private _pageSizeOptions: number[] = [10, 20, 50];
 
+    isFocused: boolean = false;
+
     /** Displayed set of page size options. Will be sorted and include current page size. */
     _displayedPageSizeOptions: number[] = [];
 

--- a/projects/cashmere/src/lib/select/select.component.html
+++ b/projects/cashmere/src/lib/select/select.component.html
@@ -1,11 +1,15 @@
 <div class="hc-select-container">
     <span class="hc-select-chevron"></span>
-    <select class="hc-select-input"
-            [disabled]="disabled"
-            (change)="value = $event.target.value"
-            [value]="value"
-            [required]="required">
-        <option *ngIf="placeholder" value="" selected disabled hidden>{{placeholder}}</option>
+    <select
+        class="hc-select-input"
+        [disabled]="disabled"
+        (change)="value = $event.target.value"
+        [value]="value"
+        (focus)="focus.next()"
+        (blur)="blur.next()"
+        [required]="required"
+    >
+        <option *ngIf="placeholder" value="" selected disabled hidden>{{ placeholder }}</option>
         <ng-content select="option"></ng-content>
     </select>
 </div>

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -1,4 +1,16 @@
-import {Component, forwardRef, HostBinding, Input, ViewEncapsulation, ElementRef, Optional, DoCheck, Self} from '@angular/core';
+import {
+    Component,
+    forwardRef,
+    HostBinding,
+    Input,
+    ViewEncapsulation,
+    ElementRef,
+    Optional,
+    DoCheck,
+    Self,
+    Output,
+    EventEmitter
+} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR, NgForm, FormGroupDirective, NgControl} from '@angular/forms';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
@@ -68,6 +80,11 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
             this.onChange(val);
         }
     }
+
+    @Output()
+    readonly focus: EventEmitter<void> = new EventEmitter<void>();
+    @Output()
+    readonly blur: EventEmitter<void> = new EventEmitter<void>();
 
     private _value: string = '';
 


### PR DESCRIPTION
if the total items being paged is smaller than the page size, display "Showing all of n" instead of
i.e. "Showing 20 of 5"

fix #639