### PR TITLE
docs(issue template): simplify existing templates and add doc template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,32 +1,23 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug or unexpected behavior
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Summary**
 
-**To Reproduce**
-Reproduce it on stackblitz fork
-https://stackblitz.com/edit/cashmere-demo?file=app%2Fhome%2Fhome.component.ts
-_OR_
-Steps to reproduce the behavior:
+*Let us know what went wrong. The rest of this form is optional.*
 
-1.  Go to '...'
-2.  Click on '....'
-3.  Scroll down to '....'
-4.  See error
+**Reproduction**
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+Steps to reproduce:
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+1. 
+2. 
+3. 
+4. 
 
-**Browser:**
-
--   Browser [e.g. chrome, safari]
--   Version [e.g. 22]
+Stackblitz reproduction (you can fork from the Stackblitz link in a component example):
 
 **Additional context**
-Add any other context about the problem here.
+
+*You can share screenshots, library versions, your web browser and version, or anything else that might be relevant.*

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,9 +12,6 @@ about: Report a bug or unexpected behavior
 Steps to reproduce:
 
 1. 
-2. 
-3. 
-4. 
 
 Stackblitz reproduction (click the "Edit on Stackblitz" link on a component example and fork the template):
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ Steps to reproduce:
 3. 
 4. 
 
-Stackblitz reproduction (you can fork from the Stackblitz link in a component example):
+Stackblitz reproduction (click the "Edit on Stackblitz" link on a component example and fork the template):
 
 **Additional context**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,16 +5,16 @@ about: Report a bug or unexpected behavior
 
 **Summary**
 
-*Let us know what went wrong. The rest of this form is optional.*
+_Let us know what went wrong. The rest of this form is optional._
 
 **Reproduction**
 
 Steps to reproduce:
 
-1. 
+1.
 
 Stackblitz reproduction (click the "Edit on Stackblitz" link on a component example and fork the template):
 
 **Additional context**
 
-*You can share screenshots, library versions, your web browser and version, or anything else that might be relevant.*
+_You can share screenshots, library versions, your web browser and version, or anything else that might be relevant._

--- a/.github/ISSUE_TEMPLATE/doc_request.md
+++ b/.github/ISSUE_TEMPLATE/doc_request.md
@@ -5,8 +5,8 @@ about: Ask us to clarify or improve a piece of documentation
 
 **Where does our documentation fall short?**
 
-*Tell us which Cashmere documentation page this request is about and what's missing or unclear. The rest of this form is optional.*
+_Tell us which Cashmere documentation page this request is about and what's missing or unclear. The rest of this form is optional._
 
 **What would you add or change?**
 
-*If you were able to figure things out on your own, tell us what you did. You can also share ideas for code snippets, examples, better wording, and so on.*
+_If you were able to figure things out on your own, tell us what you did. You can also share ideas for code snippets, examples, better wording, and so on._

--- a/.github/ISSUE_TEMPLATE/doc_request.md
+++ b/.github/ISSUE_TEMPLATE/doc_request.md
@@ -1,0 +1,12 @@
+---
+name: Documentation/example request
+about: Ask us to clarify or improve a piece of documentation
+---
+
+**Where does our documentation fall short?**
+
+*Tell us which Cashmere documentation page this request is about and what's missing or unclear. The rest of this form is optional.*
+
+**What would you add or change?**
+
+*If you were able to figure things out on your own, tell us what you did. You can also share ideas for code snippets, examples, better wording, and so on.*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,12 +5,12 @@ about: Suggest an idea for Cashmere
 
 **Describe your idea**
 
-*Tell us what you wish Cashmere could do. The rest of this form is optional.*
+_Tell us what you wish Cashmere could do. The rest of this form is optional._
 
 **What problem are you trying to solve?**
 
-*Ex. I'm always frustrated when ...*
+_Ex. I'm always frustrated when ..._
 
 **Additional context**
 
-*You can share screenshots, alternative solutions or ideas you've considered, which components would need to change, whether or not this would be a breaking change, or anything else that may be relevant.*
+_You can share screenshots, alternative solutions or ideas you've considered, which components would need to change, whether or not this would be a breaking change, or anything else that may be relevant._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,21 +1,16 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for Cashmere
 ---
 
-**Describe the problem this feature request is solving**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Describe your idea**
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+*Tell us what you wish Cashmere could do. The rest of this form is optional.*
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**What problem are you trying to solve?**
 
-** If any, which components will have to change, and how **
-
--   Components changed?
--   Are these breaking changes to public interfaces?
+*Ex. I'm always frustrated when ...*
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+
+*You can share screenshots, alternative solutions or ideas you've considered, which components would need to change, whether or not this would be a breaking change, or anything else that may be relevant.*


### PR DESCRIPTION
My goals here are to:

1. Significantly reduce friction for Cashmere outsiders who want to report issues
2. Make documentation a first-class citizen by inviting Cashmere users to recommend improvements to it

Potential objections: I understand the impulse to ask for as much information as possible from issue creators, but in my experience this makes people feel like submitting an issue isn't worth the trouble. Most software bugs and feature requests can be effectively described in a sentence or two. If a bug report is severely lacking in detail or we're unable to reproduce it, we should take a moment to follow up and ask for specific clarification.

In short, if we want participation from the Health Catalyst community, we should make it easy for them to participate.