### PR TITLE
fix(drawer): prevent animation interupt

### DIFF
--- a/projects/cashmere/src/lib/drawer/drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.ts
@@ -234,8 +234,6 @@ export class Drawer implements AfterContentInit {
 
     /** Toggles the drawer */
     toggle(isOpen: boolean = !this.opened): Promise<DrawerPromiseResult> {
-        this._drawerOpened = isOpen;
-
         if (!this._animationPromise) {
             this._drawerOpened = isOpen;
 


### PR DESCRIPTION
Stops the toggle function from interrupting animation and throwing an error.  I'm pretty sure this was a mistake in the toggle function because it was setting `_drawerOpened` twice both inside and outside of the `animationPromise` logic.  As best as I can tell the component wasn't written to have its animation interrupted - hence the error.

closes #766