### PR TITLE
fix(toasts): HcToastRef close()

### DIFF
--- a/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-custom.component.ts
+++ b/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-custom.component.ts
@@ -10,7 +10,7 @@ import {Component} from '@angular/core';
                 color: white;
                 padding: 20px 10px;
                 display: flex;
-                width: 400px;
+                width: 100%;
             }
             .custom-toast-icon {
                 margin-right: 20px;
@@ -25,6 +25,7 @@ import {Component} from '@angular/core';
             }
             .custom-toast-body {
                 font-size: 12px;
+                width: 319px
             }
         `
     ]

--- a/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
@@ -62,20 +62,7 @@ export class HcToasterService {
         if (options.clickDismiss) {
             _toastRef.componentInstance._canDismiss = options.clickDismiss;
             _toastRef.componentInstance._closeClick.subscribe(() => {
-                this._removeToastPointer(_toastRef);
                 _toastRef.close();
-                if (options.toastClosed) {
-                    options.toastClosed();
-                }
-                _toastRef.componentInstance._animationStateChanged
-                    .pipe(
-                        filter(event => event.phaseName === 'done' && event.toState === 'leave'),
-                        take(1)
-                    )
-                    .subscribe(() => {
-                        this._updateToastPositions();
-                    });
-                _toastRef.componentInstance._closeClick.unsubscribe();
             });
         }
 
@@ -111,22 +98,26 @@ export class HcToasterService {
         if (options.timeout !== 0) {
             setTimeout(() => {
                 if (_toastRef.componentInstance) {
-                    this._removeToastPointer(_toastRef);
                     _toastRef.close();
-                    if (options.toastClosed) {
-                        options.toastClosed();
-                    }
-                    _toastRef.componentInstance._animationStateChanged
-                        .pipe(
-                            filter(event => event.phaseName === 'done' && event.toState === 'leave'),
-                            take(1)
-                        )
-                        .subscribe(() => {
-                            this._updateToastPositions();
-                        });
                 }
             }, options.timeout);
         }
+
+        // Cleanup functions called when the toast close animation is triggered
+        _toastRef.componentInstance._animationStateChanged
+            .pipe(
+                filter(event => event.phaseName === 'done' && event.toState === 'leave'),
+                take(1)
+            )
+            .subscribe(() => {
+                this._removeToastPointer(_toastRef);
+                if (options.toastClosed) {
+                    options.toastClosed();
+                }
+                this._updateToastPositions();
+                _toastRef.componentInstance._animationStateChanged.unsubscribe();
+                _toastRef.componentInstance._closeClick.unsubscribe();
+            });
 
         this._toasts.push(_toastRef);
         return _toastRef;
@@ -135,7 +126,7 @@ export class HcToasterService {
     /** Closes the most recent toast displayed */
     closeLastToast() {
         if (this._toasts.length > 0) {
-            const element = this._toasts.pop();
+            const element = this._toasts[this._toasts.length - 1];
             if (element) {
                 element.close();
             }
@@ -146,7 +137,7 @@ export class HcToasterService {
     closeAllToasts() {
         let len = this._toasts.length;
         for (let index = 0; index < len; index++) {
-            const element = this._toasts.pop();
+            const element = this._toasts[index];
             if (element) {
                 element.close();
             }


### PR DESCRIPTION
`close()` function now correctly updates service when called on any HcToastRef.  Great catch on this one @isaaclyman - in looking back at the service, the way I was handling close cleanup was pretty goofy.  It's all tied to the completion of the animation event now (which HcToastRef close() triggers).  So everything is cleaner and more logical.

Made a minor fix to the custom component example as well while I was in there to handle full width versions.

closes #842