### PR TITLE
docs(hc-icons): fix hc-icons in stackblitz examples

### DIFF
--- a/projects/cashmere-examples/src/project-template/src/styles.scss
+++ b/projects/cashmere-examples/src/project-template/src/styles.scss
@@ -4,4 +4,7 @@ $fa-font-path: 'node_modules/font-awesome/fonts';
 $FontPathOpenSans: 'node_modules/npm-font-open-sans/fonts';
 @import '~npm-font-open-sans/open-sans';
 
+$hc-icons-font-path: 'node_modules/@healthcatalyst/cashmere/hcicons';
+@import '~@healthcatalyst/cashmere/hcicons/hcicons';
+
 @import '~@healthcatalyst/cashmere/scss/cashmere';


### PR DESCRIPTION
Seems to fix #892 

Someone should validate though! Run a fresh `npm run build`, fire up the app, then open the stackblitz example for hc-icons component.