### PR TITLE
fix(input): IE11 vertical alignment

### DIFF
--- a/projects/cashmere/src/lib/sass/input.scss
+++ b/projects/cashmere/src/lib/sass/input.scss
@@ -11,10 +11,7 @@
     padding: 0;
     margin: 0;
     width: 100%;
-
     max-width: 100%;
-
-    vertical-align: bottom;
     text-align: inherit;
 
     &[disabled] {


### PR DESCRIPTION
corrects vertical alignment for input text boxes in IE11

closes #692