### PR TITLE
feat(tab): remove tabs service

### DIFF
--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.spec.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.spec.ts
@@ -56,8 +56,12 @@ describe('TabSetComponent', () => {
             expect(component.direction).toBe(expectedDirection);
         });
 
-        it('should be set for all children from parent input', () => {
-            component._tabs.forEach(t => expect(t._direction).toBe(expectedDirection));
+        it('should be set for all children from parent input after second change detection cycle', (done: any) => {
+            setTimeout(() => {
+                fixture.detectChanges();
+                component._tabs.forEach(t => expect(t._direction).toBe(expectedDirection));
+                done();
+            });
         });
 
         it('should throw for unsupported direction', () => {

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
@@ -1,8 +1,7 @@
 import {AfterContentInit, Component, ContentChildren, Input, QueryList, Output } from '@angular/core';
-import { EventEmitter, TemplateRef, Self, OnInit } from '@angular/core';
+import { EventEmitter, TemplateRef } from '@angular/core';
 import {TabComponent} from '../tab/tab.component';
 import {ActivatedRoute, Router} from '@angular/router';
-import { TabsService } from '../tabs.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -34,10 +33,9 @@ export function invalidDefaultTab(tabVal: string) {
 @Component({
     selector: `hc-tab-set`,
     templateUrl: './tab-set.component.html',
-    styleUrls: ['./tab-set.component.scss'],
-    providers: [TabsService]
+    styleUrls: ['./tab-set.component.scss']
 })
-export class TabSetComponent implements OnInit, AfterContentInit {
+export class TabSetComponent implements AfterContentInit {
     _routerEnabled: boolean = false;
     private _direction: string = 'vertical';
     private _defaultTab: string = '0';
@@ -82,13 +80,14 @@ export class TabSetComponent implements OnInit, AfterContentInit {
         }
     }
 
-    constructor(private router: Router, private route: ActivatedRoute, @Self() private _tabsService: TabsService) {}
-
-    ngOnInit(): void {
-        this._tabsService.direction = this.direction;
-    }
+    constructor(private router: Router, private route: ActivatedRoute) {}
 
     ngAfterContentInit(): void {
+        this.setUpTabs();
+        this._tabs.changes.subscribe(() => this.setUpTabs());
+    }
+
+    private setUpTabs(): void {
         if (this._tabs.length === 0) {
             throw tabComponentMissing();
         }
@@ -97,17 +96,12 @@ export class TabSetComponent implements OnInit, AfterContentInit {
             this.defaultToFirstTab();
         }
         this.checkForRouterUse();
-
-        this._tabs.changes.subscribe(() => {
-            if (this.defaultTab !== 'none') {
-                this.defaultToFirstTab();
-            }
-            this.checkForRouterUse();
-
-            this.subscribeToTabClicks();
-        });
-
+        this.setTabDirection();
         this.subscribeToTabClicks();
+    }
+
+    private setTabDirection(): void {
+        setTimeout(() => this._tabs.forEach(t => t._direction = this.direction));
     }
 
     private subscribeToTabClicks(): void {
@@ -168,9 +162,6 @@ export class TabSetComponent implements OnInit, AfterContentInit {
     }
 
     private checkForRouterUse() {
-        if (this._tabs.length === 0) {
-            return;
-        }
         const countUsingRouter = this._tabs.filter(tab => tab.routerLink !== undefined).length;
         if (countUsingRouter > 0 && countUsingRouter < this._tabs.length) {
             const tabsMissingRouterLink = this._tabs.filter(tab => tab.routerLink === undefined);

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.html
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.html
@@ -1,10 +1,12 @@
-<a *ngIf="routerLink; else tabWithoutRouting" class="hc-tab-{{_direction}} hc-text-ellipsis"
-    [routerLink]="routerLink"
-    routerLinkActive="active"
-    (click)="tabClick.emit()">
-    <ng-container *ngIf="_htmlTitle" [ngTemplateOutlet]="_htmlTitle.tabTitle"></ng-container>
-    {{tabTitle}}
-</a>
+<ng-container *ngIf="_direction">
+    <a *ngIf="routerLink; else tabWithoutRouting" class="hc-tab-{{_direction}} hc-text-ellipsis"
+        [routerLink]="routerLink"
+        routerLinkActive="active"
+        (click)="tabClick.emit()">
+        <ng-container *ngIf="_htmlTitle" [ngTemplateOutlet]="_htmlTitle.tabTitle"></ng-container>
+        {{tabTitle}}
+    </a>
+</ng-container>
 <ng-template #tabWithoutRouting>
     <a class="hc-tab-{{_direction}} hc-text-ellipsis"
         [class.active]="_active"

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.spec.ts
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.spec.ts
@@ -1,38 +1,25 @@
 import {TabComponent} from './tab.component';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import { TabsService } from '../tabs.service';
 
 describe('TabComponent', () => {
 
     let component: TabComponent;
     let fixture: ComponentFixture<TabComponent>;
-    let tabsService: TabsService;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [RouterTestingModule],
-            declarations: [TabComponent],
-            providers: [TabsService]
+            declarations: [TabComponent]
         }).compileComponents();
 
         fixture = TestBed.createComponent(TabComponent);
         component = fixture.componentInstance;
-        tabsService = fixture.debugElement.injector.get(TabsService);
 
         fixture.detectChanges();
     }));
 
     it('should create', () => {
         expect(component).toBeTruthy();
-    });
-
-    describe('ngOnInit', () => {
-        it('sets direction to value from TabsService', () => {
-            tabsService.direction = 'vertical';
-            component.ngOnInit();
-
-            expect(component._direction).toEqual(tabsService.direction);
-        });
     });
 });

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.ts
@@ -1,14 +1,13 @@
 import { Component, Input, ContentChildren, QueryList, AfterContentInit, Output } from '@angular/core';
-import { EventEmitter, TemplateRef, ViewChild, OnInit } from '@angular/core';
+import { EventEmitter, TemplateRef, ViewChild } from '@angular/core';
 import { HcTabTitleComponent } from './tab-title.component';
-import { TabsService } from '../tabs.service';
 
 @Component({
     templateUrl: './tab.component.html',
     selector: `hc-tab`,
     styleUrls: ['./tab.component.scss']
 })
-export class TabComponent implements OnInit, AfterContentInit {
+export class TabComponent implements AfterContentInit {
     /** Plain text title of the tab; for HTML support include a `hc-tab-title` element */
     @Input()
     tabTitle: string = '';
@@ -34,15 +33,9 @@ export class TabComponent implements OnInit, AfterContentInit {
     @ContentChildren(HcTabTitleComponent)
     _tabTitle: QueryList<HcTabTitleComponent>;
 
-    ngOnInit(): void {
-        this._direction = this._tabsService.direction;
-    }
-
     ngAfterContentInit() {
         if (this._tabTitle) {
             this._htmlTitle = this._tabTitle.first;
         }
     }
-
-    constructor(private _tabsService: TabsService) {}
 }

--- a/projects/cashmere/src/lib/tabs/tabs.service.ts
+++ b/projects/cashmere/src/lib/tabs/tabs.service.ts
@@ -1,6 +1,0 @@
-import { Injectable } from "@angular/core";
-
-@Injectable()
-export class TabsService {
-    direction: string;
-}


### PR DESCRIPTION
Remove dependency on TabsService. TabSetComponent and TabComponent no longer need it. Instead TabComponents are not rendered until their direction is set by their TabSetComponent.

@joeskeen : I had to add the use of setTimeout when setting the direction. I looked in the console and found that Angular was throwing because its value changed before the change detection cycle completed.