### PR TITLE
fix(toasts): closing multiple toasts

### DIFF
--- a/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.scss
+++ b/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.scss
@@ -33,6 +33,7 @@
 
 .progress-row {
     display: flex;
+    align-items: end;
     width: 100%;
 }
 

--- a/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
@@ -15,8 +15,6 @@ export type ToastContentType<T> = Type<T> | TemplateRef<any>;
 @Injectable()
 export class HcToasterService {
     _toasts: HcToastRef[] = [];
-    endedToastAnim = new Subject<void>();
-    private get endedToastAnim$(): Observable<void> { return this.endedToastAnim.asObservable(); }
 
     // Inject overlay service
     constructor(private injector: Injector, private _overlay: Overlay) {}
@@ -122,14 +120,12 @@ export class HcToasterService {
                 filter(event => event.phaseName === 'done' && event.toState === 'leave'),
                 take(1)
             )
-            .pipe(takeUntil(this.endedToastAnim$))
             .subscribe(() => {
                 this._removeToastPointer(_toastRef);
                 if (options.toastClosed) {
                     options.toastClosed();
                 }
                 this._updateToastPositions();
-                this.endedToastAnim.next();
                 _toastRef.componentInstance._closeClick.unsubscribe();
             });
 


### PR DESCRIPTION
Ensures cleanup functions are called on close with multiple toasts.  The `takeUntil` pipe was preventing the cleanup functions from being called more than once when multiple toasts were open.  

@joeskeen can you verify there aren't any unintended consequences from removing that pipe?  I'm not entirely sure why it was there in the first place, it may have been an artifact of an earlier version.

closes #1018