### PR TITLE
fix(hc-banner): flex start justify content

### DIFF
--- a/projects/cashmere/src/lib/banner/hc-banner.scss
+++ b/projects/cashmere/src/lib/banner/hc-banner.scss
@@ -5,7 +5,7 @@
 .hc-banner {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     width: 100%;
     padding: 10px;
     z-index: $zindex-subnav;


### PR DESCRIPTION
There are some flex box issues with IE that can be solved with setting the justify-content to
flex-start

#### Before
![image](https://user-images.githubusercontent.com/3075414/51875605-e935fb00-2322-11e9-871d-9d7c043cc7e7.png)

#### After
(Ignore the small chunk of scroll bar that's covering some of the banner, there are tons of other IE issues at the moment...)
![image](https://user-images.githubusercontent.com/3075414/51875616-efc47280-2322-11e9-8e69-220b381f6c09.png)

Thanks @YaroBear for finding this solution and helping me out!

Fixes issue #684 
