### PR TITLE
test(radios): radio button unit tests

### DIFF
--- a/projects/cashmere/src/lib/radio-button/radio-button.component.spec.ts
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.spec.ts
@@ -1,24 +1,177 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {RadioButtonComponent} from './radio';
+import {RadioButtonComponent, RadioButtonChangeEvent} from './radio';
 import {RadioButtonModule} from './radio-button.module';
+import {Component, DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+
+@Component({
+    template: `
+        <div (click)="parentElementClicked = true" (keyup)="parentElementKeyedUp = true">
+            <hc-radio-button
+                [id]="radioId"
+                [required]="isRequired"
+                [checked]="isChecked"
+                [disabled]="isDisabled"
+                [value]="radioValue"
+                (change)="onRadioChange($event)"
+            >
+                Simple radio button
+            </hc-radio-button>
+        </div>
+    `
+})
+export class SingleRadioComponent {
+    isChecked: boolean = false;
+    isRequired: boolean = false;
+    isIndeterminate: boolean = false;
+    isDisabled: boolean = false;
+    parentElementClicked: boolean = false;
+    parentElementKeyedUp: boolean = false;
+    radioId: string | null = 'simple-radio';
+    radioValue: string = 'single_radio';
+
+    onRadioClick: (event?: Event) => void = () => {};
+    onRadioChange: (event?: RadioButtonChangeEvent) => void = () => {};
+}
 
 describe('RadioButtonComponent', () => {
-    let component: RadioButtonComponent;
-    let fixture: ComponentFixture<RadioButtonComponent>;
+    let fixture: ComponentFixture<any>;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [RadioButtonModule]
+            imports: [RadioButtonModule],
+            declarations: [SingleRadioComponent]
         }).compileComponents();
+        fixture = TestBed.createComponent(RadioButtonComponent);
     }));
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(RadioButtonComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+    describe('basic behaviors', () => {
+        let radioDebugElement: DebugElement;
+        let radioNativeElement: HTMLElement;
+        let radioInstance: RadioButtonComponent;
+        let testComponent: SingleRadioComponent;
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
+        let inputElement: HTMLInputElement;
+
+        beforeEach(() => {
+            fixture = TestBed.createComponent(SingleRadioComponent);
+            fixture.detectChanges();
+
+            radioDebugElement = fixture.debugElement.query(By.directive(RadioButtonComponent));
+            radioNativeElement = radioDebugElement.nativeElement;
+            radioInstance = radioDebugElement.componentInstance;
+            testComponent = fixture.debugElement.componentInstance;
+
+            inputElement = <HTMLInputElement>radioNativeElement.querySelector('input');
+
+            fixture.detectChanges();
+        });
+
+        it('should add and remove checked state', () => {
+            expect(radioInstance.checked).toBe(false);
+            expect(inputElement.checked).toBe(false);
+
+            testComponent.isChecked = true;
+            fixture.detectChanges();
+
+            expect(radioInstance.checked).toBe(true);
+            expect(inputElement.checked).toBe(true);
+
+            testComponent.isChecked = false;
+            fixture.detectChanges();
+
+            expect(radioInstance.checked).toBe(false);
+            expect(inputElement.checked).toBe(false);
+        });
+
+        it('should toggle checked state on click', () => {
+            expect(radioInstance.checked).toBe(false);
+
+            inputElement.click();
+            fixture.detectChanges();
+
+            expect(radioInstance.checked).toBe(true);
+        });
+
+        it('should change native element checked when check programmatically', () => {
+            expect(inputElement.checked).toBe(false);
+
+            radioInstance.checked = true;
+            fixture.detectChanges();
+
+            expect(inputElement.checked).toBe(true);
+        });
+
+        it('should add and remove disabled state', () => {
+            expect(radioInstance.disabled).toBe(false);
+            expect(inputElement.tabIndex).toBe(0);
+            expect(inputElement.disabled).toBe(false);
+
+            testComponent.isDisabled = true;
+            fixture.detectChanges();
+
+            expect(radioInstance.disabled).toBe(true);
+            expect(inputElement.disabled).toBe(true);
+
+            testComponent.isDisabled = false;
+            fixture.detectChanges();
+
+            expect(radioInstance.disabled).toBe(false);
+            expect(inputElement.tabIndex).toBe(0);
+            expect(inputElement.disabled).toBe(false);
+        });
+
+        it('should not toggle `checked` state upon interaction while disabled', () => {
+            testComponent.isDisabled = true;
+            fixture.detectChanges();
+
+            inputElement.click();
+            expect(radioInstance.checked).toBe(false);
+        });
+
+        it('should preserve the user-provided id', () => {
+            expect(radioNativeElement.id).toBe('simple-radio');
+            expect(inputElement.id).toBe('simple-radio-input');
+        });
+
+        it('should generate a unique id for the radio button input if no id is set', () => {
+            testComponent.radioId = null;
+            fixture.detectChanges();
+
+            expect(radioInstance._inputId).toMatch(/hc-radio-button-\d+/);
+            expect(inputElement.id).toBe(radioInstance._inputId);
+        });
+
+        it('should forward the required attribute', () => {
+            testComponent.isRequired = true;
+            fixture.detectChanges();
+
+            expect(inputElement.required).toBe(true);
+
+            testComponent.isRequired = false;
+            fixture.detectChanges();
+
+            expect(inputElement.required).toBe(false);
+        });
+
+        it('should forward the value to input element', () => {
+            testComponent.radioValue = 'basic_radio';
+            fixture.detectChanges();
+
+            expect(inputElement.value).toBe('basic_radio');
+        });
+
+        it('should emit a change event when clicked', () => {
+            spyOn(testComponent, 'onRadioChange');
+
+            expect(inputElement.checked).toBe(false);
+
+            inputElement.click();
+            fixture.detectChanges();
+
+            expect(inputElement.checked).toBe(true);
+
+            expect(testComponent.onRadioChange).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/projects/cashmere/src/lib/radio-button/radio-group.directive.spec.ts
+++ b/projects/cashmere/src/lib/radio-button/radio-group.directive.spec.ts
@@ -1,24 +1,39 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {FormsModule} from '@angular/forms';
-import {Component, DebugElement} from '@angular/core';
+import {FormsModule, NgModel} from '@angular/forms';
+import {Component, DebugElement, QueryList, ViewChildren} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {RadioGroupDirective} from './radio';
+import {RadioButtonChangeEvent, RadioGroupDirective} from './radio';
+import {RadioButtonModule} from './radio-button.module';
 
 @Component({
     template: `
-        <hc-radio-group [disabled]="true"></hc-radio-group>
+        <hc-radio-group [id]="groupId" [name]="groupName" [value]="groupValue" [disabled]="isDisabled" (change)="onGroupChange($event)">
+            <hc-radio-button [value]="oneValue" [checked]="oneChecked">Radio One</hc-radio-button>
+            <hc-radio-button [value]="twoValue" [checked]="twoChecked">Radio Two</hc-radio-button>
+        </hc-radio-group>
     `
 })
-class TestRadioGroupComponent {}
+class TestRadioGroupComponent {
+    oneChecked: boolean = true;
+    twoChecked: boolean = false;
+    oneValue: string = 'radio_one';
+    twoValue: string = 'radio_two';
+    groupId: string | null = 'simple-radio-group';
+    groupName: string | null = 'radio-group-name';
+    groupValue: string = 'radio_one';
+    isDisabled: boolean = false;
 
-describe('RadioButtonComponent', () => {
+    onGroupChange: (event?: RadioButtonChangeEvent) => void = () => {};
+}
+
+describe('RadioGroupComponent', () => {
     let component: TestRadioGroupComponent;
     let fixture: ComponentFixture<TestRadioGroupComponent>;
     let el: DebugElement;
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [TestRadioGroupComponent, RadioGroupDirective],
-            imports: [FormsModule]
+            declarations: [TestRadioGroupComponent],
+            imports: [FormsModule, RadioButtonModule]
         }).compileComponents();
     }));
 
@@ -33,8 +48,178 @@ describe('RadioButtonComponent', () => {
         expect(el).not.toBeNull();
     });
 
-    it('should read disabled attribute input as true', () => {
+    it('should preserve the user-provided id', () => {
         const directiveInstance = el.injector.get(RadioGroupDirective);
+        expect(directiveInstance.id).toBe('simple-radio-group');
+    });
+
+    it('should set the id for the radio group to the name if no id is set', () => {
+        component.groupId = null;
+        fixture.detectChanges();
+
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        expect(directiveInstance.id).toMatch('radio-group-name');
+    });
+
+    it('should set a unique id for the radio group if no name or id is set', () => {
+        component.groupId = null;
+        component.groupName = null;
+        fixture.detectChanges();
+
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        expect(directiveInstance.id).toMatch(/hc-radio-group-\d+/);
+    });
+
+    it('should store a list of the included radio buttons', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        expect(directiveInstance.radios).not.toBeNull();
+    });
+
+    it('should update the layout orientation', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        expect(directiveInstance.inline).toBe(false);
+
+        directiveInstance.inline = true;
+        fixture.detectChanges();
+
+        expect(directiveInstance.inline).toBe(true);
+
+        directiveInstance.inline = false;
+        fixture.detectChanges();
+
+        expect(directiveInstance.inline).toBe(false);
+    });
+
+    it('should set the group as required', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        expect(directiveInstance.required).toBe(false);
+
+        directiveInstance.required = true;
+        fixture.detectChanges();
+
+        expect(directiveInstance.required).toBe(true);
+
+        directiveInstance.required = false;
+        fixture.detectChanges();
+
+        expect(directiveInstance.required).toBe(false);
+    });
+
+    it('should set the group as disabled', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        expect(directiveInstance.disabled).toBe(false);
+
+        directiveInstance.disabled = true;
+        fixture.detectChanges();
+
         expect(directiveInstance.disabled).toBe(true);
+
+        directiveInstance.disabled = false;
+        fixture.detectChanges();
+
+        expect(directiveInstance.disabled).toBe(false);
+    });
+
+    it('should set radio buttons to disabled when the group is disabled', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        directiveInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(directiveInstance.radios.last.disabled).toBe(true);
+    });
+
+    it('should set the value of the group when a radio button is clicked', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+
+        let inputElement = <HTMLInputElement>directiveInstance.radios.last._elementRef.nativeElement.querySelector('input');
+        inputElement.click();
+
+        fixture.detectChanges();
+
+        expect(directiveInstance.value).toBe('radio_two');
+    });
+
+    it('should set the selected property of the group when a radio button is clicked', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        let inputElement = <HTMLInputElement>directiveInstance.radios.last._elementRef.nativeElement.querySelector('input');
+        inputElement.click();
+
+        let newValue = directiveInstance.selected;
+        fixture.detectChanges();
+
+        expect(directiveInstance.selected).not.toBeNull();
+        if (directiveInstance.selected) {
+            expect(directiveInstance.selected.value).toBe('radio_two');
+        }
+    });
+
+    it('should update the selected radio button when the groups value is changed', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+
+        directiveInstance.value = 'radio_two';
+        fixture.detectChanges();
+
+        expect(directiveInstance.radios.last.checked).toBe(true);
+    });
+
+    it('should emit a change event when a radio button is clicked', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+        spyOn(component, 'onGroupChange');
+
+        expect(directiveInstance.radios.last.checked).toBe(false);
+
+        let inputElement = <HTMLInputElement>directiveInstance.radios.last._elementRef.nativeElement.querySelector('input');
+        inputElement.click();
+        fixture.detectChanges();
+
+        expect(directiveInstance.radios.last.checked).toBe(true);
+
+        expect(component.onGroupChange).toHaveBeenCalledTimes(1);
     });
 });
+
+@Component({
+    template: `
+        <hc-radio-group [(ngModel)]="isGood">
+            <hc-radio-button value="one">One</hc-radio-button>
+            <hc-radio-button value="two">Two</hc-radio-button>
+        </hc-radio-group>
+    `
+})
+class RadioWithNgModelComponent {
+    isGood: string = 'one';
+}
+
+describe('RadioGroups with ngModel', () => {
+    let component: RadioWithNgModelComponent;
+    let fixture: ComponentFixture<RadioWithNgModelComponent>;
+    let el: DebugElement;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [RadioWithNgModelComponent],
+            imports: [RadioButtonModule, FormsModule]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(RadioWithNgModelComponent);
+        fixture.detectChanges();
+
+        component = fixture.componentInstance;
+        el = fixture.debugElement.query(By.directive(RadioGroupDirective));
+        fixture.detectChanges();
+    });
+
+    it('should set a value correctly using ngModel', () => {
+        const directiveInstance = el.injector.get(RadioGroupDirective);
+
+        let inputElement = <HTMLInputElement>directiveInstance.radios.last._elementRef.nativeElement.querySelector('input');
+        inputElement.click();
+        fixture.detectChanges();
+
+        expect(component.isGood).toBe('two');
+    });
+});
+
+

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -16,7 +16,8 @@ import {
     Output,
     QueryList,
     DoCheck,
-    Self
+    Self,
+    ElementRef
 } from '@angular/core';
 import {parseBooleanAttribute} from '../util';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
@@ -40,10 +41,12 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
     /** Event emitted when the value of a radio button changes inside the group. */
     @Output()
     change: EventEmitter<RadioButtonChangeEvent> = new EventEmitter<RadioButtonChangeEvent>();
+    /** A list of all the radio buttons included in the group */
     @ContentChildren(forwardRef(() => RadioButtonComponent), {descendants: true})
-    _radios: QueryList<RadioButtonComponent>;
+    radios: QueryList<RadioButtonComponent>;
     private _value: any = null;
-    private _name = `hc-radio-group-${nextUniqueId++}`;
+    private _uniqueName = `hc-radio-group-${nextUniqueId++}`;
+    private _name = this._uniqueName;
     private _inline = false;
     private _initialized = false; // if value of radio group has been set to initial value
     private _selected: RadioButtonComponent | null = null; // the currently selected radio
@@ -61,7 +64,7 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
     }
 
     set name(value: string) {
-        this._name = value;
+        this._name = value ? value : this._uniqueName;
         this._updateRadioButtonNames();
     }
 
@@ -183,16 +186,16 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
     }
 
     private _markRadiosForCheck() {
-        if (this._radios) {
-            this._radios.forEach(radio => radio._markForCheck());
+        if (this.radios) {
+            this.radios.forEach(radio => radio._markForCheck());
         }
     }
 
     private _updateSelectedRadio() {
         let isAlreadySelected = this._selected !== null && this._selected.value === this._value;
-        if (this._radios && !isAlreadySelected) {
+        if (this.radios && !isAlreadySelected) {
             this._selected = null;
-            this._radios.forEach(radio => {
+            this.radios.forEach(radio => {
                 radio.checked = this.value === radio.value;
                 if (radio.checked) {
                     this._selected = radio;
@@ -208,8 +211,8 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
     }
 
     private _updateRadioButtonNames(): void {
-        if (this._radios) {
-            this._radios.forEach(radio => {
+        if (this.radios) {
+            this.radios.forEach(radio => {
                 radio.name = this.name;
             });
         }
@@ -290,7 +293,7 @@ export class RadioButtonComponent implements OnInit {
 
     @HostBinding('attr.id')
     get _getHostId(): string {
-        return this._uniqueId;
+        return this.id;
     }
 
     /** Boolean value of whether the radio button is required */
@@ -333,13 +336,10 @@ export class RadioButtonComponent implements OnInit {
     }
 
     get _inputId() {
-        if (this.id) {
-            return this.id;
-        }
-        return `${this._uniqueId}-input`;
+        return `${this.id || this._uniqueId}-input`;
     }
 
-    constructor(@Optional() radioGroup: RadioGroupDirective, private cdRef: ChangeDetectorRef) {
+    constructor(@Optional() radioGroup: RadioGroupDirective, private cdRef: ChangeDetectorRef, public _elementRef: ElementRef) {
         this.radioGroup = radioGroup;
     }
 


### PR DESCRIPTION
Adds unit tests for radio buttons and radio groups.  I'm pretty new to writing unit tests, so I'd appreciate any feedback you have.  The radio buttons are pretty similar in form to the checkbox which had unit tests already, so I tried to model after them.

closes #621