### PR TITLE
fix(button): IE11 split button width

### DIFF
--- a/projects/cashmere/src/lib/sass/button.scss
+++ b/projects/cashmere/src/lib/sass/button.scss
@@ -219,7 +219,7 @@ $btn-icon-sz: 18px;
     margin-right: 0;
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
-    min-width: unset;
+    min-width: auto;
 }
 
 @mixin hc-split-button-toggle() {


### PR DESCRIPTION
IE11 fix to fix min-width constraint on split buttons

closes #698