### PR TITLE
fix(popover): fixes center hover flickering

### DIFF
--- a/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
@@ -348,6 +348,8 @@ export class HcPopoverAnchoringService implements OnDestroy {
       backdropClass: config.backdropClass || 'cdk-overlay-transparent-backdrop',
       scrollStrategy: this._getScrollStrategyInstance(config.scrollStrategy),
       direction: this._getDirection(),
+
+      panelClass: 'overlay-pointer-events'
     });
   }
 

--- a/projects/cashmere/src/lib/sass/_cdk-overlay.scss
+++ b/projects/cashmere/src/lib/sass/_cdk-overlay.scss
@@ -3,3 +3,7 @@
 .cdk-overlay-container {
     z-index: $zindex-cdk-overlay; // override index for implementation inside a modal: https://github.com/HealthCatalyst/Fabric.Cashmere/issues/867
 }
+
+.overlay-pointer-events {
+    pointer-events: none !important;
+}

--- a/projects/cashmere/src/lib/sass/_toaster.scss
+++ b/projects/cashmere/src/lib/sass/_toaster.scss
@@ -1,3 +1,0 @@
-.toast-overlay-clicks {
-    pointer-events: none !important;
-}

--- a/projects/cashmere/src/lib/sass/cashmere.scss
+++ b/projects/cashmere/src/lib/sass/cashmere.scss
@@ -19,7 +19,6 @@
 @import './subnav';
 @import './tables';
 @import './tabs';
-@import './toaster';
 @import './tile';
 @import './tooltip';
 @import './typography';

--- a/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
@@ -176,9 +176,9 @@ export class HcToasterService {
         let positionStrategy = this._getPositionStrategy(String(config.position), this._toasts.length);
 
         if (config.position === 'top-full-width' || config.position === 'bottom-full-width') {
-            overlayConfig = new OverlayConfig({positionStrategy, width: '96%', panelClass: 'toast-overlay-clicks'});
+            overlayConfig = new OverlayConfig({positionStrategy, width: '96%', panelClass: 'overlay-pointer-events'});
         } else {
-            overlayConfig = new OverlayConfig({positionStrategy, panelClass: 'toast-overlay-clicks'});
+            overlayConfig = new OverlayConfig({positionStrategy, panelClass: 'overlay-pointer-events'});
         }
 
         return overlayConfig;


### PR DESCRIPTION
Removes pointer events on popover to prevent hover flickering

Looks like I had already needed to address this on the overlay for toasts, so I just made the toast fix class general and applied it to the popover overlay.

closes #861