### PR TITLE
feat(tables): cell text justify

### DIFF
--- a/projects/cashmere-examples/src/lib/resizable-columns/resizable-columns-example.component.html
+++ b/projects/cashmere-examples/src/lib/resizable-columns/resizable-columns-example.component.html
@@ -56,7 +56,7 @@
     </ng-container>
 
     <!-- Weight Column -->
-    <ng-container hcColumnDef="weight">
+    <ng-container hcColumnDef="weight" justify="right">
         <th hc-header-cell *hcHeaderCellDef [style.width]="columnObjects[2].width + 'px'">
             <span>{{ columnObjects[2].title }}</span>
             <hc-cell-resizer
@@ -84,7 +84,7 @@
     </ng-container>
 
     <!-- Symbol Column -->
-    <ng-container hcColumnDef="symbol">
+    <ng-container hcColumnDef="symbol" justify="right">
         <th hc-header-cell *hcHeaderCellDef [style.width]="columnObjects[3].width + 'px'">
             <span>{{ columnObjects[3].title }}</span>
             <hc-cell-resizer

--- a/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
@@ -7,20 +7,20 @@
     </ng-container>
 
     <!-- Name Column -->
-    <ng-container hcColumnDef="name">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header arrowPosition="before">Name</th>
+    <ng-container hcColumnDef="name" justify="right">
+        <th hc-header-cell *hcHeaderCellDef hc-sort-header>Right Align</th>
         <td hc-cell *hcCellDef="let element">{{element.name}}</td>
     </ng-container>
 
     <!-- Weight Column -->
-    <ng-container hcColumnDef="weight">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header arrowPosition="before">Weight</th>
+    <ng-container hcColumnDef="weight" justify="center">
+        <th hc-header-cell *hcHeaderCellDef hc-sort-header>Center Align</th>
         <td hc-cell *hcCellDef="let element">{{element.weight}}</td>
     </ng-container>
 
     <!-- Discovered -->
-    <ng-container hcColumnDef="discovered">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header arrowPosition="before">Discovered</th>
+    <ng-container hcColumnDef="discovered" justify="right">
+        <th hc-header-cell *hcHeaderCellDef hc-sort-header arrowPosition="before">Left Indicator</th>
         <td hc-cell *hcCellDef="let element">{{element.discovered | date:'fullDate'}}</td>
     </ng-container>
 

--- a/projects/cashmere/src/lib/sass/tables.scss
+++ b/projects/cashmere/src/lib/sass/tables.scss
@@ -37,12 +37,10 @@ table.hc-table {
         border-top: none;
         line-height: 1.3;
         padding: $cell-padding;
-        text-align: right;
         position: relative;
         background-clip: padding-box;
 
         &:first-of-type {
-            text-align: left;
             .hc-cell-resizer-left {
                 display: none;
             }
@@ -159,6 +157,31 @@ table.hc-table {
         }
         &.hc-row-selected:hover {
             background-color: $row-color-selected-hover;
+        }
+    }
+
+    // Column text justify options
+    th.hc-table-justify-left,
+    td.hc-table-justify-left {
+        text-align: left;
+        .hc-sort-header-container {
+            justify-content: left;
+        }
+    }
+
+    th.hc-table-justify-right,
+    td.hc-table-justify-right {
+        text-align: right;
+        .hc-sort-header-container {
+            justify-content: right;
+        }
+    }
+
+    th.hc-table-justify-center,
+    td.hc-table-justify-center {
+        text-align: center;
+        .hc-sort-header-container {
+            justify-content: center;
         }
     }
 

--- a/projects/cashmere/src/lib/table/cell.ts
+++ b/projects/cashmere/src/lib/table/cell.ts
@@ -50,9 +50,25 @@ export class HcFooterCellDef extends CdkFooterCellDef {}
     providers: [{provide: CdkColumnDef, useExisting: HcColumnDef}]
 })
 export class HcColumnDef extends CdkColumnDef {
+    private _justify: string = 'left';
+
     /** Unique name for this column. */
     @Input('hcColumnDef')
     name: string;
+
+    /** Sets the text alignment for this column: `left` (default), `center` or `right` */
+    @Input()
+    get justify(): string {
+        return this._justify;
+    }
+
+    set justify(justifyVal: string) {
+        if (justifyVal === 'left' || justifyVal === 'center' || justifyVal === 'right') {
+            this._justify = justifyVal;
+        } else {
+            throw Error('Unsupported table column alignment value: ' + justifyVal);
+        }
+    }
 
     /** Whether this column should be sticky positioned at the start of the row */
     @Input()
@@ -72,9 +88,10 @@ export class HcColumnDef extends CdkColumnDef {
     }
 })
 export class HcHeaderCell extends CdkHeaderCell {
-    constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
+    constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
+        elementRef.nativeElement.classList.add(`hc-table-justify-` + columnDef.justify);
     }
 }
 
@@ -87,9 +104,10 @@ export class HcHeaderCell extends CdkHeaderCell {
     }
 })
 export class HcFooterCell extends CdkFooterCell {
-    constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
+    constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
+        elementRef.nativeElement.classList.add(`hc-table-justify-` + columnDef.justify);
     }
 }
 
@@ -102,8 +120,9 @@ export class HcFooterCell extends CdkFooterCell {
     }
 })
 export class HcCell extends CdkCell {
-    constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
+    constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
+        elementRef.nativeElement.classList.add(`hc-table-justify-` + columnDef.justify);
     }
 }

--- a/projects/cashmere/src/lib/table/table.md
+++ b/projects/cashmere/src/lib/table/table.md
@@ -100,10 +100,13 @@ The `HcTable` is focused on a single responsibility: efficiently render rows of 
 performant and accessible way.
 
 You'll notice that the table itself doesn't come out of the box with a lot of features, but expects
-that the table will be included in a composition of components that fills out its features.
+that the table will be included in a composition of components that fills out its features. For example,
+you can add sorting to the table by using HcSort and mutating the data provided to the table according to
+their outputs.
 
-For example, you can add sorting to the table by using HcSort and
-mutating the data provided to the table according to their outputs.
+The text alignment of a column may be set using the `justify` property on the `ng-container` of a column.
+It defaults to a value of `left`, but my be set to `right` or `center`. Columns containing numerical data
+should typically be right aligned.
 
 To simplify the use case of having a table that can sort, and filter an array of data,
 the Cashmere library comes with a `HcTableDataSource` that has already implemented
@@ -141,6 +144,9 @@ If you are not using the `HcTableDataSource`, but instead implementing custom lo
 data, listen to the sort's `(hcSortChange)` event and re-order your data according to the sort state.
 If you are providing a data array directly to the table, don't forget to call `renderRows()` on the
 table, since it will not automatically check the array for changes.
+
+The position of the sorting indicator can be set using the `arrowPosition` property.  If set to `before`
+it will place the indicator to the left of the header text.
 
 The `HcSort` is one provided solution to sorting your table's data, but it is not the only option.
 

--- a/src/app/styles/table/table-demo.component.html
+++ b/src/app/styles/table/table-demo.component.html
@@ -6,13 +6,15 @@
         <h5>Basic Example</h5>
         <p>Add the base class
             <code>.hc-table</code> to an HTML
-            <code>&lt;table&gt;</code> to get the default Catalyst table stylings.</p>
+            <code>&lt;table&gt;</code> to get the default Catalyst table stylings. Set the alignment of a cell
+            using <code>.hc-table-justify-left</code> (default), <code>.hc-table-justify-center</code>, or
+            <code>.hc-table-justify-right</code>. Justify right is typically used for numerical values.</p>
         <table class="hc-table">
             <thead>
                 <tr>
                     <th>First Name</th>
                     <th>Last Name</th>
-                    <th>MRN</th>
+                    <th class="hc-table-justify-right">MRN</th>
                     <th>Birth Date</th>
                     <th>Payor</th>
                 </tr>
@@ -21,28 +23,28 @@
                 <tr>
                     <td>Samuel</td>
                     <td>Walker</td>
-                    <td>Z1223334444</td>
+                    <td class="hc-table-justify-right">Z1223334444</td>
                     <td>Mar 27, 1978</td>
                     <td>MetLife</td>
                 </tr>
                 <tr>
                     <td>Whitney</td>
                     <td>Allen</td>
-                    <td>Z5223335555</td>
+                    <td class="hc-table-justify-right">Z5223335555</td>
                     <td>Jan 14, 1954</td>
                     <td>New York Life</td>
                 </tr>
                 <tr>
                     <td>Kendra</td>
                     <td>Jacobs</td>
-                    <td>Z6223336666</td>
+                    <td class="hc-table-justify-right">Z6223336666</td>
                     <td>Aug 27, 1990</td>
                     <td>Prudential Financial</td>
                 </tr>
                 <tr>
                     <td>Gerald</td>
                     <td>Lynch</td>
-                    <td>Z7223337777</td>
+                    <td class="hc-table-justify-right">Z7223337777</td>
                     <td>Mar 15, 1981</td>
                     <td>MetLife</td>
                 </tr>
@@ -106,7 +108,7 @@
                     <th class="hc-col-sortable hc-active-sort hc-sort-asc">Active Sort (Ascending)</th>
                     <th>Nope</th>
                     <th class="hc-col-sortable hc-active-sort hc-sort-desc">Active Sort (Descending)</th>
-                    <th class="hc-col-sortable-left">Left aligned</th>
+                    <th class="hc-col-sortable-left">Left indicator</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Adds text justify options to component and table styles.  This is a pretty important feature, I'm amazed it didn't come up sooner.  I've built it so the dev has some options when it comes to alignment - they can choose to right justify, but keep the sorting indicator to the right as well if that's preferred (I was asked about this recently).

closes #646