### PR TITLE
fix(app-switcher): add to entryComponents

### DIFF
--- a/projects/cashmere/src/lib/app-switcher/app-switcher.module.ts
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.module.ts
@@ -14,6 +14,7 @@ import {IconModule} from '../icon/icon.module';
     imports: [CommonModule, PopoverModule, HttpClientModule, PipesModule, IconModule],
     declarations: [AppSwitcherComponent, AppSwitcherLinksComponent],
     exports: [AppSwitcherComponent, AppSwitcherLinksComponent],
+    entryComponents: [AppSwitcherComponent],
     providers: [
         {
             provide: APP_SWITCHER_SERVICE,


### PR DESCRIPTION
add AppSwitcherComponent to NgModule.EntryComponents

Due to the issues with Popper.js in Atlas, I have tried to switch to an Angular CDK version for the App Switcher; unfortunately, the `AppSwitcherComponent` is not in `entryComponents` so it can't be used to create a `ComponentPortal`.  This should fix that.