### PR TITLE
fix(modal): fixed event handling

### DIFF
--- a/projects/cashmere/src/lib/modal/modal-overlay.component.ts
+++ b/projects/cashmere/src/lib/modal/modal-overlay.component.ts
@@ -45,7 +45,7 @@ export class ModalOverlayComponent {
     @HostListener('document:keyup.escape', ['$event'])
     _escapeKey(event: any) {
         if (!this._ignoreEscapeKey) {
-            this.activeModal.close();
+            this.activeModal.dismiss();
         }
     }
 }

--- a/projects/cashmere/src/lib/modal/modal-window.component.ts
+++ b/projects/cashmere/src/lib/modal/modal-window.component.ts
@@ -37,8 +37,9 @@ export class ModalWindowComponent {
     @HostListener('click', ['$event'])
     _overlayClick(event: any) {
         let modalContentNotPresent = true;
-        let modalWindowTargetIncluded = event.path.findIndex(p => p === this.el.nativeElement) > -1;
-        let classList: (DOMTokenList | undefined)[] = event.path.map(p => p.classList);
+        let path = this._eventPath(event);
+        let modalWindowTargetIncluded = path.findIndex(p => p === this.el.nativeElement) > -1;
+        let classList: (DOMTokenList | undefined)[] = path.map(p => p.classList);
         for (let cl of classList) {
             if (cl) {
                 if (cl.contains('hc-modal-content')) {
@@ -55,7 +56,35 @@ export class ModalWindowComponent {
                 2. Not the hc-modal-content and
                 3. the overlay click option is disabled. */
         if (!this._ignoreOverlayClick && modalContentNotPresent && modalWindowTargetIncluded) {
-            this.activeModal.close();
+            this.activeModal.dismiss();
         }
+    }
+
+    // Serves as a polyfill for Event.composedPath() or Event.Path
+    _eventPath(evt: any) {
+        let path = (evt.composedPath && evt.composedPath()) || evt.path,
+            target = evt.target;
+
+        if (path != null) {
+            // Safari doesn't include Window, but it should.
+            return path.indexOf(window) < 0 ? path.concat(window) : path;
+        }
+
+        if (target === window) {
+            return [window];
+        }
+
+        function _getParents(node, memo?) {
+            memo = memo || [];
+            let parentNode = node.parentNode;
+
+            if (!parentNode) {
+                return memo;
+            } else {
+                return _getParents(parentNode, memo.concat(parentNode));
+            }
+        }
+
+        return [target].concat(_getParents(target), window);
     }
 }


### PR DESCRIPTION
The reason we were seeing that modal click error was because `event.path` is apparently only supported in Chrome currently.  A StackOverflow answer provided a nice polyfill though that seems to do the trick.  Also took care of the issue @joeskeen were `close()` was being used instead of `dismiss()` when the modal is closed either via the escape key or clicking outside (if configured to allow that).

closes #664
closes #665