### PR TITLE
fix(toasts): change detection

### DIFF
--- a/projects/cashmere/src/lib/toaster/hc-toast.component.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toast.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, ElementRef, ViewContainerRef, ComponentRef} from '@angular/core';
+import {Component, EventEmitter, ElementRef, ViewContainerRef, ComponentRef, ChangeDetectorRef} from '@angular/core';
 import {trigger, state, style, transition, animate, AnimationEvent} from '@angular/animations';
 import {Portal, CdkPortalOutletAttachedRef} from '@angular/cdk/portal';
 import {BehaviorSubject} from 'rxjs';
@@ -30,7 +30,7 @@ export class HcToastComponent {
     _toastPortal: Portal<any>;
     readonly _componentInstance = new BehaviorSubject<any>(null);
 
-    constructor(public _el: ElementRef, public _viewContainerRef: ViewContainerRef) {}
+    constructor(public _el: ElementRef, public _viewContainerRef: ViewContainerRef, public _changeRef: ChangeDetectorRef) {}
 
     _onAnimationStart(event: AnimationEvent) {
         this._animationStateChanged.emit(event);

--- a/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
@@ -128,6 +128,7 @@ export class HcToasterService {
             }, options.timeout);
         }
 
+        _toastRef.componentInstance._changeRef.detectChanges();
         this._toasts.push(_toastRef);
         return _toastRef;
     }


### PR DESCRIPTION
Detects changes on addToast to fix changed after checked error.  @isaaclyman - I tested this out by modifying the toast example to show a toast via `ngOnInit`.  I was getting the same error you referenced, but this change appears to fix the problem.  Let me know if this works in your case as well.  Thanks!

closes #844