### PR TITLE
fix(app-switcher): make app switcher configuration more flexible

### DIFF
--- a/projects/cashmere/src/lib/app-switcher/app-switcher.service.spec.ts
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.service.spec.ts
@@ -1,0 +1,150 @@
+import {TestBed, async, inject} from '@angular/core/testing';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import {AppSwitcherService} from './app-switcher.service';
+import {APP_SWITCHER_CONFIG} from './app-switcher-interfaces';
+
+describe('AppSwitcherService', () => {
+    describe('when initialized with a discoveryServiceUri ending in a version', () => {
+        let service: AppSwitcherService;
+
+        beforeEach(async(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule],
+                providers: [AppSwitcherService, {provide: APP_SWITCHER_CONFIG, useValue: {discoveryServiceUri: 'foo://bar/baz/v1'}}]
+            });
+        }));
+
+        beforeEach(() => (service = TestBed.get(AppSwitcherService)));
+
+        it('should have the correct allApplicationsUri', () => {
+            expect(service.allApplicationsUri).toBe('foo://bar/baz/apps');
+        });
+
+        it('should use the correct uri when fetching services', async(
+            inject([HttpTestingController], (httpMock: HttpTestingController) => {
+                service.getApplications().subscribe();
+
+                const req = httpMock.expectOne(
+                    `foo://bar/baz/v1/Services?$filter=DiscoveryType eq 'Application' and IsHidden eq false&$top=12`,
+                    'DiscoveryService call'
+                );
+                req.flush([]);
+                httpMock.verify();
+            })
+        ));
+    });
+
+    describe('when initialized with a discoveryServiceUri ending in a version and a slash', () => {
+        let service: AppSwitcherService;
+
+        beforeEach(async(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule],
+                providers: [AppSwitcherService, {provide: APP_SWITCHER_CONFIG, useValue: {discoveryServiceUri: 'foo://bar/baz/v1/'}}]
+            });
+        }));
+
+        beforeEach(() => (service = TestBed.get(AppSwitcherService)));
+
+        it('should have the correct allApplicationsUri', () => {
+            expect(service.allApplicationsUri).toBe('foo://bar/baz/apps');
+        });
+
+        it('should use the correct uri when fetching services', async(
+            inject([HttpTestingController], (httpMock: HttpTestingController) => {
+                service.getApplications().subscribe();
+
+                const req = httpMock.expectOne(
+                    `foo://bar/baz/v1/Services?$filter=DiscoveryType eq 'Application' and IsHidden eq false&$top=12`,
+                    'DiscoveryService call'
+                );
+                req.flush([]);
+                httpMock.verify();
+            })
+        ));
+    });
+
+    describe('when initialized with a discoveryServiceUri not ending in a version', () => {
+        let service: AppSwitcherService;
+
+        beforeEach(async(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule],
+                providers: [AppSwitcherService, {provide: APP_SWITCHER_CONFIG, useValue: {discoveryServiceUri: 'foo://bar/baz/'}}]
+            });
+        }));
+
+        beforeEach(() => (service = TestBed.get(AppSwitcherService)));
+
+        it('should have the correct allApplicationsUri', () => {
+            expect(service.allApplicationsUri).toBe('foo://bar/baz/apps');
+        });
+
+        it('should use the correct uri when fetching services', async(
+            inject([HttpTestingController], (httpMock: HttpTestingController) => {
+                service.getApplications().subscribe();
+
+                const req = httpMock.expectOne(
+                    `foo://bar/baz/v1/Services?$filter=DiscoveryType eq 'Application' and IsHidden eq false&$top=12`,
+                    'DiscoveryService call'
+                );
+                req.flush([]);
+                httpMock.verify();
+            })
+        ));
+    });
+
+    describe('when initialized with a discoveryServiceUri not ending in a slash', () => {
+        let service: AppSwitcherService;
+
+        beforeEach(async(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule],
+                providers: [AppSwitcherService, {provide: APP_SWITCHER_CONFIG, useValue: {discoveryServiceUri: 'foo://bar/baz'}}]
+            });
+        }));
+
+        beforeEach(() => (service = TestBed.get(AppSwitcherService)));
+
+        it('should have the correct allApplicationsUri', () => {
+            expect(service.allApplicationsUri).toBe('foo://bar/baz/apps');
+        });
+
+        it('should use the correct uri when fetching services', async(
+            inject([HttpTestingController], (httpMock: HttpTestingController) => {
+                service.getApplications().subscribe();
+
+                const req = httpMock.expectOne(
+                    `foo://bar/baz/v1/Services?$filter=DiscoveryType eq 'Application' and IsHidden eq false&$top=12`,
+                    'DiscoveryService call'
+                );
+                req.flush([]);
+                httpMock.verify();
+            })
+        ));
+    });
+
+    describe('when not provided an APP_SWITCHER_CONFIG', () => {
+        beforeEach(async(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule],
+                providers: [AppSwitcherService]
+            });
+        }));
+        it('should throw an error', () => {
+            expect(() => TestBed.get(AppSwitcherService)).toThrowError();
+        });
+    });
+
+    describe('when provided an APP_SWITCHER_CONFIG without a discoveryServiceUri', () => {
+        beforeEach(async(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule],
+                providers: [AppSwitcherService, {provide: APP_SWITCHER_CONFIG, useValue: {}}]
+            });
+        }));
+        it('should throw an error', () => {
+            expect(() => TestBed.get(AppSwitcherService)).toThrowError();
+        });
+    });
+});

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.service.ts
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.service.ts
@@ -4,16 +4,35 @@ import {HttpClient} from '@angular/common/http';
 import {Inject, Injectable} from '@angular/core';
 import {IAppSwitcherConfig, IAppSwitcherService, IDiscoveryRequest, APP_SWITCHER_CONFIG} from './app-switcher-interfaces';
 
+/**
+ * An app switcher service designed to work with the Health Catalyst DOS platform's DiscoveryService
+ */
 @Injectable()
 export class AppSwitcherService implements IAppSwitcherService {
     readonly allApplicationsUri: string;
+    private readonly discoveryServiceUri: string;
 
     constructor(private http: HttpClient, @Inject(APP_SWITCHER_CONFIG) private config: IAppSwitcherConfig) {
-        this.allApplicationsUri = `${this.config.discoveryServiceUri}/apps`;
+        if (!config || !config.discoveryServiceUri) {
+            throw new Error(
+                [
+                    'Failed to initialize AppSwitcherService: invalid APP_SWITCHER_CONFIG.',
+                    'You must provide a config object with a `discoveryServiceUri`.',
+                    `(value provided: ${config ? config.discoveryServiceUri : config})`
+                ].join(' ')
+            );
+        }
+
+        this.discoveryServiceUri = this.normalizeUri(this.config.discoveryServiceUri);
+        this.allApplicationsUri = `${this.discoveryServiceUri}/apps`;
     }
 
     getApplications(): Observable<IDiscoveryRequest> {
-        const url = `${this.config.discoveryServiceUri}/Services?$filter=DiscoveryType eq 'Application' and IsHidden eq false&$top=12`;
-        return this.http.get<IDiscoveryRequest>(url, {withCredentials: true}) as any;
+        const url = `${this.discoveryServiceUri}/v1/Services?$filter=DiscoveryType eq 'Application' and IsHidden eq false&$top=12`;
+        return this.http.get<IDiscoveryRequest>(url, {withCredentials: true});
+    }
+
+    private normalizeUri(uri: string): string {
+        return uri.replace(/\/(v\d+\/?)?$/, '');
     }
 }

--- a/projects/cashmere/src/lib/navbar/navbar.md
+++ b/projects/cashmere/src/lib/navbar/navbar.md
@@ -52,7 +52,7 @@ In addition to the help menu, all Heath Catalyst applications should also includ
 </hc-navbar>
 ```
 
-The app switcher service must be setup in order for the application switcher to function. The discovery service uri is required to set this up
+The app switcher service must be set up in order for the application switcher to function. The discovery service uri is required to set this up
 
 ```Typescript
 import { NavbarModule, AppSwitcherModule, IconModule, PopoverModule, ListModule,
@@ -67,6 +67,33 @@ import { NavbarModule, AppSwitcherModule, IconModule, PopoverModule, ListModule,
     exports: [NavbarModule, AppSwitcherModule, IconModule, PopoverModule, ListModule, SelectModule]
 })
 export class CashmereModule {}
+...
+```
+
+When the discovery service uri is determined at runtime (via configuration), you must register a custom app switcher config provider.
+_(The reason you can't use `forRoot` for this is that the Angular AOT compiler will evaluate the expression (i.e. `window.discoveryServiceUri`)
+at build-time using NodeJS and replace it with `null`.)_
+
+```Typescript
+import { NavbarModule, AppSwitcherModule, IconModule, PopoverModule, ListModule,
+    SelectModule, APP_SWITCHER_CONFIG, IAppSwitcherConfig } from '@healthcatalyst/cashmere';
+
+@NgModule({
+    imports: [
+        AppSwitcherModule
+    ],
+    providers: [
+        {provide: APP_SWITCHER_CONFIG, useFactory: getAppSwitcherConfig}
+    ],
+    exports: [AppSwitcherModule, ...]
+})
+export class CashmereModule {}
+
+function getAppSwitcherConfig() {
+    return {
+        discoveryServiceUri: window.discoveryServiceUri
+    } as IAppSwitcherConfig;
+}
 ...
 ```
 


### PR DESCRIPTION
add validation and normalization for the app switcher configuration; also provide documentation on
how to provide discoveryServiceUri to the app swithcer at runtime (as opposed to AOT build time)

fix related to this conversation:

Joe Skeen [4 hours ago]
Is anyone using the Cashmere App Switcher in a DOS app?  I've tried a few ways to hook up the discovery service and only getting part of it to work.  In IDEA, the `discoveryServiceUri` is being hard-coded to `'/DiscoveryService`, but it should be getting that value instead from the web.config.  In Atlas I'm able to pass in `window.discoveryServiceRoot`, which makes getting the apps work, but not the "All Apps" page (it goes to `/DiscoveryService/v1/apps` which is a 404

Ty Jones [4 hours ago]
We were seeing some bugs around that where the production build was stripping out the Disco Service URL. @ben.anderson and I tried figuring out a way around it, but were unsuccessful. I did snooze a GitHub notification around an issue for this with a potential fix though: https://github.com/angular/angular-cli/issues/9929 (edited)

Joe Skeen [4 hours ago]
I ended up fixing it for Atlas by using a function (I can help you with that if you need)

Ty Jones [4 hours ago]
Did you try using the prod settings with AOT?

Joe Skeen [4 hours ago]
(the prod build issue)

Joe Skeen [4 hours ago]
yes

Ty Jones [4 hours ago]
We have a function, but it strips it out

Ty Jones [4 hours ago]
```export function getDiscoveryServiceRootUri(): string {
    return (<any>window).discoveryServiceRoot;
}

@NgModule({
    imports: [
        AppSwitcherModule.forRoot({
            discoveryServiceUri: getDiscoveryServiceRootUri()
        })
    ]
})
export class AppModule { }```

Joe Skeen [4 hours ago]
this is how I get it to work:

```...

export function init(identityService: FabricIdentityService) {
    return () => {
        return identityService.login().toPromise();
    };
}

export function getAppSwitcherConfig() {
    return {
        discoveryServiceUri: (window as any).discoveryServiceRoot
    } as IAppSwitcherConfig;
}

@NgModule({
    declarations: [AppComponent, PageNotFoundComponent, SearchWidgetComponent],
    imports: [
     ...
    ],
    providers: [
        {
            provide: APP_INITIALIZER,
            useFactory: init,
            deps: [FabricIdentityService],
            multi: true
        },
        {
            provide: APP_SWITCHER_CONFIG,
            useFactory: getAppSwitcherConfig
        },
        Title,
        PageNotFoundRouteActivator,
        NavbarRouteActivator,
        ValueSetLibraryConfigService,
        SharedCommentsService
    ],
    entryComponents: [SearchWidgetComponent],
    bootstrap: [AppComponent]
})
export class AppModule {}```

(edited)

Ty Jones [4 hours ago]
I believe we tried using those tokens, but I don't remember. I'm interested in trying that out to see if it works for us!

Joe Skeen [4 hours ago]
You can't use `forRoot` because AOT runs the actual code using Node.JS and `window` is not defined

Joe Skeen [4 hours ago]
but since it's wired in as a provider, you don't have that issue as that is determined at runtime rather than at buildtime

Ty Jones [4 hours ago]
Got it! That makes sense. I'm not all that familiar with AOT. I'll add this thread to the bug report so we can get a fix for it! Thanks @Joe Skeen!

Joe Skeen [4 hours ago]
This is where it clicked for me: https://healthcatalyst.slack.com/archives/C18TTJA1W/p1549326442837500
Joe Skeen
Finally figured it out: https://github.com/angular/angular-cli/issues/10957#issuecomment-391166731
From a thread in #pe-data-governanceYesterday at 5:27 PMView reply

Ty Jones [4 hours ago]
@ben.anderson :this:

Ben Anderson [4 hours ago]
Thank, you :thank-you-ty:

Joe Skeen [4 hours ago]
but anyway, I'm still stuck on the All Apps link.  I'm not sure what value I'm supposed to provide.  Do I have to trim off the `/v1`?

Joe Skeen [4 hours ago]
it feels like a hack, but I'm going to try it

Ty Jones [4 hours ago]
That might be the case. We're a little inconsistent about that across our configurations I think.

Ty Jones [4 hours ago]
For example, some of the `/ping` endpoints require no version number

Joe Skeen [4 hours ago]
I mean, which version are we pinging?

Joe Skeen [4 hours ago]
Whatever the case, I think we need to add some documentation to Cashmere about how to correctly hook up the App Switcher

Joe Skeen [4 hours ago]
the closest thing we have is the StackBlitz that shows how to hook up a fake app switcher service

Joe Skeen [4 hours ago]
quick review @ty.jones @ben.anderson?
```export function getAppSwitcherConfig() {
    const discoveryServiceRoot: string = (window as any).discoveryServiceRoot;
    if (!discoveryServiceRoot) {
        throw new Error('Unable to initialize app switcher.  `discoveryServiceRoot` was not found on `window`.');
    }

    return {
        discoveryServiceUri: stripVersion(discoveryServiceRoot)
    } as IAppSwitcherConfig;

    function stripVersion(url: string): string {
        return url.replace(/v\d+\/?$/, '');
    }
}```
(edited)

Ty Jones [4 hours ago]
Looks good to me, aside from my weak regex skills to verify that it's correct, but it looks ok to me there too!

Joe Skeen [4 hours ago]
I just added a `$` to only match at the end of the string

Ty Jones [4 hours ago]
Yeah I saw the update in real time haha

Ben Anderson [4 hours ago]
THere is instuctions how to set it up here: https://cashmere.healthcatalyst.net/components/navbar/usage

Ben Anderson [4 hours ago]
Are you suggestion we need better instructions for a scenario like this?

Joe Skeen [4 hours ago]
well, there are a couple issues with the examples there

Ben Anderson [4 hours ago]
Looks good to me btw

Joe Skeen [4 hours ago]
1. the discovery service URL shouldn't be hard coded, after all it could be installed at any URL

Joe Skeen [4 hours ago]
2. if you try to get the URL from `window.` then when you run AOT build it will become `null`

Joe Skeen [4 hours ago]
so for practical applications, you can't actually use `forRoot`

Joe Skeen [4 hours ago]
The docs show how to implement a custom app switcher, but not how to wire it up with a runtime-determined value for discoveryServiceUri

Joe Skeen [4 hours ago]
does that make sense?

Ben Anderson [4 hours ago]
kind of

Ben Anderson [4 hours ago]
`getApplications` returns an observable, you could read the discovery service url however you want, and get the applications from the discovery service yourself

Ben Anderson [4 hours ago]
in that example its set at compile time, but you could chain a call to get that url, then call the disco service

Joe Skeen [4 hours ago]
sorry, I'm not meaning in a custom app switcher, I want to use the built-in one but provide the URL at runtime

Ben Anderson [4 hours ago]
oh I see. Ya. I think we could improve the docs for your scenario

Joe Skeen [4 hours ago]
if you don't wire it up with the `APP_SWITCHER_CONFIG` token, AOT will break it

Ben Anderson [4 hours ago]
right

Joe Skeen [4 hours ago]
right :slightly_smiling_face:

Ben Anderson [4 hours ago]
The built in AppSwitcherService isn't anything special though

Joe Skeen [4 hours ago]
sure, but why reinvent the wheel if it works?

Joe Skeen [1 hour ago]
hmm... might have to implement our own anyway. The Cashmere app switcher service (current version) doesn't append a `/v1` anymore like it used to.  This means that either it can load the list of apps, or it can generate the all apps url correctly, but not both :disappointed:

Joe Skeen [1 hour ago]
as that service is tightly coupled with the implementation of the discovery service, wouldn't it make sense to have it append the `/v1`?  https://github.com/HealthCatalyst/Fabric.Cashmere/blob/dev/projects/cashmere/src/lib/app-switcher/app-switcher.service.ts#L16
projects/cashmere/src/lib/app-switcher/app-switcher.service.ts:16
        ```const url = `${this.config.discoveryServiceUri}/Services?$filter=DiscoveryType eq 'Application' and IsHidden eq false&$top=12`;```
HealthCatalyst/Fabric.CashmereAdded by GitHub

Joe Skeen [1 hour ago]
it's funny because IDEA is using an older version of Cashmere (before the injection tokens) and it works great but the current version on Atlas does not https://github.com/HealthCatalyst/Fabric.Cashmere/commit/9ae5bd8cb357344bff2b04309327f623ca8d663a#diff-13b27b4b1097df4c5e12ba5e9ac20abdL28 (edited)

Joe Skeen [1 hour ago]
I think I'll submit a PR to fix this