### PR TITLE
Ie select

### DIFF
--- a/projects/cashmere-examples/src/lib/select-disabled/select-disabled-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-disabled/select-disabled-example.component.html
@@ -2,8 +2,8 @@
     <hc-form-field inline>
         <hc-label>Select your facility:</hc-label>
         <hc-select disabled placeholder="Select a city:">
-            <option>Philadelphia</option>
-            <option>Atlanta</option>
+            <option value="1">Philadelphia</option>
+            <option value="2">Atlanta</option>
         </hc-select>
     </hc-form-field>
 </div>

--- a/projects/cashmere-examples/src/lib/select-standard/select-standard-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-standard/select-standard-example.component.html
@@ -2,11 +2,11 @@
     <hc-form-field>
         <hc-label>Facility Location:</hc-label>
         <hc-select placeholder="Select a city:">
-            <option>Philadelphia</option>
-            <option>Atlanta</option>
-            <option>Salt Lake City</option>
-            <option>Chicago</option>
-            <option>Orlando</option>
+            <option value="1">Philadelphia</option>
+            <option value="2">Atlanta</option>
+            <option value="3">Salt Lake City</option>
+            <option value="4">Chicago</option>
+            <option value="5">Orlando</option>
         </hc-select>
     </hc-form-field>
 </div>

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -36,8 +36,9 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 @mixin hc-form-field-content-wrapper() {
-    display: grid;
+    display: flex;
     flex-direction: inherit;
+    flex-wrap: wrap;
     width: 100%;
 }
 

--- a/projects/cashmere/src/lib/select/select.md
+++ b/projects/cashmere/src/lib/select/select.md
@@ -1,13 +1,15 @@
 The hc-select component may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.
 
+Note that for IE11 compatibility, a value must be specified for each `<option>` in `<hc-select>`. Otherwise the select box will not display the selected option.
+
 To add a label use an hc-label within a hc-form-field. If the select box is required add the required attribute and an asterisk will be shown next to the label.
 
 ```html
 <hc-form-field>
     <hc-label>Select your facility:</hc-label>
     <hc-select required placeholder="Select a city:">
-        <option>Philadelphia</option>
-        <option>Atlanta</option>
+        <option value="1">Philadelphia</option>
+        <option value="2">Atlanta</option>
     </hc-select>
     <hc-error>Facility is required</hc-error>
 </hc-form-field>


### PR DESCRIPTION
Corrects display type on form field content wrapper for IE11.  Another interesting finding: our select boxes will not display properly in IE11 unless a `value` is set in the `<option>` tag.  I've added this to the usage doc for select in case anyone reads it, and corrected any examples that didn't have values set.

closes #702, closes #691
