### PR TITLE
docs(filters): updated filter styles

### DIFF
--- a/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.component.html
+++ b/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.component.html
@@ -1,7 +1,7 @@
 <div class="chip-row-wrapper">
-    <button hc-button title="Filters" buttonStyle="link" class="demo-button-width">
-        <span class="hc-filters-icon"></span>
-        Filters:
+    <button hc-button title="Filters" buttonStyle="primary-alt" class="filters-trigger">
+        <hc-icon fontSet="hc-icons" fontIcon="hci-filters" class="icon-left"></hc-icon>
+        Show Filters
     </button>
     <hc-chip-row wrap="false">
         <hc-chip action="true" (click)="hideChip($event);">Payer (11)</hc-chip>

--- a/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.component.scss
+++ b/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.component.scss
@@ -8,6 +8,12 @@
     align-items: center;
 }
 
-.demo-button-width {
+.filters-trigger {
     min-width: unset !important;
+    margin-top: -5px;
+    margin-right: 5px;
+}
+
+.icon-left {
+    margin-right: 10px;
 }

--- a/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.html
+++ b/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.html
@@ -59,9 +59,10 @@
         </hc-menu-drawer>
 
         <div class="drawer-content">
-            <button hc-button title="Filters" buttonStyle="link" (click)="leftDrawer.toggle()">
-                <span class="hc-filters-icon"></span>
-                Filters off
+            <button hc-button title="Filters" buttonStyle="primary-alt" (click)="leftDrawer.toggle()">
+                <hc-icon fontSet="hc-icons" fontIcon="hci-filters" class="icon-left"></hc-icon>
+                <span *ngIf="leftDrawer.opened">Hide Filters</span>
+                <span *ngIf="!leftDrawer.opened">Show Filters</span>
             </button>
         </div>
     </hc-drawer-container>

--- a/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.scss
+++ b/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.scss
@@ -18,3 +18,8 @@
 .hc-drawer-right .fa-plus {
     margin: 0 auto 0 0;
 }
+
+.icon-left {
+    margin-right: 10px;
+}
+


### PR DESCRIPTION
Alejo and I had the opportunity to attend a UX Research training this past week, and as part of it we conducted a user test around the functionality of the filters drawer.  We discovered (see results below), that users really struggled to know how to trigger the drawer.  But once they opened the drawer, they were able to filter fine.  So I've discussed with the UX team and we are proposing a style change to make the trigger more prominent and more button-like.

Once these changes are merged, I'll work on broadcasting this out to all the product teams to make the change.

<img width="1044" alt="Screen Shot 2019-08-09 at 10 03 41 AM" src="https://user-images.githubusercontent.com/22795893/62893886-c68c9200-bd08-11e9-86fe-e2125c83a121.png">
