### PR TITLE
fix(all): IE11 nav css fix

### DIFF
--- a/projects/cashmere/src/lib/sass/_subnav.scss
+++ b/projects/cashmere/src/lib/sass/_subnav.scss
@@ -3,6 +3,7 @@
 
 .subnav {
     width: 100%;
+    height: 52px;
     min-height: 52px;
     box-sizing: border-box;
     padding: 8px 20px;

--- a/src/app/components/components.component.scss
+++ b/src/app/components/components.component.scss
@@ -21,6 +21,7 @@
     margin-top: 20px;
     position: fixed;
     min-width: 250px;
+    left: 23px;
 
     hc-tile {
         padding: 10px 15px;


### PR DESCRIPTION
Corrects positioning of nav elements in IE11 on the demo site.  A few interesting learnings to note here:

- IE doesn't handle `position: fixed` the same as Chrome.  You need to set a `left` value or the element will just be floating out wherever.
- IE doesn't handle the flex parameter `align-items: center;` for vertical alignment unless a height is set for the element.  If only `min-height` is set, it won't work.

closes #707