### PR TITLE
fix(icons): resolve naming collision

### DIFF
--- a/projects/cashmere/src/lib/icon-font/hcicons.css
+++ b/projects/cashmere/src/lib/icon-font/hcicons.css
@@ -303,7 +303,7 @@
   .hc-global-w:before {
     content: "\e95b";
   }
-  .hc-link:before {
+  .hc-web-link:before {
     content: "\e972";
   }
   .hc-broken-link:before {

--- a/src/app/styles/icons/icon-guide.component.html
+++ b/src/app/styles/icons/icon-guide.component.html
@@ -321,7 +321,7 @@
                 <hc-icon fontSet="hc-icons" fontIcon="hc-global-w" hcIconLg></hc-icon><span>hc-global-w<span class="unicode"> [e95b]</span></span><span class="alt-text">permissions, write</span>
             </div>
             <div class="icon-example">
-                <hc-icon fontSet="hc-icons" fontIcon="hc-link" hcIconLg></hc-icon><span>hc-link<span class="unicode"> [e972]</span></span><span class="alt-text">anchor, url</span>
+                <hc-icon fontSet="hc-icons" fontIcon="hc-web-link" hcIconLg></hc-icon><span>hc-web-link<span class="unicode"> [e972]</span></span><span class="alt-text">anchor, url</span>
             </div>
             <div class="icon-example">
                 <hc-icon fontSet="hc-icons" fontIcon="hc-broken-link" hcIconLg></hc-icon><span>hc-broken-link<span class="unicode"> [e911]</span></span><span class="alt-text">anchor, url</span>


### PR DESCRIPTION
corrects a css collision on `hc-link`

closes #833