### PR TITLE
refactor(multiple): remove font-awesome dependency

### DIFF
--- a/projects/cashmere-examples/src/lib/button-link/button-link-example.html
+++ b/projects/cashmere-examples/src/lib/button-link/button-link-example.html
@@ -11,7 +11,7 @@
         <span class="value">
             <span class="hc-font-bold">Last Month</span> (9/3/17 - 10/3/17)
         </span>
-        <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="icon-right" hcIconSm></hc-icon>
+        <hc-icon fontSet="fa" fontIcon="fa-chevron-down" hcIconSm></hc-icon>
     </button>
 </p>
 <hc-popover-content #example>

--- a/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.css
+++ b/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.css
@@ -4,5 +4,5 @@
 }
 
 .demo-button-width {
-    min-width: unset;
+    min-width: unset !important;
 }

--- a/projects/cashmere/src/lib/accordion/accordion.component.scss
+++ b/projects/cashmere/src/lib/accordion/accordion.component.scss
@@ -33,15 +33,17 @@ $accordion-toolbar-padding: 0 10px;
         cursor: pointer;
 
         &::after {
-            display: block;
-            transform: translate(-50%, 2px) rotate(46deg);
-            border-top: 2px solid;
-            border-left: 2px solid;
-            left: 50%;
             content: '';
-            width: 8px;
-            height: 8px;
-            position: relative;
+            transform: rotate(180deg);
+            display: block;
+            background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNi45NzgiIGhlaWdodD0iMTcuMzE5IiB2aWV3Qm94PSIwIDAgMjYuOTc4IDE3LjMxOSI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogIzAwYWVmZjsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHBhdGggaWQ9IlBhdGhfNSIgZGF0YS1uYW1lPSJQYXRoIDUiIGNsYXNzPSJjbHMtMSIgZD0iTTI4LjE3NS0xMi4xODhhMS4wODEsMS4wODEsMCwwLDAsMC0xLjUyM0wyNS40LTE2LjQ3M2ExLjA2MSwxLjA2MSwwLDAsMC0xLjUwNywwTDE1LTcuNTg0bC04Ljg5LTguODlhMS4wNjEsMS4wNjEsMCwwLDAtMS41MDcsMEwxLjgyNS0xMy43MTFhMS4wODEsMS4wODEsMCwwLDAsMCwxLjUyM0wxNC4yNDcuMjE4YTEuMDYxLDEuMDYxLDAsMCwwLDEuNTA3LDBaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMS41MTEgMTYuNzg3KSIvPgo8L3N2Zz4K');
+            background-repeat: no-repeat;
+            background-size: contain;
+            width: 13px;
+            height: 8.5px;
+            pointer-events: none;
+            box-sizing: border-box;
+            margin-top: 2px;
         }
     }
 
@@ -53,7 +55,7 @@ $accordion-toolbar-padding: 0 10px;
     &.hc-accordion-closed,
     &.hc-accordion-closing {
         .hc-accordion-trigger::after {
-            transform: translate(-50%, -2px) rotate(-134deg);
+            transform: rotate(0deg);
         }
     }
 }

--- a/projects/cashmere/src/lib/button/button.component.scss
+++ b/projects/cashmere/src/lib/button/button.component.scss
@@ -52,7 +52,12 @@
         @include hc-split-button-main();
     }
     .hc-split-button-toggle {
-        @include hc-split-button-toggle();
+        &:not(.hc-secondary) {
+            @include hc-split-button-toggle();
+        }
+        &.hc-secondary {
+            @include hc-button-secondary-toggle();
+        }
         &.hc-sm {
             @include hc-button-sm-toggle();
         }

--- a/projects/cashmere/src/lib/chip/chip-row/chip-row.component.ts
+++ b/projects/cashmere/src/lib/chip/chip-row/chip-row.component.ts
@@ -4,8 +4,8 @@ import {parseBooleanAttribute} from '../../util';
 /** Supporting component to help with grouping chips into collections */
 @Component({
     selector: 'hc-chip-row',
-    template: `<div class="chip-row-contents" [ngClass]="{'single-row': !wrap}"><div>
-                    <div class="row-buffer"><ng-content></ng-content></div>
+    template: `<div class="hc-chip-row-contents" [ngClass]="{'hc-chip-single-row': !wrap}"><div>
+                    <div class="hc-chip-row-buffer"><ng-content></ng-content></div>
                 </div></div>`,
     styleUrls: ['../chip.component.scss'],
     encapsulation: ViewEncapsulation.None

--- a/projects/cashmere/src/lib/chip/chip.component.html
+++ b/projects/cashmere/src/lib/chip/chip.component.html
@@ -1,0 +1,4 @@
+<div class="hc-chip hc-chip-{{color}}" [ngClass]="{'hc-chip-close': action}">
+    <ng-content></ng-content>
+    <span *ngIf="action" class="hc-chip-close-icon"></span>
+</div>

--- a/projects/cashmere/src/lib/chip/chip.component.scss
+++ b/projects/cashmere/src/lib/chip/chip.component.scss
@@ -2,7 +2,7 @@
 @import '../sass/functions.scss';
 @import '../sass/mixins.scss';
 
-.chip {
+.hc-chip {
     border-radius: 6px;
     height: 32px;
     line-height: 32px;
@@ -11,69 +11,87 @@
     padding: 0 15px;
     margin: 5px;
     white-space: nowrap;
+
+    &.hc-chip-close {
+        cursor: pointer;
+    }
 }
 
-.neutral {
+.hc-chip-neutral {
     color: $text;
     background-color: tint($text, 87%);
+
+    .hc-chip-close-icon {
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOS44ODgiIGhlaWdodD0iMTkuODg4IiB2aWV3Qm94PSIwIDAgMTkuODg4IDE5Ljg4OCI+CiAgPHBhdGggaWQ9IlBhdGhfMSIgZGF0YS1uYW1lPSJQYXRoIDEiIGQ9Ik0yMS43My0zLjU4M2ExLjYyMywxLjYyMywwLDAsMC0uNDY5LTEuMTM4TDE2LjMzOS05LjY0M2w0LjkyMi00LjkyMkExLjYyMywxLjYyMywwLDAsMCwyMS43My0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLS40NjktMS4xMzhsLTIuMjc3LTIuMjc3YTEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LS40NjksMS42MjMsMS42MjMsMCwwLDAtMS4xMzguNDY5TDExLjc4Ni0xNC4yLDYuODY0LTE5LjExOGExLjYyMywxLjYyMywwLDAsMC0xLjEzOC0uNDY5LDEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LjQ2OUwyLjMxLTE2Ljg0MkExLjYyMywxLjYyMywwLDAsMCwxLjg0Mi0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLC40NjksMS4xMzhMNy4yMzItOS42NDMsMi4zMS00LjcyMWExLjYyMywxLjYyMywwLDAsMC0uNDY5LDEuMTM4QTEuNjIzLDEuNjIzLDAsMCwwLDIuMzEtMi40NDRMNC41ODctLjE2N0ExLjYyMywxLjYyMywwLDAsMCw1LjcyNS4zLDEuNjIzLDEuNjIzLDAsMCwwLDYuODY0LS4xNjdsNC45MjItNC45MjJMMTYuNzA4LS4xNjdBMS42MjMsMS42MjMsMCwwLDAsMTcuODQ2LjNhMS42MjMsMS42MjMsMCwwLDAsMS4xMzgtLjQ2OWwyLjI3Ny0yLjI3N0ExLjYyMywxLjYyMywwLDAsMCwyMS43My0zLjU4M1oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xLjg0MiAxOS41ODcpIiBmaWxsPSIjMzMzIi8+Cjwvc3ZnPgo=');
+    }
 }
 
-.red {
+.hc-chip-red {
     color: $ruby-red;
     background-color: tint($ruby-red, 85%);
     border: 2px solid tint($ruby-red, 75%);
     line-height: 28px !important;
+
+    .hc-chip-close-icon {
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOS44ODgiIGhlaWdodD0iMTkuODg4IiB2aWV3Qm94PSIwIDAgMTkuODg4IDE5Ljg4OCI+CiAgPHBhdGggaWQ9IlBhdGhfMiIgZGF0YS1uYW1lPSJQYXRoIDIiIGQ9Ik0yMS43My0zLjU4M2ExLjYyMywxLjYyMywwLDAsMC0uNDY5LTEuMTM4TDE2LjMzOS05LjY0M2w0LjkyMi00LjkyMkExLjYyMywxLjYyMywwLDAsMCwyMS43My0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLS40NjktMS4xMzhsLTIuMjc3LTIuMjc3YTEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LS40NjksMS42MjMsMS42MjMsMCwwLDAtMS4xMzguNDY5TDExLjc4Ni0xNC4yLDYuODY0LTE5LjExOGExLjYyMywxLjYyMywwLDAsMC0xLjEzOC0uNDY5LDEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LjQ2OUwyLjMxLTE2Ljg0MkExLjYyMywxLjYyMywwLDAsMCwxLjg0Mi0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLC40NjksMS4xMzhMNy4yMzItOS42NDMsMi4zMS00LjcyMWExLjYyMywxLjYyMywwLDAsMC0uNDY5LDEuMTM4QTEuNjIzLDEuNjIzLDAsMCwwLDIuMzEtMi40NDRMNC41ODctLjE2N0ExLjYyMywxLjYyMywwLDAsMCw1LjcyNS4zLDEuNjIzLDEuNjIzLDAsMCwwLDYuODY0LS4xNjdsNC45MjItNC45MjJMMTYuNzA4LS4xNjdBMS42MjMsMS42MjMsMCwwLDAsMTcuODQ2LjNhMS42MjMsMS42MjMsMCwwLDAsMS4xMzgtLjQ2OWwyLjI3Ny0yLjI3N0ExLjYyMywxLjYyMywwLDAsMCwyMS43My0zLjU4M1oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xLjg0MiAxOS41ODcpIiBmaWxsPSIjOTUxYzFlIi8+Cjwvc3ZnPgo=');
+    }
 }
 
-.yellow {
+.hc-chip-yellow {
     color: shade($yellow-orange, 25%);
     background-color: tint($yellow-orange, 80%);
     border: 2px solid tint($yellow-orange, 50%);
     line-height: 28px !important;
+
+    .hc-chip-close-icon {
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOS44ODgiIGhlaWdodD0iMTkuODg4IiB2aWV3Qm94PSIwIDAgMTkuODg4IDE5Ljg4OCI+CiAgPHBhdGggaWQ9IlBhdGhfMyIgZGF0YS1uYW1lPSJQYXRoIDMiIGQ9Ik0yMS43My0zLjU4M2ExLjYyMywxLjYyMywwLDAsMC0uNDY5LTEuMTM4TDE2LjMzOS05LjY0M2w0LjkyMi00LjkyMkExLjYyMywxLjYyMywwLDAsMCwyMS43My0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLS40NjktMS4xMzhsLTIuMjc3LTIuMjc3YTEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LS40NjksMS42MjMsMS42MjMsMCwwLDAtMS4xMzguNDY5TDExLjc4Ni0xNC4yLDYuODY0LTE5LjExOGExLjYyMywxLjYyMywwLDAsMC0xLjEzOC0uNDY5LDEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LjQ2OUwyLjMxLTE2Ljg0MkExLjYyMywxLjYyMywwLDAsMCwxLjg0Mi0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLC40NjksMS4xMzhMNy4yMzItOS42NDMsMi4zMS00LjcyMWExLjYyMywxLjYyMywwLDAsMC0uNDY5LDEuMTM4QTEuNjIzLDEuNjIzLDAsMCwwLDIuMzEtMi40NDRMNC41ODctLjE2N0ExLjYyMywxLjYyMywwLDAsMCw1LjcyNS4zLDEuNjIzLDEuNjIzLDAsMCwwLDYuODY0LS4xNjdsNC45MjItNC45MjJMMTYuNzA4LS4xNjdBMS42MjMsMS42MjMsMCwwLDAsMTcuODQ2LjNhMS42MjMsMS42MjMsMCwwLDAsMS4xMzgtLjQ2OWwyLjI3Ny0yLjI3N0ExLjYyMywxLjYyMywwLDAsMCwyMS43My0zLjU4M1oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xLjg0MiAxOS41ODcpIiBmaWxsPSIjYWQ5MzM1Ii8+Cjwvc3ZnPgo=');
+    }
 }
 
-.green {
+.hc-chip-green {
     color: $green;
     background-color: tint($light-green, 60%);
     border: 2px solid tint($light-green, 30%);
     line-height: 28px !important;
+
+    .hc-chip-close-icon {
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOS44ODgiIGhlaWdodD0iMTkuODg4IiB2aWV3Qm94PSIwIDAgMTkuODg4IDE5Ljg4OCI+CiAgPHBhdGggaWQ9IlBhdGhfNCIgZGF0YS1uYW1lPSJQYXRoIDQiIGQ9Ik0yMS43My0zLjU4M2ExLjYyMywxLjYyMywwLDAsMC0uNDY5LTEuMTM4TDE2LjMzOS05LjY0M2w0LjkyMi00LjkyMkExLjYyMywxLjYyMywwLDAsMCwyMS43My0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLS40NjktMS4xMzhsLTIuMjc3LTIuMjc3YTEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LS40NjksMS42MjMsMS42MjMsMCwwLDAtMS4xMzguNDY5TDExLjc4Ni0xNC4yLDYuODY0LTE5LjExOGExLjYyMywxLjYyMywwLDAsMC0xLjEzOC0uNDY5LDEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LjQ2OUwyLjMxLTE2Ljg0MkExLjYyMywxLjYyMywwLDAsMCwxLjg0Mi0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLC40NjksMS4xMzhMNy4yMzItOS42NDMsMi4zMS00LjcyMWExLjYyMywxLjYyMywwLDAsMC0uNDY5LDEuMTM4QTEuNjIzLDEuNjIzLDAsMCwwLDIuMzEtMi40NDRMNC41ODctLjE2N0ExLjYyMywxLjYyMywwLDAsMCw1LjcyNS4zLDEuNjIzLDEuNjIzLDAsMCwwLDYuODY0LS4xNjdsNC45MjItNC45MjJMMTYuNzA4LS4xNjdBMS42MjMsMS42MjMsMCwwLDAsMTcuODQ2LjNhMS42MjMsMS42MjMsMCwwLDAsMS4xMzgtLjQ2OWwyLjI3Ny0yLjI3N0ExLjYyMywxLjYyMywwLDAsMCwyMS43My0zLjU4M1oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xLjg0MiAxOS41ODcpIiBmaWxsPSIjMDBhODU5Ii8+Cjwvc3ZnPgo=');
+    }
 }
 
-.close {
-    cursor: pointer;
-}
-
-.close:after {
-    content: '\f00d';
-    font-family: FontAwesome;
-    @include fontSize(15px);
-    padding-left: 12px;
+.hc-chip-close-icon {
     opacity: 0.4;
-}
-
-.chip-row-contents {
+    width: 10px;
+    height: 10px;
+    margin-left: 13px;
+    background-repeat: no-repeat;
+    background-size: contain;
     display: inline-block;
 }
 
-.single-row {
+.hc-chip-row-contents {
+    display: inline-block;
+}
+
+.hc-chip-single-row {
     height: 42px;
     overflow: hidden;
 }
 
-.single-row:before {
+.hc-chip-single-row:before {
     content: '';
     float: left;
     width: 5px;
     height: 50px;
 }
 
-.single-row > *:first-child {
+.hc-chip-single-row > *:first-child {
     float: right;
     width: 100%;
     margin-left: -5px;
 }
 
-.single-row:after {
+.hc-chip-single-row:after {
     content: '…more';
 
     box-sizing: content-box;
@@ -90,6 +108,6 @@
     text-align: right;
 }
 
-.row-buffer {
+.hc-chip-row-buffer {
     margin-right: 3.5em;
 }

--- a/projects/cashmere/src/lib/chip/chip.component.ts
+++ b/projects/cashmere/src/lib/chip/chip.component.ts
@@ -12,7 +12,7 @@ export function validateColorInput(inputStr: string) {
 /** Chips represent complex entities in small blocks, such as filters, contacts, or system information */
 @Component({
     selector: 'hc-chip',
-    template: `<div [class]="color" [ngClass]="{'close': action, 'chip': true}"><ng-content></ng-content></div>`,
+    templateUrl: './chip.component.html',
     styleUrls: ['./chip.component.scss'],
     encapsulation: ViewEncapsulation.None
 })

--- a/projects/cashmere/src/lib/pagination/pagination.component.html
+++ b/projects/cashmere/src/lib/pagination/pagination.component.html
@@ -19,7 +19,8 @@
             (click)="_previousPage()"
             [disabled]="!totalPages || _isFirstPage"
         >
-            <hc-icon fontSet="fa" fontIcon="fa-chevron-left"></hc-icon>&nbsp; <span>PREV</span>
+            <span class="hc-page-button-chevron left"></span>
+            <span>PREV</span>
         </button>
         <!-- page navigation buttons to appear normally -->
         <button
@@ -32,7 +33,7 @@
             (click)="_goToPage(page)"
         >
             <span *ngIf="!!page">{{ page }}</span>
-            <hc-icon *ngIf="!page" fontSet="fa" fontIcon="fa-ellipsis-h"></hc-icon>
+            <span *ngIf="!page" class="hc-page-button-ellipsis"></span>
         </button>
         <!-- page navigation buttons to appear when space is limited -->
         <button
@@ -45,7 +46,7 @@
             (click)="_goToPage(page)"
         >
             <span *ngIf="!!page">{{ page }}</span>
-            <hc-icon *ngIf="!page" fontSet="fa" fontIcon="fa-ellipsis-h"></hc-icon>
+            <span *ngIf="!page" class="hc-page-button-ellipsis"></span>
         </button>
         <button
             hc-button
@@ -54,8 +55,8 @@
             (click)="_nextPage()"
             [disabled]="!totalPages || _isLastPage"
         >
-            <span>NEXT</span>&nbsp;
-            <hc-icon fontSet="fa" fontIcon="fa-chevron-right"></hc-icon>
+            <span>NEXT</span>
+            <span class="hc-page-button-chevron"></span>
         </button>
     </div>
 </div>

--- a/projects/cashmere/src/lib/pagination/pagination.component.scss
+++ b/projects/cashmere/src/lib/pagination/pagination.component.scss
@@ -44,12 +44,6 @@
         color: $primary-brand;
         font-weight: bold;
 
-        hc-icon {
-            font-size: 13px !important;
-            height: 12px !important;
-            width: 13px !important;
-        }
-
         &:hover {
             color: darken($primary-brand, 10%);
         }
@@ -101,10 +95,31 @@
         margin-right: 0;
     }
 
-    button.hc-inner-button hc-icon {
-        margin-top: 7px;
+    .hc-page-button-chevron {
+        display: inline-block;
+        width: 7px;
+        height: 12px;
+        margin: 1px 3px 0 7px;
+        background-repeat: no-repeat;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3LjM4NSIgaGVpZ2h0PSIxMiIgdmlld0JveD0iMCAwIDcuMzg1IDEyIj4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBmaWxsOiAjMDBhZWZmOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8cGF0aCBpZD0iUGF0aF81IiBkYXRhLW5hbWU9IlBhdGggNSIgY2xhc3M9ImNscy0xIiBkPSJNMTMuMzcxLTE0LjgyNmEuNDQ4LjQ0OCwwLDAsMCwwLS42NWwtMS4yMzYtMS4xNzhhLjQ4Ni40ODYsMCwwLDAtLjY3LDBsLTMuOTU0LDMuNzktMy45NTQtMy43OWEuNDg2LjQ4NiwwLDAsMC0uNjcsMEwxLjY1MS0xNS40NzVhLjQ0OC40NDgsMCwwLDAsMCwuNjVsNS41MjUsNS4yOWEuNDg2LjQ4NiwwLDAsMCwuNjcsMFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE2Ljc4NyAxMy41MTEpIHJvdGF0ZSgtOTApIi8+Cjwvc3ZnPgo=');
+
+        &.left {
+            transform: rotate(180deg);
+            margin: 1px 7px 0 3px;
+        }
     }
 
+    .hc-page-button-ellipsis {
+        display: inline-block;
+        opacity: 0.4;
+        width: 11px;
+        height: 3px;
+        margin-bottom: 1px;
+        background-repeat: no-repeat;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSI1IiB2aWV3Qm94PSIwIDAgMjAgNSI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogIzAwYWVmZjsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHBhdGggaWQ9IlBhdGhfNiIgZGF0YS1uYW1lPSJQYXRoIDYiIGNsYXNzPSJjbHMtMSIgZD0iTTUuNDU1LTEzLjc1QTEuMzExLDEuMzExLDAsMCwwLDQuMDkxLTE1SDEuMzY0QTEuMzExLDEuMzExLDAsMCwwLDAtMTMuNzV2Mi41QTEuMzExLDEuMzExLDAsMCwwLDEuMzY0LTEwSDQuMDkxYTEuMzExLDEuMzExLDAsMCwwLDEuMzY0LTEuMjVabTcuMjczLDBBMS4zMTEsMS4zMTEsMCwwLDAsMTEuMzY0LTE1SDguNjM2YTEuMzExLDEuMzExLDAsMCwwLTEuMzY0LDEuMjV2Mi41QTEuMzExLDEuMzExLDAsMCwwLDguNjM2LTEwaDIuNzI3YTEuMzExLDEuMzExLDAsMCwwLDEuMzY0LTEuMjVabTcuMjczLDBBMS4zMTEsMS4zMTEsMCwwLDAsMTguNjM2LTE1SDE1LjkwOWExLjMxMSwxLjMxMSwwLDAsMC0xLjM2NCwxLjI1djIuNUExLjMxMSwxLjMxMSwwLDAsMCwxNS45MDktMTBoMi43MjdBMS4zMTEsMS4zMTEsMCwwLDAsMjAtMTEuMjVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwIDE1KSIvPgo8L3N2Zz4K');
+    }
     .expanded-page-button {
         display: block;
     }

--- a/projects/cashmere/src/lib/sass/button.scss
+++ b/projects/cashmere/src/lib/sass/button.scss
@@ -114,6 +114,7 @@ $btn-icon-sz: 18px;
         color: $gray-600;
     }
 }
+
 @mixin hc-button-minimal() {
     background-color: transparent;
     color: $gray-500;
@@ -230,20 +231,52 @@ $btn-icon-sz: 18px;
     border-top-left-radius: 0;
 
     &::after {
-        display: flex;
-        height: 20px;
-        align-items: center;
-        font: normal normal normal 12px/1 FontAwesome;
-        content: '\f078';
+        content: '';
+        width: 12px;
+        height: 8px;
+        margin-top: 2px;
+        display: inline-block;
+        background-repeat: no-repeat;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNCIgaGVpZ2h0PSI4Ljk4NyIgdmlld0JveD0iMCAwIDE0IDguOTg3Ij4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8cGF0aCBpZD0iUGF0aF81IiBkYXRhLW5hbWU9IlBhdGggNSIgY2xhc3M9ImNscy0xIiBkPSJNMTUuMzQ4LTE0LjRhLjU2MS41NjEsMCwwLDAsMC0uNzkxbC0xLjQ0Mi0xLjQzM2EuNTUxLjU1MSwwLDAsMC0uNzgyLDBMOC41MTEtMTIuMDExLDMuOS0xNi42MjRhLjU1MS41NTEsMCwwLDAtLjc4MiwwTDEuNjc0LTE1LjE5MWEuNTYxLjU2MSwwLDAsMCwwLC43OTFMOC4xMi03Ljk2M2EuNTUxLjU1MSwwLDAsMCwuNzgyLDBaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMS41MTEgMTYuNzg3KSIvPgo8L3N2Zz4K');
+    }
+}
+
+@mixin hc-button-secondary-toggle() {
+    min-width: auto;
+    padding: 8px 12px;
+    margin-left: 0;
+    border-left: 1px solid rgba(0, 0, 0, 0.12);
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+
+    &::after {
+        content: '';
+        width: 12px;
+        height: 8px;
+        margin-top: 2px;
+        display: inline-block;
+        background-repeat: no-repeat;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNCIgaGVpZ2h0PSI4Ljk4NyIgdmlld0JveD0iMCAwIDE0IDguOTg3Ij4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBmaWxsOiAjMzMzOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8cGF0aCBpZD0iUGF0aF81IiBkYXRhLW5hbWU9IlBhdGggNSIgY2xhc3M9ImNscy0xIiBkPSJNMTUuMzQ4LTE0LjRhLjU2MS41NjEsMCwwLDAsMC0uNzkxbC0xLjQ0Mi0xLjQzM2EuNTUxLjU1MSwwLDAsMC0uNzgyLDBMOC41MTEtMTIuMDExLDMuOS0xNi42MjRhLjU1MS41NTEsMCwwLDAtLjc4MiwwTDEuNjc0LTE1LjE5MWEuNTYxLjU2MSwwLDAsMCwwLC43OTFMOC4xMi03Ljk2M2EuNTUxLjU1MSwwLDAsMCwuNzgyLDBaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMS41MTEgMTYuNzg3KSIvPgo8L3N2Zz4K');
     }
 }
 
 @mixin hc-button-sm-toggle() {
     padding: 3px 7px;
+    &::after {
+        width: 10px;
+        height: 6px;
+        margin-top: 1px;
+    }
 }
 
 @mixin hc-button-lg-toggle() {
     padding: 0px 16px;
+    &::after {
+        width: 14px;
+        height: 9px;
+    }
 }
 
 @mixin hc-split-button-divider() {

--- a/projects/cashmere/src/lib/sass/tables.scss
+++ b/projects/cashmere/src/lib/sass/tables.scss
@@ -162,48 +162,32 @@ table.hc-table {
             background-color: $row-color-action-hover;
         }
 
-        //TODO: redo the guts of these icons when we roll our own icon font
-        &:before,
         &:after {
-            display: inline-block;
+            content: '';
             position: absolute;
-            bottom: 11px;
-            font: normal normal normal 12px/1 FontAwesome;
-            text-rendering: auto;
-            -webkit-font-smoothing: antialiased;
-        }
-        &:before {
-            right: 23px;
-            bottom: 9px;
-            content: $fa-var-long-arrow-down;
-        }
-        &:after {
-            right: 18px;
+            right: 1px;
             bottom: 10px;
-            content: $fa-var-long-arrow-down;
-            transform: rotate(180deg);
+            height: 13px;
+            width: 13px;
+            margin-left: 15px;
+            padding-right: 35px;
+            background-repeat: no-repeat;
+            background-position: center center;
+            background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNzYwLjc4IDE3OTIiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojYTNhNWE3O308L3N0eWxlPjwvZGVmcz48dGl0bGU+QXJ0Ym9hcmQgMTwvdGl0bGU+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNTgyLDEzNDIuODlIODA1Ljc5cTMxLjM0LDAsMzcuMzEsMTYuNDJ0LTE0LjkxLDM3LjNMNDg1LDE3NjkuNjNRNDY0LjA3LDE3OTIsNDMyLjc3LDE3OTJ0LTUyLjIxLTIyLjM3bC0zNDMuMjEtMzczcS0yMC45MS0yMC44OC0xNC45MS0zNy4zdDM3LjMtMTYuNDJIMjgzLjU2VjBINTgyWm03OTguMjYtMTMxOSwzNDMuMiwzNzEuNTVxMjAuODUsMjAuOTEsMTQuOTIsMzYuNTV0LTM3LjMxLDE1LjY2SDE0NzcuMjRWMTc5MC41MkgxMTc4LjgyVjQ0Ny42M0g5NTVxLTMxLjMyLDAtMzcuMy0xNS42NnQxNC45MS0zNi41NWwzNDMuMi0zNzEuNTVRMTI5Ni42NiwxLjUsMTMyOCwxLjQ4VDEzODAuMjQsMjMuODdaIi8+PC9zdmc+');
         }
 
         &.hc-active-sort {
             color: $thead-active-font-color;
 
             &.hc-sort-asc {
-                &:before {
-                    content: $fa-var-sort-amount-asc;
-                    right: 16px;
-                }
                 &:after {
-                    content: none;
+                    background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNzYwLjc4IDE3OTIiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojMDBhODU5O308L3N0eWxlPjwvZGVmcz48dGl0bGU+QXJ0Ym9hcmQgMTwvdGl0bGU+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNzA0Ljc4LDE0NDBxMCwxMi0xMCwyNGwtMzE5LDMxOWEzMy4zNiwzMy4zNiwwLDAsMS0yMyw5cS0xMiwwLTIzLTlsLTMyMC0zMjBxLTE1LTE2LTctMzUsOC0yMCwzMC0yMGgxOTJWMzJxMC0xNCw5LTIzdDIzLTloMTkycTE0LDAsMjMsOXQ5LDIzVjE0MDhoMTkycTE0LDAsMjMsOVQ3MDQuNzgsMTQ0MFptMTA1NiwxMjh2MTkycTAsMTQtOSwyM3QtMjMsOWgtODMycS0xNCwwLTIzLTl0LTktMjNWMTU2OHEwLTE0LDktMjN0MjMtOWg4MzJxMTQsMCwyMyw5VDE3NjAuNzgsMTU2OFptLTE5Mi01MTJ2MTkycTAsMTQtOSwyM3QtMjMsOWgtNjQwcS0xNCwwLTIzLTl0LTktMjNWMTA1NnEwLTE0LDktMjN0MjMtOWg2NDBxMTQsMCwyMyw5VDE1NjguNzgsMTA1NlptLTE5Mi01MTJWNzM2cTAsMTQtOSwyM3QtMjMsOWgtNDQ4cS0xNCwwLTIzLTl0LTktMjNWNTQ0cTAtMTQsOS0yM3QyMy05aDQ0OHExNCwwLDIzLDlUMTM3Ni43OCw1NDRabS0xOTItNTEyVjIyNHEwLDE0LTksMjN0LTIzLDloLTI1NnEtMTQsMC0yMy05dC05LTIzVjMycTAtMTQsOS0yM3QyMy05aDI1NnExNCwwLDIzLDlUMTE4NC43OCwzMloiLz48L3N2Zz4=');
                 }
             }
 
             &.hc-sort-desc {
-                &:before {
-                    content: $fa-var-sort-amount-desc;
-                    right: 16px;
-                }
                 &:after {
-                    content: none;
+                    background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNzYwLjc4IDE3OTIiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojMDBhODU5O308L3N0eWxlPjwvZGVmcz48dGl0bGU+QXJ0Ym9hcmQgMTwvdGl0bGU+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTE4NC43OCwxNTY4djE5MnEwLDE0LTksMjN0LTIzLDloLTI1NnEtMTQsMC0yMy05dC05LTIzVjE1NjhxMC0xNCw5LTIzdDIzLTloMjU2cTE0LDAsMjMsOVQxMTg0Ljc4LDE1NjhabS00ODAtMTI4cTAsMTItMTAsMjRsLTMxOSwzMTlhMzMuMzYsMzMuMzYsMCwwLDEtMjMsOXEtMTIsMC0yMy05bC0zMjAtMzIwcS0xNS0xNi03LTM1LDgtMjAsMzAtMjBoMTkyVjMycTAtMTQsOS0yM3QyMy05aDE5MnExNCwwLDIzLDl0OSwyM1YxNDA4aDE5MnExNCwwLDIzLDlUNzA0Ljc4LDE0NDBabTY3Mi0zODR2MTkycTAsMTQtOSwyM3QtMjMsOWgtNDQ4cS0xNCwwLTIzLTl0LTktMjNWMTA1NnEwLTE0LDktMjN0MjMtOWg0NDhxMTQsMCwyMyw5VDEzNzYuNzgsMTA1NlptMTkyLTUxMlY3MzZxMCwxNC05LDIzdC0yMyw5aC02NDBxLTE0LDAtMjMtOXQtOS0yM1Y1NDRxMC0xNCw5LTIzdDIzLTloNjQwcTE0LDAsMjMsOVQxNTY4Ljc4LDU0NFptMTkyLTUxMlYyMjRxMCwxNC05LDIzdC0yMyw5aC04MzJxLTE0LDAtMjMtOXQtOS0yM1YzMnEwLTE0LDktMjN0MjMtOWg4MzJxMTQsMCwyMyw5VDE3NjAuNzgsMzJaIi8+PC9zdmc+');
                 }
             }
         }
@@ -214,24 +198,8 @@ table.hc-table {
         padding-right: 16px;
         padding-left: 35px;
 
-        &:before {
-            left: 16px;
-            right: auto;
-        }
         &:after {
-            left: 21px;
-            right: auto;
-        }
-
-        &.hc-active-sort {
-            &.hc-sort-asc:before {
-                left: 16px;
-                right: auto;
-            }
-            &.hc-sort-desc:before {
-                left: 16px;
-                right: auto;
-            }
+            left: -14px;
         }
     }
 

--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -33,13 +33,20 @@
     line-height: 35px;
     text-align: center;
     pointer-events: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     &:after {
-        content: '\f078';
-        font-family: FontAwesome;
-        color: #00aeff;
+        content: '';
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNi45NzgiIGhlaWdodD0iMTcuMzE5IiB2aWV3Qm94PSIwIDAgMjYuOTc4IDE3LjMxOSI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogIzAwYWVmZjsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHBhdGggaWQ9IlBhdGhfNSIgZGF0YS1uYW1lPSJQYXRoIDUiIGNsYXNzPSJjbHMtMSIgZD0iTTI4LjE3NS0xMi4xODhhMS4wODEsMS4wODEsMCwwLDAsMC0xLjUyM0wyNS40LTE2LjQ3M2ExLjA2MSwxLjA2MSwwLDAsMC0xLjUwNywwTDE1LTcuNTg0bC04Ljg5LTguODlhMS4wNjEsMS4wNjEsMCwwLDAtMS41MDcsMEwxLjgyNS0xMy43MTFhMS4wODEsMS4wODEsMCwwLDAsMCwxLjUyM0wxNC4yNDcuMjE4YTEuMDYxLDEuMDYxLDAsMCwwLDEuNTA3LDBaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMS41MTEgMTYuNzg3KSIvPgo8L3N2Zz4K');
+        background-repeat: no-repeat;
+        background-size: contain;
+        width: 13px;
+        height: 8.5px;
         pointer-events: none;
         box-sizing: border-box;
+        margin-top: 2px;
     }
 }
 
@@ -74,8 +81,8 @@
 }
 
 .hc-select-disabled {
-    .hc-select-chevron:after {
-        color: tint($primary-brand, 60%);
+    .hc-select-chevron {
+        opacity: 0.4;
     }
 }
 

--- a/src/app/styles/chart/chart-demo.component.html
+++ b/src/app/styles/chart/chart-demo.component.html
@@ -23,9 +23,10 @@
 
     <hc-tile>
         <div class="header-row">
-            <span class="header-dropdown" [hcPopover]="options" popperPlacement="bottom">
-                <h2 class="chart-header dropdown">Patient Readmissions</h2>
-            </span>
+            <button hc-button title="Patient Readmissions" buttonStyle="link" class="chart-header" [hcPopover]="options" popperPlacement="bottom">
+                <h2>Patient Readmissions</h2>
+                <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="header-icon-right"></hc-icon>
+            </button>
             <span class="header-right">
                 <hc-icon fontSet="fa" fontIcon="fa-share-alt" (click)="chartShare(content,'Share Chart')"></hc-icon>
                 <hc-icon fontSet="fa" fontIcon="fa-info-circle" (click)="chartInfo(content, 'Chart Information')"></hc-icon>

--- a/src/app/styles/chart/chart-demo.component.scss
+++ b/src/app/styles/chart/chart-demo.component.scss
@@ -71,20 +71,15 @@ hc-swatch-demo-component {
 }
 
 .chart-header {
-    display: inline;
+    padding: 0 !important;
+
     .light {
         font-weight: 300;
     }
+}
 
-    &.dropdown:after {
-        content: '\f078';
-        font-family: FontAwesome;
-        font-size: 20px;
-        color: $primary-brand;
-        margin-left: 20px;
-        vertical-align: text-top;
-        font-weight: 400;
-    }
+.header-icon-right {
+    margin-left: 20px;
 }
 
 .header-row {


### PR DESCRIPTION
Embeds glyphs in css instead of using FA in either classes or hc-icon.  Also corrected the css class names in hc-chip while I was in there to match our [current naming conventions](https://cashmere.healthcatalyst.net/guides/naming-conventions).

closes #663