### PR TITLE
fix(navbar): IE11 logo display style

### DIFF
--- a/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
@@ -13,7 +13,9 @@
         <span class="hc-text-ellipsis">{{ username }}</span>
         <hc-icon fontSet="fa" fontIcon="fa-angle-down"></hc-icon>
     </div>
-    <hc-navbar-mobile-menu>
+    <!-- Inline style is added for example only to prevent its mobile menu from colliding with Cashmere site navigation -->
+    <!-- Do NOT include style="display: none;" in your hc-navbar-mobile-menu tag -->
+    <hc-navbar-mobile-menu style="display: none;">
         <hc-list>
             <hc-list-item routerLink="undefined" routerLinkActive="active-link"><span hcListLine>Home</span></hc-list-item>
             <hc-list-item routerLink="undefined" routerLinkActive="active-link"><span hcListLine>Oncology</span></hc-list-item>

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -57,9 +57,6 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
 @mixin navbar-app {
     height: 100%;
     padding: $navbar-app-padding;
-    display: flex;
-    justify-content: center;
-    align-items: center;
 
     &.logo-condense {
         padding-right: 25px;


### PR DESCRIPTION
Removes flex style on navbar logo to prevent IE11 from collapsing on it.  Also noticed that at the mobile breakpoint on IE, the second mobile menu was visible.  But on all browsers, when the second example's mobile menu was opened, it couldn't be closed (because it was behind the main site nav).  So I hid the navbar in the example, but included a comment so devs would know that shouldn't go in their code if they're copy/pasting.

closes #705