### PR TITLE
feat(all): demo site navigation

### DIFF
--- a/guides/using-and-customizing-components.md
+++ b/guides/using-and-customizing-components.md
@@ -1,4 +1,4 @@
-# Using and Customizing Components
+# Customizing Components
 
 ###### Last updated October 10, 2018
 

--- a/projects/cashmere/src/lib/accordion/accordion.component.scss
+++ b/projects/cashmere/src/lib/accordion/accordion.component.scss
@@ -17,6 +17,9 @@ $accordion-toolbar-padding: 0 10px;
             .hc-accordion-trigger {
                 order: 1;
                 margin-left: auto;
+                display: flex;
+                justify-content: center;
+                align-items: center;
             }
             .hc-accordion-toolbar {
                 order: 0;

--- a/src/app/components/components.component.html
+++ b/src/app/components/components.component.html
@@ -1,13 +1,75 @@
-<hc-subnav class="responsive-subnav" fixedTop="true">
-    <div class="subnav-container">
-        <span class="subnav-label">Components: </span>
-        <span class="subnav-select">
-            <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
-                <option *ngFor="let option of docItems" [value]="option.id" [selected]="option.id === thisPage">{{option.name}}</option>
-            </hc-select>
-        </span>
+<div class="hc-components-container">
+    <hc-subnav class="responsive-subnav" fixedTop="true">
+        <div class="subnav-container">
+            <span class="subnav-label">Components: </span>
+            <span class="subnav-select">
+                <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
+                    <option *ngFor="let option of docItems" [value]="option.id" [selected]="option.id === thisPage">{{
+                        option.name
+                    }}</option>
+                </hc-select>
+            </span>
+        </div>
+    </hc-subnav>
+
+    <div class="hc-components-left-column">
+        <div class="hc-components-nav-container">
+            <hc-tile>
+                <div class="hc-components-nav-list">
+                    <hc-accordion triggerAlign="right" [open]="thisCategory == 'forms'">
+                        <hc-accordion-toolbar>Form Controls</hc-accordion-toolbar>
+                        <ng-container *ngFor="let option of docItems">
+                            <div *ngIf="option.category == 'forms'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': option.id == thisPage }" (click)="navUpdate(option.id)">{{ option.name }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                    <div class="hc-components-nav-divider"></div>
+                    <hc-accordion triggerAlign="right" [open]="thisCategory == 'nav'">
+                        <hc-accordion-toolbar>Navigation</hc-accordion-toolbar>
+                        <ng-container *ngFor="let option of docItems">
+                            <div *ngIf="option.category == 'nav'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': option.id == thisPage }" (click)="navUpdate(option.id)">{{ option.name }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                    <div class="hc-components-nav-divider"></div>
+                    <hc-accordion triggerAlign="right" [open]="thisCategory == 'layout'">
+                        <hc-accordion-toolbar>Layout</hc-accordion-toolbar>
+                        <ng-container *ngFor="let option of docItems">
+                            <div *ngIf="option.category == 'layout'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': option.id == thisPage }" (click)="navUpdate(option.id)">{{ option.name }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                    <div class="hc-components-nav-divider"></div>
+                    <hc-accordion triggerAlign="right" [open]="thisCategory == 'buttons'">
+                        <hc-accordion-toolbar>Buttons & Indicators</hc-accordion-toolbar>
+                        <ng-container *ngFor="let option of docItems">
+                            <div *ngIf="option.category == 'buttons'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': option.id == thisPage }" (click)="navUpdate(option.id)">{{ option.name }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                    <div class="hc-components-nav-divider"></div>
+                    <hc-accordion triggerAlign="right" [open]="thisCategory == 'popups'">
+                        <hc-accordion-toolbar>Popups & Notifications</hc-accordion-toolbar>
+                        <ng-container *ngFor="let option of docItems">
+                            <div *ngIf="option.category == 'popups'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': option.id == thisPage }" (click)="navUpdate(option.id)">{{ option.name }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                    <div class="hc-components-nav-divider"></div>
+                    <hc-accordion triggerAlign="right" [open]="thisCategory == 'table'">
+                        <hc-accordion-toolbar>Data Table</hc-accordion-toolbar>
+                        <ng-container *ngFor="let option of docItems">
+                            <div *ngIf="option.category == 'table'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': option.id == thisPage }" (click)="navUpdate(option.id)">{{ option.name }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                </div>
+            </hc-tile>
+        </div>
     </div>
-</hc-subnav>
-<hc-tab-set class="full-height">
-    <hc-tab *ngFor="let docItem of docItems" [tabTitle]="docItem.name" [routerLink]="docItem.id"></hc-tab>
-</hc-tab-set>
+    <div class="hc-components-right-column">
+        <hc-tab-set class="full-height">
+            <hc-tab *ngFor="let docItem of docItems" [tabTitle]="docItem.name" [routerLink]="docItem.id"></hc-tab>
+        </hc-tab-set>
+    </div>
+</div>

--- a/src/app/components/components.component.scss
+++ b/src/app/components/components.component.scss
@@ -1,0 +1,70 @@
+@import 'scss/colors';
+@import 'scss/variables';
+@import 'scss/mixins';
+
+.hc-components-container {
+    width: 100%;
+    min-height: calc(100vh - 53px);
+    display: flex;
+    background-color: $slate-gray-100;
+}
+
+.hc-components-left-column {
+    width: 25%;
+    display: flex;
+    justify-content: center;
+    min-width: 275px;
+}
+
+.hc-components-nav-container {
+    width: 22.5%;
+    margin-top: 20px;
+    position: fixed;
+    min-width: 250px;
+
+    hc-tile {
+        padding: 10px 15px;
+    }
+}
+
+.hc-components-nav-list {
+    max-height: calc(100vh - 113px);
+    overflow-y: auto;
+}
+
+.hc-components-nav-divider {
+    background-color: $gray-300;
+    width: 100%;
+    height: 1px;
+}
+
+.hc-components-nav-link {
+    @include fontSize(14px);
+    color: $gray-500;
+    padding: 14px 0 14px 30px;
+    cursor: pointer;
+}
+
+.hc-components-nav-link-active {
+    color: $primary-brand;
+    font-weight: 700;
+}
+
+.hc-components-nav-spacer {
+    display: block;
+    height: 15px;
+}
+
+.hc-components-right-column {
+    width: 75%;
+    max-width: 1100px;
+}
+
+@include media-breakpoint-down(md) {
+    .hc-components-left-column {
+        display: none;
+    }
+    .hc-components-right-column {
+        width: 100%;
+    }
+}

--- a/src/app/components/components.component.ts
+++ b/src/app/components/components.component.ts
@@ -6,11 +6,13 @@ import {Subject} from 'rxjs';
 
 @Component({
     selector: 'hc-demo-components',
-    templateUrl: './components.component.html'
+    templateUrl: './components.component.html',
+    styleUrls: ['./components.component.scss']
 })
 export class ComponentsComponent implements OnDestroy {
     docItems: DocItem[];
     thisPage = '';
+    thisCategory = '';
     selectOptions: Array<string> = [];
     private unsubscribe = new Subject<void>();
 
@@ -22,6 +24,11 @@ export class ComponentsComponent implements OnDestroy {
             if (event instanceof NavigationEnd) {
                 if (activatedRoute.firstChild) {
                     this.thisPage = activatedRoute.firstChild.snapshot.params['id'];
+                    this.docItems.forEach(element => {
+                        if (this.thisPage === element.id) {
+                            this.thisCategory = element.category;
+                        }
+                    });
                 }
             }
         });
@@ -30,6 +37,13 @@ export class ComponentsComponent implements OnDestroy {
     // Handle changes to the select component and navigate
     selectUpdate(event: any) {
         this.router.navigate(['/components/' + event]);
+        window.scrollTo(0, 0);
+    }
+
+    // Handle nav changes via the sidebar
+    navUpdate(id: any) {
+        this.router.navigate(['/components/' + id]);
+        window.scrollTo(0, 0);
     }
 
     ngOnDestroy(): void {

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -3,106 +3,129 @@ import {Injectable} from '@angular/core';
 export interface DocItem {
     id: string;
     name: string;
+    // Category options are: 'forms', 'nav', 'layout', 'buttons', 'popups', 'table'
+    category: string;
     examples?: string[];
     usageDoc?: boolean;
 }
 
 const docs: DocItem[] = [
-    {id: 'accordion', name: 'Accordion', examples: ['accordion-overview']},
-    {id: 'banner', name: 'Banner', examples: ['banner-overview']},
-    {id: 'breadcrumbs', name: 'Breadcrumbs', usageDoc: true},
-    {
-        id: 'button',
-        name: 'Button',
-        examples: ['button-type', 'button-split', 'button-size', 'button-anchor', 'button-link', 'button-icon']
-    },
     {
         id: 'checkbox',
         name: 'Checkbox',
+        category: 'forms',
         examples: ['checkbox-standard', 'checkbox-disabled', 'checkbox-forms'],
         usageDoc: true
+    },
+    {id: 'accordion', name: 'Accordion', category: 'layout', examples: ['accordion-overview']},
+    {id: 'banner', name: 'Banner', category: 'popups', examples: ['banner-overview']},
+    {id: 'breadcrumbs', name: 'Breadcrumbs', category: 'nav', usageDoc: true},
+    {
+        id: 'button',
+        name: 'Button',
+        category: 'buttons',
+        examples: ['button-type', 'button-split', 'button-size', 'button-anchor', 'button-link', 'button-icon']
     },
     {
         id: 'chip',
         name: 'Chip',
+        category: 'buttons',
         examples: ['chip-basic', 'chip-action', 'chip-row', 'chip-singlerow']
     },
     {
         id: 'datepicker',
         name: 'Datepicker',
+        category: 'forms',
         examples: ['datepicker', 'datepicker-sugar', 'datepicker-selected-value'],
         usageDoc: true
     },
     {
         id: 'date-range',
         name: 'DateRange',
+        category: 'forms',
         examples: ['date-range'],
         usageDoc: true
     },
     {
         id: 'drawer',
         name: 'Drawer',
+        category: 'layout',
         examples: ['drawer-basic', 'drawer-overlay', 'drawer-side', 'drawer-menu']
     },
-    {id: 'form-field', name: 'Form Field', examples: ['form-field-overview']},
-    {id: 'icon', name: 'Icon', examples: ['icon-overview']},
+    {id: 'form-field', name: 'Form Field', category: 'forms', examples: ['form-field-overview']},
+    {id: 'icon', name: 'Icon', category: 'buttons', examples: ['icon-overview']},
     {
         id: 'input',
         name: 'Input',
+        category: 'forms',
         usageDoc: true,
         examples: ['input-required', 'input-suffix', 'input-prefix']
     },
-    {id: 'list', name: 'List', examples: ['list-overview']},
-    {id: 'modal', name: 'Modal', examples: ['modal-overview']},
+    {id: 'list', name: 'List', category: 'layout', examples: ['list-overview']},
+    {id: 'modal', name: 'Modal', category: 'popups', examples: ['modal-overview']},
     {
         id: 'navbar',
         name: 'Navbar',
+        category: 'nav',
         examples: ['navbar-overview', 'navbar-app-switcher'],
         usageDoc: true
     },
     {
         id: 'pagination',
         name: 'Pagination',
+        category: 'nav',
         usageDoc: true,
         examples: ['pagination-standard', 'pagination-load-more', 'pagination-simple']
     },
-    {id: 'picklist', name: 'Picklist', examples: ['picklist-simple', 'picklist-valueset'], usageDoc: true},
+    {id: 'picklist', name: 'Picklist', category: 'layout', examples: ['picklist-simple', 'picklist-valueset'], usageDoc: true},
     {
         id: 'popover',
         name: 'Popover',
+        category: 'popups',
         examples: ['popover-overview', 'popover-placement', 'popover-dynamic']
     },
-    {id: 'progress-indicators', name: 'Progress Indicators', examples: ['progress-spinner', 'progress-dots'], usageDoc: true},
+    {
+        id: 'progress-indicators',
+        name: 'Progress Indicators',
+        category: 'buttons',
+        examples: ['progress-spinner', 'progress-dots'],
+        usageDoc: true
+    },
     {
         id: 'radio-button',
         name: 'Radio Button',
+        category: 'forms',
         examples: ['radio-button-standard', 'radio-button-disabled', 'radio-button-forms'],
         usageDoc: true
     },
     {
         id: 'select',
         name: 'Select',
+        category: 'forms',
         examples: ['select-standard', 'select-disabled', 'select-validation', 'select-forms'],
         usageDoc: true
     },
-    {id: 'sort', name: 'Sort', usageDoc: true},
-    {id: 'subnav', name: 'Subnav', examples: ['subnav-overview']},
+    {id: 'sort', name: 'Sort', category: 'table', usageDoc: true},
+    {id: 'subnav', name: 'Subnav', category: 'nav', examples: ['subnav-overview']},
     {
         id: 'table',
         name: 'Table',
+        category: 'table',
         examples: ['table-overview', 'table-sort', 'table-filter'],
         usageDoc: true
     },
     {
         id: 'tabs',
         name: 'Tabs',
+        category: 'layout',
         examples: ['tabs-horizontal', 'tabs-vertical']
     },
-    {id: 'tile', name: 'Tile', examples: ['tile-overview']},
-    {id: 'toaster', name: 'Toaster Messages', examples: ['toaster-overview']},
+    {id: 'tile', name: 'Tile', category: 'layout', examples: ['tile-overview']},
+    {id: 'toaster', name: 'Toaster Messages', category: 'popups', examples: ['toaster-overview']},
     {
         id: 'typeform-survey',
         name: 'Typeform Survey',
+        category: 'popups',
         examples: ['typeform-survey-overview'],
         usageDoc: true
     }

--- a/src/app/guides/guides.component.html
+++ b/src/app/guides/guides.component.html
@@ -1,14 +1,40 @@
-<hc-subnav class="responsive-subnav" fixedTop="true">
-    <div class="subnav-container">
-        <span class="subnav-label">Guides: </span>
-        <span class="subnav-select">
-            <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
-                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === thisPage">{{option}}</option>
-            </hc-select>
-        </span>
+<div class="hc-components-container">
+    <hc-subnav class="responsive-subnav" fixedTop="true">
+        <div class="subnav-container">
+            <span class="subnav-label">Guides: </span>
+            <span class="subnav-select">
+                <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
+                    <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === thisPage">{{option}}</option>
+                </hc-select>
+            </span>
+        </div>
+    </hc-subnav>
+
+    <div class="hc-components-left-column">
+        <div class="hc-components-nav-container">
+            <hc-tile>
+                <div class="hc-components-nav-list">
+                    <hc-accordion triggerAlign="right" open='true'>
+                        <hc-accordion-toolbar>Using Cashmere</hc-accordion-toolbar>
+                        <ng-container *ngFor="let guide of guidesService.guides">
+                            <div *ngIf="guide.category == 'using'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': guide.title == thisPage }" (click)="navUpdate(guide.route)">{{ guide.title }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                    <div class="hc-components-nav-divider"></div>
+                    <hc-accordion triggerAlign="right" open='true'>
+                        <hc-accordion-toolbar>Development</hc-accordion-toolbar>
+                        <ng-container *ngFor="let guide of guidesService.guides">
+                            <div *ngIf="guide.category == 'dev'" class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': guide.title == thisPage }" (click)="navUpdate(guide.route)">{{ guide.title }}</div>
+                        </ng-container>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                </div>
+            </hc-tile>
+        </div>
     </div>
-</hc-subnav>
-<hc-tab-set class="full-height">
-    <hc-tab *ngFor="let guide of guidesService.guides" [tabTitle]="guide.title" [routerLink]="['/guides/', guide.route]">
-    </hc-tab>
-</hc-tab-set>
+    <hc-tab-set class="full-height">
+        <hc-tab *ngFor="let guide of guidesService.guides" [tabTitle]="guide.title" [routerLink]="['/guides/', guide.route]">
+        </hc-tab>
+    </hc-tab-set>
+</div>

--- a/src/app/guides/guides.component.ts
+++ b/src/app/guides/guides.component.ts
@@ -6,16 +6,16 @@ import {Subject} from 'rxjs';
 
 @Component({
     selector: 'hc-guides',
-    templateUrl: './guides.component.html'
+    templateUrl: './guides.component.html',
+    styleUrls: ['../components/components.component.scss']
 })
-export class GuidesComponent implements OnInit, OnDestroy {
+export class GuidesComponent implements OnDestroy {
     thisPage = '';
     selectOptions: Array<string> = [];
+
     private unsubscribe = new Subject<void>();
 
-    constructor(public guidesService: GuidesService, private activatedRoute: ActivatedRoute, private router: Router) {}
-
-    ngOnInit() {
+    constructor(public guidesService: GuidesService, private activatedRoute: ActivatedRoute, private router: Router) {
         // Listen for vertical tab bar navigation and update the select component
         this.router.events.pipe(takeUntil(this.unsubscribe)).subscribe(event => {
             if (event instanceof NavigationEnd) {
@@ -39,9 +39,16 @@ export class GuidesComponent implements OnInit, OnDestroy {
         for (let entry of this.guidesService.guides) {
             if (event === entry.title) {
                 this.router.navigate(['/guides/' + entry.route]);
+                window.scrollTo(0, 0);
                 break;
             }
         }
+    }
+
+    // Handle nav changes via the sidebar
+    navUpdate(page: any) {
+        this.router.navigate(['/guides/' + page]);
+        window.scrollTo(0, 0);
     }
 
     ngOnDestroy(): void {

--- a/src/app/guides/guides.service.ts
+++ b/src/app/guides/guides.service.ts
@@ -3,6 +3,8 @@ import {Injectable} from '@angular/core';
 export interface IGuide {
     title: string;
     route: string;
+    // Categories are: 'using' and 'dev'
+    category: string;
     document: string;
 }
 
@@ -12,36 +14,43 @@ export class GuidesService {
         {
             title: 'Getting Started',
             route: 'getting-started',
+            category: 'using',
             document: require('raw-loader!../../../guides/getting-started.md')
         },
         {
             title: 'Guidelines for Contribution',
             route: 'contribution-guide',
+            category: 'dev',
             document: require('raw-loader!../../../guides/contribution-guide.md')
         },
         {
             title: 'Naming Conventions',
             route: 'naming-conventions',
+            category: 'dev',
             document: require('raw-loader!../../../guides/naming-conventions.md')
         },
         {
             title: 'Submit an Issue',
             route: 'submit-an-issue',
+            category: 'using',
             document: require('raw-loader!../../../guides/submit-an-issue.md')
         },
         {
             title: 'Supported Browsers',
             route: 'supported-browsers',
+            category: 'using',
             document: require('raw-loader!../../../guides/supported-browsers.md')
         },
         {
-            title: 'Using and Customizing Components',
+            title: 'Customizing Components',
             route: 'using-customizing-components',
+            category: 'dev',
             document: require('raw-loader!../../../guides/using-and-customizing-components.md')
         },
         {
             title: 'Working with Examples',
             route: 'working-with-examples',
+            category: 'dev',
             document: require('raw-loader!../../../guides/working-with-examples.md')
         }
     ];

--- a/src/app/styles/styles-routes.module.ts
+++ b/src/app/styles/styles-routes.module.ts
@@ -69,7 +69,7 @@ const routes: Routes = [
             },
             {
                 path: '**',
-                redirectTo: 'about'
+                redirectTo: 'color'
             }
         ]
     }

--- a/src/app/styles/styles.component.html
+++ b/src/app/styles/styles.component.html
@@ -1,22 +1,53 @@
-<hc-subnav class="responsive-subnav" fixedTop="true">
-    <div class="subnav-container">
-        <span class="subnav-label">Styles: </span>
-        <span class="subnav-select">
-            <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
-                <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === thisPage">{{ option }}</option>
-            </hc-select>
-        </span>
+<div class="hc-components-container">
+    <hc-subnav class="responsive-subnav" fixedTop="true">
+        <div class="subnav-container">
+            <span class="subnav-label">Styles: </span>
+            <span class="subnav-select">
+                <hc-select [(ngModel)]="thisPage" (ngModelChange)="selectUpdate($event)">
+                    <option *ngFor="let option of selectOptions" [value]="option" [selected]="option === thisPage">{{ option }}</option>
+                </hc-select>
+            </span>
+        </div>
+    </hc-subnav>
+    <div class="hc-components-left-column">
+        <div class="hc-components-nav-container">
+            <hc-tile>
+                <div class="hc-components-nav-list">
+                    <hc-accordion triggerAlign="right" open='true'>
+                        <hc-accordion-toolbar>Foundations</hc-accordion-toolbar>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Colors' == thisPage }" (click)="navUpdate('color')">Colors</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Typography' == thisPage }" (click)="navUpdate('typography')">Typography</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Icons' == thisPage }" (click)="navUpdate('icons')">Icons</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Code' == thisPage }" (click)="navUpdate('code')">Code</div>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                    <div class="hc-components-nav-divider"></div>
+                    <hc-accordion triggerAlign="right" open='true'>
+                        <hc-accordion-toolbar>Visual Guidelines</hc-accordion-toolbar>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'About Modal' == thisPage }" (click)="navUpdate('about')">About Modal</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Breadcrumbs' == thisPage }" (click)="navUpdate('breadcrumbs')">Breadcrumbs</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Charts' == thisPage }" (click)="navUpdate('chart')">Charts</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Error Pages' == thisPage }" (click)="navUpdate('error')">Error Pages</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Login Page' == thisPage }" (click)="navUpdate('login')">Login Page</div>
+                        <div class="hc-components-nav-link" [ngClass]="{'hc-components-nav-link-active': 'Tables' == thisPage }" (click)="navUpdate('table')">Tables</div>
+                        <div class="hc-components-nav-spacer"></div>
+                    </hc-accordion>
+                </div>
+            </hc-tile>
+        </div>
     </div>
-</hc-subnav>
-<hc-tab-set class="full-height">
-    <hc-tab tabTitle="About Modal" routerLink="/styles/about"> About Modal </hc-tab>
-    <hc-tab tabTitle="Breadcrumbs" routerLink="/styles/breadcrumbs"> Breadcrumbs </hc-tab>
-    <hc-tab tabTitle="Charts" routerLink="/styles/chart"> Charts </hc-tab>
-    <hc-tab tabTitle="Code" routerLink="/styles/code"> Code </hc-tab>
-    <hc-tab tabTitle="Colors" routerLink="/styles/color"> Colors </hc-tab>
-    <hc-tab tabTitle="Icons" routerLink="/styles/icons"> Icons </hc-tab>
-    <hc-tab tabTitle="Error Pages" routerLink="/styles/error"> Error Pages </hc-tab>
-    <hc-tab tabTitle="Login Page" routerLink="/styles/login"> Login Page </hc-tab>
-    <hc-tab tabTitle="Tables" routerLink="/styles/table"> Tables </hc-tab>
-    <hc-tab tabTitle="Typography" routerLink="/styles/typography"> Typography </hc-tab>
-</hc-tab-set>
+    <div class="hc-components-right-column">
+        <hc-tab-set class="full-height">
+            <hc-tab tabTitle="About Modal" routerLink="/styles/about"> About Modal </hc-tab>
+            <hc-tab tabTitle="Breadcrumbs" routerLink="/styles/breadcrumbs"> Breadcrumbs </hc-tab>
+            <hc-tab tabTitle="Charts" routerLink="/styles/chart"> Charts </hc-tab>
+            <hc-tab tabTitle="Code" routerLink="/styles/code"> Code </hc-tab>
+            <hc-tab tabTitle="Colors" routerLink="/styles/color"> Colors </hc-tab>
+            <hc-tab tabTitle="Icons" routerLink="/styles/icons"> Icons </hc-tab>
+            <hc-tab tabTitle="Error Pages" routerLink="/styles/error"> Error Pages </hc-tab>
+            <hc-tab tabTitle="Login Page" routerLink="/styles/login"> Login Page </hc-tab>
+            <hc-tab tabTitle="Tables" routerLink="/styles/table"> Tables </hc-tab>
+            <hc-tab tabTitle="Typography" routerLink="/styles/typography"> Typography </hc-tab>
+        </hc-tab-set>
+    </div>
+</div>

--- a/src/app/styles/styles.component.ts
+++ b/src/app/styles/styles.component.ts
@@ -5,7 +5,8 @@ import {Subject} from 'rxjs';
 
 @Component({
     selector: 'hc-demo-styles',
-    templateUrl: './styles.component.html'
+    templateUrl: './styles.component.html',
+    styleUrls: ['../components/components.component.scss']
 })
 export class StylesComponent implements OnDestroy {
     thisPage = '';
@@ -41,10 +42,17 @@ export class StylesComponent implements OnDestroy {
             for (let entry of root.children) {
                 if (entry.data && event === entry.data.title) {
                     this.router.navigate(['/styles/' + entry.path]);
+                    window.scrollTo(0, 0);
                     break;
                 }
             }
         }
+    }
+
+    // Handle nav changes via the sidebar
+    navUpdate(page: any) {
+        this.router.navigate(['/styles/' + page]);
+        window.scrollTo(0, 0);
     }
 
     ngOnDestroy(): void {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -19,10 +19,9 @@ body {
 }
 
 .demo-content {
-    width: 90%;
+    width: 95%;
     max-width: 1000px;
     margin: 0 auto;
-    padding: 0 30px 50px;
 
     ul {
         margin: 12px 0;
@@ -42,6 +41,25 @@ body {
 
 .full-height > .hc-vertical-tab-container {
     min-height: calc(100vh - 53px);
+}
+
+.full-height > .hc-vertical-tab-container > .hc-tab-bar-vertical {
+    display: none;
+}
+
+.full-height > .hc-vertical-tab-container > .hc-tab-content-vertical {
+    width: 100% !important;
+}
+
+.hc-components-nav-container {
+    .hc-accordion-content {
+        padding: 0 !important;
+    }
+
+    .hc-accordion-toolbar {
+        color: $dark-blue;
+        font-weight: 600;
+    }
 }
 
 .responsive-subnav {
@@ -74,11 +92,7 @@ body {
     .responsive-subnav {
         display: flex !important;
     }
-    .full-height > .hc-vertical-tab-container > .hc-tab-bar-vertical {
-        display: none;
-    }
     .full-height > .hc-vertical-tab-container > .hc-tab-content-vertical {
-        width: 100% !important;
         margin-top: 52px;
     }
     hc-tile {


### PR DESCRIPTION
Some much needed improvements to the navigation of the demo site.  You'll see that I kept the `hc-tabs` because I didn't want to reinvent the wheel on all its routing functionality, but I hid the left portion and replaced it with my new fixed navigation tile (leveraging our `hc-accordion` component)

For anyone on a Windows computer, can you send me a screenshot of what the scrollbar on the left nav tile looks like when you expand several sections?  Not totally sure whether the tile will expand horizontally to accommodate it or if it will stick out off the edge.

closes #655