### PR TITLE
fix(pagination): initial value of pageSize

### DIFF
--- a/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.ts
+++ b/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.ts
@@ -8,8 +8,8 @@ import {Component} from '@angular/core';
     templateUrl: 'pagination-simple-example.component.html'
 })
 export class PaginationSimpleExampleComponent {
-    _pageNumber: number = 15;
-    pageSize: number = 20;
+    _pageNumber: number = 8;
+    pageSize: number = 100;
     totalItems: number = 1000;
 
     get pageNumber() {

--- a/projects/cashmere/src/lib/pagination/base-pagination.ts
+++ b/projects/cashmere/src/lib/pagination/base-pagination.ts
@@ -52,6 +52,7 @@ export class BasePaginationComponent extends Initializable implements OnInit {
     set pageSize(value: number) {
         this._pageSize = coerceNumberProperty(value);
         this._pageSizeUpdated();
+        this._emitPageEvent(this.pageNumber);
     }
     private _pageSize: number = BasePaginationComponent._DEFAULT_PAGE_SIZE;
 

--- a/projects/cashmere/src/lib/pagination/base-pagination.ts
+++ b/projects/cashmere/src/lib/pagination/base-pagination.ts
@@ -40,6 +40,7 @@ export class BasePaginationComponent extends Initializable implements OnInit {
         if (sanitizedValue !== value) {
             setTimeout(() => (this.pageNumber = sanitizedValue));
         } else {
+            this.pageNumberChange.emit(this.pageNumber);
             this._emitPageEvent(prevPageNumber);
         }
     }
@@ -52,6 +53,7 @@ export class BasePaginationComponent extends Initializable implements OnInit {
     set pageSize(value: number) {
         this._pageSize = coerceNumberProperty(value);
         this._pageSizeUpdated();
+        this.pageSizeChange.emit(this.pageSize);
         this._emitPageEvent(this.pageNumber);
     }
     private _pageSize: number = BasePaginationComponent._DEFAULT_PAGE_SIZE;
@@ -60,10 +62,12 @@ export class BasePaginationComponent extends Initializable implements OnInit {
     @Output()
     readonly page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
 
+    /** Emits the new page number when the page number changes. */
     @Output()
-    readonly pageNumberChange: Observable<number> = this.page.pipe(map(e => e.pageNumber));
+    readonly pageNumberChange: EventEmitter<number> = new EventEmitter<number>();
+    /** Emits the new page size when the page size changes. */
     @Output()
-    readonly pageSizeChange: Observable<number> = this.page.pipe(map(e => e.pageSize));
+    readonly pageSizeChange: EventEmitter<number> = new EventEmitter<number>();
 
     ngOnInit() {
         this._markInitialized();


### PR DESCRIPTION
Stops initial value of pageSize from being overwritten to the default.  I starred at this one for hours thinking it had something to do with base class inheritance.  Turns out it just had to do with the two-way binding being broken;  the pageSize setter wasn't emitting on a change.

closes #776