### PR TITLE
fix(table): border width fix

### DIFF
--- a/projects/cashmere/src/lib/sass/tables.scss
+++ b/projects/cashmere/src/lib/sass/tables.scss
@@ -5,7 +5,8 @@
 
 $table-border: 2px solid $slate-gray-300 !default;
 $table-border-interior: 1px solid $slate-gray-300 !default;
-$table-border-transparent: 1px solid transparent;
+$table-border-off-transparent: 1px solid transparent;
+$table-border-transparent: 2px solid transparent;
 $table-condensed-font-size: 13px;
 $header-border-thick: 2px solid $slate-gray-300 !default;
 $cell-padding: 8px 16px !default;
@@ -30,7 +31,7 @@ table.hc-table {
     width: 100%;
     max-width: 100%;
     color: $tbody-font-color;
-    border: $table-border-transparent;
+    border: $table-border-off-transparent;
 
     td,
     th {
@@ -104,6 +105,8 @@ table.hc-table {
 
     // Add Borders
     &.hc-table-borders {
+        border: $table-border-transparent;
+
         td,
         th {
             border: $table-border;


### PR DESCRIPTION
corrects table border padding for thicker border tables which was causing IE11 to display overflow scroll bars where it shouldn't be.

closes #696