### PR TITLE
style(table): border styles

### DIFF
--- a/projects/cashmere/src/lib/sass/tables.scss
+++ b/projects/cashmere/src/lib/sass/tables.scss
@@ -3,12 +3,10 @@
 @import './colors';
 @import './mixins';
 
-$table-border: 2px solid $slate-gray-300 !default;
-$table-border-interior: 1px solid $slate-gray-300 !default;
-$table-border-off-transparent: 1px solid transparent;
-$table-border-transparent: 2px solid transparent;
+$table-border: 1px solid $slate-gray-300 !default;
+$table-border-transparent: 1px solid transparent;
 $table-condensed-font-size: 13px;
-$header-border-thick: 2px solid $slate-gray-300 !default;
+$header-border-thick: 1px solid $slate-gray-300 !default;
 $cell-padding: 8px 16px !default;
 $cell-padding-condensed: 6px 16px !default;
 $thead-font-size: 14px !default;
@@ -31,11 +29,11 @@ table.hc-table {
     width: 100%;
     max-width: 100%;
     color: $tbody-font-color;
-    border: $table-border-off-transparent;
+    border: $table-border-transparent;
 
     td,
     th {
-        border-bottom: $table-border-interior;
+        border-bottom: $table-border;
         border-top: none;
         line-height: 1.3;
         padding: $cell-padding;
@@ -62,7 +60,7 @@ table.hc-table {
 
     tbody {
         font-size: $tbody-font-size;
-        border: $table-border-interior;
+        border: $table-border;
 
         tr {
             &:nth-child(2n) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -201,7 +201,7 @@ table {
     tbody > tr:not(:last-child) > {
         td,
         th {
-            border-bottom: 1px dashed $gray-200;
+            border-bottom: 1px solid $gray-300;
         }
     }
 


### PR DESCRIPTION
Reduces bordered tables to 1px width; fixes dashed rows on demo site.  The 2px thickness on the bordered version of tables has always felt too heavy to me.

closes #700