### PR TITLE
fix(datepicker): validation with null init value

### DIFF
--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
@@ -5,5 +5,6 @@
         <hc-datepicker-toggle hcSuffix [for]="picker1">
         </hc-datepicker-toggle>
         <hc-datepicker #picker1></hc-datepicker>
+        <hc-error>Please enter valid date</hc-error>
     </hc-form-field>
 </div>

--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
@@ -1,15 +1,10 @@
-import {Component, OnInit} from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
     selector: 'hc-datepicker-example',
     templateUrl: './datepicker-example.component.html',
     styleUrls: ['datepicker-example.component.scss']
 })
-export class DatepickerExampleComponent implements OnInit {
-    constructor() {}
-
+export class DatepickerExampleComponent {
     date1 = new Date(2010, 1, 1);
-    date2 = new Date(2010, 1, 1);
-
-    ngOnInit() {}
 }

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.scss
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.scss
@@ -3,6 +3,6 @@
     height: 70px;
 }
 
-.form-container {
+.hc-calendar-wrapper > .form-container {
     padding-left: 13px;
 }

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
@@ -7,7 +7,8 @@ import {
     Output,
     EventEmitter,
     OnChanges,
-    SimpleChanges
+    SimpleChanges,
+    HostBinding
 } from '@angular/core';
 import {ConfigStoreService} from '../services/config-store.service';
 import {CalendarComponent} from '../../datepicker/calendar/calendar.component';
@@ -23,6 +24,9 @@ import {D} from '../../datepicker/datetime/date-formats';
     encapsulation: ViewEncapsulation.None
 })
 export class CalendarWrapperComponent implements OnChanges {
+    @HostBinding('class.hc-calendar-wrapper')
+    _hostClass = true;
+
     @ViewChild(CalendarComponent)
     hcCalendar: CalendarComponent;
 

--- a/projects/cashmere/src/lib/datepicker/calendar-body/calendar-body.component.html
+++ b/projects/cashmere/src/lib/datepicker/calendar-body/calendar-body.component.html
@@ -11,8 +11,6 @@
         aria-hidden="true"
         class="hc-calendar-body-label"
         [attr.colspan]="_firstRowOffset"
-        [style.paddingTop]="_cellPadding"
-        [style.paddingBottom]="_cellPadding"
     >
     </td>
     <td

--- a/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
@@ -337,7 +337,7 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
     /** Handles blur events on the input. */
     _onBlur() {
         // Reformat the input only if we have a valid value.
-        if (this.value) {
+        if (this.value || this._elementRef.nativeElement.value) {
             this._formatValue(this.value);
         }
 

--- a/projects/cashmere/src/lib/datepicker/datepicker.component.spec.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker.component.spec.ts
@@ -1082,17 +1082,17 @@ describe('DatepickerComponent', () => {
                 expect(inputEl.value).toBe('1/1/2001');
             });
 
-            it('should not reformat invalid dates on blur', () => {
+            it('should not reformat invalid dates on blur if there is an empty string in the input', () => {
                 const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
 
-                inputEl.value = 'very-valid-date';
+                inputEl.value = '';
                 dispatchFakeEvent(inputEl, 'input');
                 fixture.detectChanges();
 
                 dispatchFakeEvent(inputEl, 'blur');
                 fixture.detectChanges();
 
-                expect(inputEl.value).toBe('very-valid-date');
+                expect(inputEl.value).toBe('');
             });
 
             it('should mark input touched on calendar selection', fakeAsync(() => {

--- a/projects/cashmere/src/lib/datepicker/datepicker.md
+++ b/projects/cashmere/src/lib/datepicker/datepicker.md
@@ -124,7 +124,7 @@ As with other types of `<input>`, the datepicker works with `@angular/forms` dir
 
 ### Date validation
 
-There are three properties that add date validation to the datepicker input. The first two are the
+Date validation will only occur if the `input` element is bound via `ngModel` or `formControl`. The validator will check to see if the value entered is a valid date. Beyond that, there are three properties that add additional date validation to the datepicker input. The first two are the
 `min` and `max` properties. In addition to enforcing validation on the input, these properties will
 disable all dates on the calendar popup before or after the respective values and prevent the user
 from advancing the calendar past the `month` or `year` (depending on current view) containing the


### PR DESCRIPTION
fix that prevented validation when the initial bound value wasn't set

closes #982