### PR TITLE
fix(navbar): explicitly set line height

### DIFF
--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -24,6 +24,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     background-color: $navbar-color;
     display: flex;
     font-size: 15px;
+    line-height: 1;
 }
 
 @mixin navbar-brand {


### PR DESCRIPTION
insure we don't inherit line height from somewhere else and throw off vertical alignment

re #644