### PR TITLE
fix(modal): click drag outside modal

### DIFF
--- a/projects/cashmere/src/lib/modal/modal-window.component.ts
+++ b/projects/cashmere/src/lib/modal/modal-window.component.ts
@@ -34,7 +34,7 @@ export class ModalWindowComponent {
         return state;
     }
 
-    @HostListener('click', ['$event'])
+    @HostListener('mousedown', ['$event'])
     _overlayClick(event: any) {
         let modalContentNotPresent = true;
         let path = this._eventPath(event);


### PR DESCRIPTION
prevents a click drag outside a modal from accidentally closing it

closes #998