### PR TITLE
fix(input): textarea example

### DIFF
--- a/projects/cashmere-examples/src/lib/input-text-area/input-text-area-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-text-area/input-text-area-example.component.html
@@ -1,0 +1,4 @@
+<hc-form-field>
+    <hc-label>Enter a long form answer:</hc-label>
+    <textarea hcInput rows="4" cols="50">You may use textareas with hcInput as well as inputs.</textarea>
+</hc-form-field>

--- a/projects/cashmere-examples/src/lib/input-text-area/input-text-area-example.component.ts
+++ b/projects/cashmere-examples/src/lib/input-text-area/input-text-area-example.component.ts
@@ -1,0 +1,10 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title Text Area
+ */
+@Component({
+    selector: 'hc-input-text-area-example',
+    templateUrl: 'input-text-area-example.component.html'
+})
+export class InputTextAreaExampleComponent {}

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -58,6 +58,10 @@
     }
 }
 
+.hc-form-field-suffix {
+    @include hc-form-field-suffix();
+}
+
 .hc-form-field-prefix {
     @include hc-form-field-prefix();
 }

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -47,8 +47,6 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     align-items: baseline;
     box-sizing: border-box;
     width: 100%;
-
-    padding: 0 7px 0 0;
     border: 1.5px solid $gray-300;
 
     background: $white;
@@ -58,8 +56,6 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     display: inline-flex;
     align-items: baseline;
     box-sizing: border-box;
-
-    padding: 0 7px 0 0;
     border: 1.5px solid $gray-300;
 
     background: $white;
@@ -105,6 +101,10 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
 @mixin hc-form-field-prefix {
     padding-left: 7px;
+}
+
+@mixin hc-form-field-suffix {
+    padding-right: 7px;
 }
 
 @mixin hc-form-field-infix() {

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -59,7 +59,7 @@ const docs: DocItem[] = [
         name: 'Input',
         category: 'forms',
         usageDoc: true,
-        examples: ['input-required', 'input-suffix', 'input-prefix']
+        examples: ['input-required', 'input-suffix', 'input-prefix', 'input-text-area']
     },
     {id: 'list', name: 'List', category: 'layout', examples: ['list-overview']},
     {id: 'modal', name: 'Modal', category: 'popups', examples: ['modal-overview']},


### PR DESCRIPTION
adds textarea example and corrects input suffix padding

closes #965
closes #983