### PR TITLE
fix(about): center header

### DIFF
--- a/projects/cashmere/src/lib/sass/about-modal.scss
+++ b/projects/cashmere/src/lib/sass/about-modal.scss
@@ -26,6 +26,7 @@
 }
 .about-app-title {
     height: 40px;
+    width: 342px;
 }
 
 .about-version {


### PR DESCRIPTION
adds an explicit svg img width for IE11

closes #699