### PR TITLE
fix(datepicker): IE11 flex layout

### DIFF
--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.scss
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.scss
@@ -5,7 +5,6 @@
 }
 
 .hc-date-range-calendar-item {
-    flex-basis: 33.33%;
     min-width: 210px;
     padding: 1em;
     font-size: 14px;


### PR DESCRIPTION
changes `flex-basis` to auto (the default value) for each column for compatibility

closes #704