### PR TITLE
fix(date-range): when dates are null minmax values are not enforced

### DIFF
--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
@@ -4,7 +4,7 @@
             [prefixLabel]="options.startDatePrefix"
             [selectedDate]="_fromDate"
             [minDate]="options.fromMinMax?.fromDate"
-            [maxDate]="!options.fromMinMax || !options.fromMinMax.toDate || !this._toDate || options.fromMinMax?.toDate > _toDate ? _toDate : options.fromMinMax?.toDate"
+            [maxDate]="_fromMaxDate | async"
             (selectedDateChange)="_updateFromDate($event)"
             [excludeWeekends]="options.excludeWeekends"
             [dateFormat]="options.dateFormat"
@@ -16,7 +16,7 @@
         <hc-calendar-wrapper
             [prefixLabel]="options.endDatePrefix"
             [selectedDate]="_toDate"
-            [minDate]="!options.toMinMax || !options.toMinMax.fromDate || !this._fromDate || options.toMinMax?.fromDate > _fromDate ? options.toMinMax?.fromDate : _fromDate"
+            [minDate]="_ToMinDate | async"
             [maxDate]="options.toMinMax?.toDate"
             (selectedDateChange)="_updateToDate($event)"
             [excludeWeekends]="options.excludeWeekends"

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
@@ -5,6 +5,7 @@ import {ConfigStoreService} from '../services/config-store.service';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {OverlayRef} from '@angular/cdk/overlay';
 import {PickerOverlayComponent} from './picker-overlay.component';
+import {tap} from 'rxjs/operators';
 
 class MockOverlayRef {
     dispose() {}
@@ -38,5 +39,149 @@ describe('RangeComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    describe('fromMaxDate', () => {
+        it('should be undefined if toDate and fromMinMax.toDate are null', async(() => {
+            return component._fromMaxDate
+                .pipe(
+                    tap((fromDate: Date | undefined) => {
+                        expect(fromDate).toBeUndefined();
+                    })
+                )
+                .subscribe();
+        }));
+
+        it('should be toDate if it is less than fromMinMax.toDate', async(() => {
+            component._toDate = new Date(2010, 1, 1);
+            const toDate = new Date(2010, 2, 1);
+            configStoreService.updateDateRangeOptions({
+                fromMinMax: {
+                    toDate
+                }
+            });
+            return component._fromMaxDate
+                .pipe(
+                    tap((fromDate: Date | undefined) => {
+                        expect(fromDate).toEqual(component._toDate);
+                    })
+                )
+                .subscribe();
+        }));
+
+        it('should be fromMinMax.toDate if it is less than toDate', async(() => {
+            component._toDate = new Date(2010, 2, 1);
+            const toDate = new Date(2010, 1, 1);
+            configStoreService.updateDateRangeOptions({
+                fromMinMax: {
+                    toDate
+                }
+            });
+            return component._fromMaxDate
+                .pipe(
+                    tap((fromDate: Date | undefined) => {
+                        expect(fromDate).toEqual(toDate);
+                    })
+                )
+                .subscribe();
+        }));
+
+        it('should default toDate when no fromMinMax.toDate is set', async(() => {
+            component._toDate = new Date(2010, 1, 1);
+            return component._fromMaxDate
+                .pipe(
+                    tap((fromDate: Date | undefined) => {
+                        expect(fromDate).toEqual(component._toDate);
+                    })
+                )
+                .subscribe();
+        }));
+
+        it('should be equal to fromMinMax.toDate', async(() => {
+            component._toDate = undefined;
+            const toDate = new Date(2011, 1, 1);
+            configStoreService.updateDateRangeOptions({
+                fromMinMax: {
+                    toDate
+                }
+            });
+            return component._fromMaxDate
+                .pipe(
+                    tap((fromDate: Date | undefined) => {
+                        expect(fromDate).toEqual(toDate);
+                    })
+                )
+                .subscribe();
+        }));
+    });
+
+    describe('ToMinDate', () => {
+        it('should be undefined if fromDate and toMinMax.fromDate are null', async(() => {
+            return component._ToMinDate
+                .pipe(
+                    tap((toDate: Date | undefined) => {
+                        expect(toDate).toBeUndefined();
+                    })
+                )
+                .subscribe();
+        }));
+
+        it('should be fromDate if it is greater than toMinMax.fromDate', async(() => {
+            component._fromDate = new Date(2010, 2, 1);
+            const fromDate = new Date(2010, 1, 1);
+            configStoreService.updateDateRangeOptions({
+                toMinMax: {
+                    fromDate
+                }
+            });
+            return component._ToMinDate
+                .pipe(
+                    tap((toDate: Date | undefined) => {
+                        expect(toDate).toEqual(component._fromDate);
+                    })
+                )
+                .subscribe();
+        }));
+
+        it('should be toMinMax.fromDate if it is greater than fromDate', async(() => {
+            component._fromDate = new Date(2010, 2, 1);
+            const fromDate = new Date(2010, 1, 1);
+            configStoreService.updateDateRangeOptions({
+                toMinMax: {
+                    fromDate
+                }
+            });
+            return component._ToMinDate
+                .pipe(
+                    tap((toDate: Date | undefined) => {
+                        expect(toDate).toEqual(component._fromDate);
+                    })
+                )
+                .subscribe();
+        }));
+
+        it('should default fromDate when no toMinMax.fromDate is set', async(() => {
+            component._fromDate = new Date(2010, 1, 1);
+            return component._ToMinDate.pipe(
+                tap((toDate: Date | undefined) => {
+                    expect(toDate).toEqual(component._toDate);
+                })
+            );
+        }));
+
+        it('should be equal to toMinMax.fromDate', async(() => {
+            component._toDate = undefined;
+            const fromDate = new Date(2011, 1, 1);
+            configStoreService.updateDateRangeOptions({
+                toMinMax: {
+                    fromDate
+                }
+            });
+            return component._ToMinDate.pipe(
+                tap((toDate: Date | undefined) => {
+                    expect(toDate).toEqual(toDate);
+                })
+            );
+        }));
     });
 });

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
@@ -6,6 +6,7 @@ import {DateRange} from '../model/model';
 import {D} from '../../datepicker/datetime/date-formats';
 import {CalendarWrapperComponent} from '../calendar-wrapper/calendar-wrapper.component';
 import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 
 // ** Date range wrapper component */
 @Component({
@@ -88,5 +89,35 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
 
     _setValidity() {
         this._disabled = !this._toDate || !this._fromDate;
+    }
+
+    get _fromMaxDate(): Observable<Date | undefined> {
+        return this.options$.pipe(
+            map(options => {
+                if (!options || !options.fromMinMax || !options.fromMinMax.toDate) {
+                    return this._toDate;
+                }
+                if (!this._toDate) {
+                    return options.fromMinMax.toDate;
+                }
+
+                return options.fromMinMax.toDate > this._toDate ? this._toDate : options.fromMinMax.toDate;
+            })
+        );
+    }
+
+    get _ToMinDate(): Observable<Date | undefined> {
+        return this.options$.pipe(
+            map(options => {
+                if (!options || !options.toMinMax || !options.toMinMax.fromDate) {
+                    return this._fromDate;
+                }
+                if (!this._fromDate) {
+                    return options.toMinMax.fromDate;
+                }
+
+                return options.toMinMax.fromDate < this._fromDate ? this._fromDate : options.toMinMax.fromDate;
+            })
+        );
     }
 }


### PR DESCRIPTION
When  I removed the start/end dates and used the year/month calendar views to set the start date to
a day in the future (which I was able to) and set the end date to "today's date". The "Apply" button
is enabled. In this scenario, I was expecting the "Apply" button to be

fix #763