### PR TITLE
fix(appswitcher): thumbnail img sizing

### DIFF
--- a/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
@@ -35,7 +35,7 @@
     </hc-navbar-mobile-menu>
 </hc-navbar>
 
-<hc-popover-content #appSwitcher><hc-app-switcher></hc-app-switcher></hc-popover-content>
+<hc-popover-content #appSwitcher><hc-app-switcher iconHeight="100"></hc-app-switcher></hc-popover-content>
 
 <hc-popover-content #options>
     <ul class="list-options">

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.html
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.html
@@ -4,7 +4,7 @@
     <div class="apps">
         <div class="app" *ngFor="let app of applications">
             <a class="thumbnail" [title]="app.Description" [href]="app.ServiceUrl" target="_blank">
-                <img class="thumbnail-img" [src]="app.Icon">
+                <img class="thumbnail-img" [height]="iconHeight" [src]="app.Icon">
                 <div class="title">{{app?.FriendlyName | ellipsis:18}}</div>
             </a>
         </div>

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.scss
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.scss
@@ -30,10 +30,12 @@
             & > a {
                 padding: 10px;
                 text-decoration: none;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
 
                 & > .thumbnail-img {
-                    width: 100px;
-                    height: 100px;
+                    width: auto;
                 }
             }
 

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.ts
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.ts
@@ -13,8 +13,19 @@ export class AppSwitcherComponent implements OnInit, OnDestroy {
     public applications: IDiscoveryApplication[];
     public subscription: Subscription;
     public brandBg = 'brand';
+    private _iconHeight: Number = 100;
 
     private ngUnsubscribe: any = new Subject();
+
+    /** Sets the height of the app thumbnail icons, width is auto (defaults to 100px) */
+    @Input()
+    get iconHeight(): Number {
+        return this._iconHeight;
+    }
+
+    set iconHeight(heightVal: Number) {
+        this._iconHeight = heightVal;
+    }
 
     constructor(@Inject(APP_SWITCHER_SERVICE) public appSwitcherService: IAppSwitcherService) {}
 

--- a/projects/cashmere/src/lib/navbar/navbar.md
+++ b/projects/cashmere/src/lib/navbar/navbar.md
@@ -36,7 +36,7 @@ You may not have all these items available. However, include what you have in th
 
 ##### App Switcher
 
-In addition to the help menu, all Heath Catalyst applications should also include the app switcher in their navbar to the left of the help menu. The app switcher allows users to easily switch between the Health Catalyst apps that they have access to.
+In addition to the help menu, all Heath Catalyst applications should also include the app switcher in their navbar to the left of the help menu. The app switcher allows users to easily switch between the Health Catalyst apps that they have access to. You may set the height of the icons that appear in the app switcher using the `iconHeight` parameter.  The height defaults to 100px, and the width will be set automatically.
 
 ```html
 <hc-navbar>
@@ -48,7 +48,7 @@ In addition to the help menu, all Heath Catalyst applications should also includ
         <hc-app-switcher-links></hc-app-switcher-links>
     </hc-navbar-mobile-menu>
     ...
-    <hc-popover-content #appSwitcher><hc-app-switcher></hc-app-switcher></hc-popover-content>
+    <hc-popover-content #appSwitcher><hc-app-switcher iconHeight="100"></hc-app-switcher></hc-popover-content>
 </hc-navbar>
 ```
 


### PR DESCRIPTION
Corrects app icons that were being stretched if they weren't square.  Adds an app switcher parameter to set the height to something other than 100px if needed.  Also fixes an issue where the names weren't being centered correctly under the icons.