### PR TITLE
fix(component-viewer): overflow visible

### DIFF
--- a/src/app/components/component-viewer/component-viewer.component.html
+++ b/src/app/components/component-viewer/component-viewer.component.html
@@ -1,6 +1,6 @@
 <div class="demo-content">
     <h1>{{docItem?.name}}</h1>
-    <hc-tab-set direction="horizontal">
+    <hc-tab-set direction="horizontal" class="overflow-visible">
         <hc-tab *ngFor="let section of sections" [tabTitle]="section" [routerLink]="section.toLowerCase()"></hc-tab>
     </hc-tab-set>
 </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -238,3 +238,7 @@ table {
         font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
     }
 }
+
+.overflow-visible > .hc-horizontal-tab-container > .hc-tab-content-horizontal {
+    overflow: visible !important;
+}


### PR DESCRIPTION
Overrides the default horizontal tab overflow to not clip box-shadow on our demo site content viewer.  I thought of doing this as an additional parameter to tabs - but no one has asked for it, so I'm assuming most devs would do an override like this anyway.

closes #590