### PR TITLE
Right-click Trigger on HcPop

### DIFF
--- a/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.component.html
@@ -26,6 +26,7 @@
             <option value="center">Center</option>
             <option value="end">End</option>
             <option value="below">Below</option>
+            <option value="mouse">Mouse Position</option>
         </hc-select>
     </hc-form-field>
 
@@ -37,6 +38,7 @@
             <option value="center">Center</option>
             <option value="end">End</option>
             <option value="after">After</option>
+            <option value="mouse">Mouse Position</option>
         </hc-select>
     </hc-form-field>
 
@@ -56,6 +58,7 @@
             <option value="click">Click</option>
             <option value="mousedown">Mousedown</option>
             <option value="hover">Hover</option>
+            <option value="rightclick">Right-Click</option>
             <option value="none">None</option>
         </hc-select>
     </hc-form-field>

--- a/projects/cashmere-examples/src/lib/popover-right-click/popover-right-click-example.component.html
+++ b/projects/cashmere-examples/src/lib/popover-right-click/popover-right-click-example.component.html
@@ -1,0 +1,37 @@
+<table class="hc-table">
+    <thead>
+        <tr>
+            <th>Item Name</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr *ngFor="let item of items">
+            <td>{{ item.name }}</td>
+            <td [hcPop]="contextmenu" trigger="rightclick" [context]="item">{{ item.subtext }}</td>
+        </tr>
+    </tbody>
+</table>
+
+<hc-pop #contextmenu
+    horizontalAlign="mouse"
+    verticalAlign="mouse"
+    (opened)="context = $event"
+    [autoCloseOnContentClick]="true"
+    [showArrow]="false">
+    <div hcMenu>
+        <button hcMenuItem>
+            <hc-icon hcMenuIcon fontSet="hc-icons" fontIcon="hci-copy"></hc-icon>
+            <span hcMenuText>Duplicate {{ context.name }}</span>
+        </button>
+        <div hcMenuItem hcDivider></div>
+        <button hcMenuItem>
+            <hc-icon hcMenuIcon fontSet="hc-icons" fontIcon="hci-archive"></hc-icon>
+            <span hcMenuText>Archive {{ context.name }}</span>
+        </button>
+        <button hcMenuItem>
+            <hc-icon hcMenuIcon fontSet="hc-icons" fontIcon="hci-delete"></hc-icon>
+            <span hcMenuText>Delete {{ context.name }}</span>
+        </button>
+    </div>
+</hc-pop>

--- a/projects/cashmere-examples/src/lib/popover-right-click/popover-right-click-example.component.ts
+++ b/projects/cashmere-examples/src/lib/popover-right-click/popover-right-click-example.component.ts
@@ -1,0 +1,16 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title Popover Menu
+ */
+@Component({
+    selector: 'hc-popover-right-click-example',
+    templateUrl: 'popover-right-click-example.component.html'
+})
+export class PopoverRightClickExampleComponent {
+    items: Object[] = [
+        {name: 'List Item One', subtext: 'Right-click on this cell for a context menu'},
+        {name: 'List Item Two', subtext: 'Right-click on this cell for another context menu'}
+    ];
+    context = {name: '', subtext: ''};
+}

--- a/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
@@ -37,6 +37,7 @@ export class HcPopoverAnchorDirective implements OnInit, OnDestroy {
   private _attachedPopover: HcPopComponent;
 
   /** Trigger event to toggle the popover. *Defaults to `"click"`.*
+   * Accepts `click`, `mousedown`, `hover`, `rightclick`, or `none`.
    * Note: if "hover" is selected, the backdrop for the popover will be disabled. */
   @Input()
   get trigger() { return this._trigger; }
@@ -46,6 +47,11 @@ export class HcPopoverAnchorDirective implements OnInit, OnDestroy {
     this._dispatchConfigNotification(new PopoverNotification(NotificationAction.UPDATE_CONFIG));
   }
   private _trigger: HcPopoverTrigger = 'click';
+
+  /** Object or value that can be passed into the popover to customize its content */
+  @Input()
+  get context() { return this._anchoring._context; }
+  set context( val: any ) { this._anchoring._context = val; }
 
   /** Emits when the popover is opened. */
   @Output() popoverOpened = new EventEmitter<void>();
@@ -82,6 +88,8 @@ export class HcPopoverAnchorDirective implements OnInit, OnDestroy {
   @HostListener('click', ['$event'])
   _showOrHideOnClick($event: MouseEvent): void {
       if (this.trigger !== 'click') { return; }
+      this._attachedPopover._offsetPos[0] = this._attachedPopover.horizontalAlign === 'mouse' ? $event.offsetX : 0;
+      this._attachedPopover._offsetPos[1] = this._attachedPopover.verticalAlign === 'mouse' ? $event.offsetY : 0;
       this.togglePopover();
   }
 
@@ -89,12 +97,28 @@ export class HcPopoverAnchorDirective implements OnInit, OnDestroy {
   @HostListener('mousedown', ['$event'])
   _showOrHideOnMouseOver($event: MouseEvent): void {
       if (this.trigger !== 'mousedown') { return; }
+      this._attachedPopover._offsetPos[0] = this._attachedPopover.horizontalAlign === 'mouse' ? $event.offsetX : 0;
+      this._attachedPopover._offsetPos[1] = this._attachedPopover.verticalAlign === 'mouse' ? $event.offsetY : 0;
       this.togglePopover();
+  }
+
+  @HostListener('contextmenu', ['$event'])
+  _showOrHideRightClick($event: MouseEvent): boolean {
+    if ( this.trigger !== 'rightclick' ) {
+        return true;
+    } else {
+        this._attachedPopover._offsetPos[0] = this._attachedPopover.horizontalAlign === 'mouse' ? $event.offsetX : 0;
+        this._attachedPopover._offsetPos[1] = this._attachedPopover.verticalAlign === 'mouse' ? $event.offsetY : 0;
+        this.togglePopover();
+        return false;
+    }
   }
 
   @HostListener('mouseenter', ['$event'])
   _showOnHover($event: MouseEvent): void {
       if (this.trigger !== 'hover') { return; }
+      this._attachedPopover._offsetPos[0] = this._attachedPopover.horizontalAlign === 'mouse' ? $event.offsetX : 0;
+      this._attachedPopover._offsetPos[1] = this._attachedPopover.verticalAlign === 'mouse' ? $event.offsetY : 0;
       this.openPopover();
   }
 

--- a/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
@@ -144,7 +144,7 @@ export class HcPopoverAnchoringService implements OnDestroy {
   openPopover(options: HcPopoverOpenOptions = {}): void {
     if (!this._popoverOpen) {
       this._applyOpenOptions(options);
-      this._createOverlay();
+      this._popover._componentOverlay = this._createOverlay();
       this._subscribeToBackdrop();
       this._subscribeToEscape();
       this._subscribeToDetachments();
@@ -154,16 +154,16 @@ export class HcPopoverAnchoringService implements OnDestroy {
 
   /** Closes the popover. */
   closePopover(value?: any): void {
-    if (this._overlayRef) {
+    if (this._popover._componentOverlay) {
       this._saveClosedState(value);
-      this._overlayRef.detach();
+      this._popover._componentOverlay.detach();
     }
   }
 
   /** Realign the popover to the anchor. */
   realignPopoverToAnchor(): void {
-    if (this._overlayRef) {
-      const config = this._overlayRef.getConfig();
+    if (this._popover._componentOverlay) {
+      const config = this._popover._componentOverlay.getConfig();
       const strategy = config.positionStrategy as FlexibleConnectedPositionStrategy;
       strategy.reapplyLastPosition();
     }

--- a/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
@@ -62,6 +62,9 @@ export class HcPopoverAnchoringService implements OnDestroy {
   /** Reference to the target popover. */
   private _popover: HcPopComponent;
 
+  /** Stores the context assigned to the popover */
+  _context: any;
+
   /** Reference to the view container for the popover template. */
   private _viewContainerRef: ViewContainerRef;
 
@@ -205,6 +208,15 @@ export class HcPopoverAnchoringService implements OnDestroy {
       );
 
       this._overlayRef = this._overlay.create(overlayConfig);
+    } else if ( this._popover.horizontalAlign === 'mouse' || this._popover.verticalAlign === 'mouse' ) {
+        /* If aligning to mouse clicks - adjust the strategy based on the most current click */
+        this._overlayRef.updatePositionStrategy( this._getPositionStrategy(
+            this._popover.horizontalAlign,
+            this._popover.verticalAlign,
+            this._popover.forceAlignment,
+            this._popover.lockAlignment,
+            this._anchor._elementRef,
+          ) );
     }
 
     // Actually open the popover
@@ -313,7 +325,11 @@ export class HcPopoverAnchoringService implements OnDestroy {
       this._popover._open = this._popoverOpen = true;
 
       this.popoverOpened.next();
-      this._popover.opened.emit();
+      if ( typeof this._context === "undefined" ) {
+        this._popover.opened.emit();
+      } else {
+        this._popover.opened.emit( this._context );
+      }
     }
   }
 
@@ -404,7 +420,7 @@ export class HcPopoverAnchoringService implements OnDestroy {
     anchor: ElementRef,
   ): FlexibleConnectedPositionStrategy {
     // Attach the overlay at the preferred position
-    const targetPosition = getPosition(horizontalTarget, verticalTarget);
+    const targetPosition = getPosition(horizontalTarget, verticalTarget, this._popover._offsetPos);
     const positions = [targetPosition];
 
     const strategy = this._overlay.position()
@@ -436,18 +452,18 @@ export class HcPopoverAnchoringService implements OnDestroy {
     // cover the anchor
     const possibleHorizontalAlignments: HcPopoverHorizontalAlign[] =
       horizontalOverlapAllowed ?
-        ['before', 'start', 'center', 'end', 'after'] :
+        ['before', 'start', 'center', 'end', 'after', 'mouse'] :
         ['before', 'after'];
     const possibleVerticalAlignments: HcPopoverVerticalAlign[] =
       verticalOverlapAllowed ?
-        ['above', 'start', 'center', 'end', 'below'] :
+        ['above', 'start', 'center', 'end', 'below', 'mouse'] :
         ['above', 'below'];
 
     // Create fallbacks for each allowed prioritized fallback alignment combo
     const fallbacks: ConnectionPositionPair[] = [];
     prioritizeAroundTarget(hTarget, possibleHorizontalAlignments).forEach(h => {
       prioritizeAroundTarget(vTarget, possibleVerticalAlignments).forEach(v => {
-        fallbacks.push(getPosition(h, v));
+        fallbacks.push(getPosition(h, v, this._popover._offsetPos));
       });
     });
 
@@ -495,10 +511,11 @@ export class HcPopoverAnchoringService implements OnDestroy {
 function getPosition(
   h: HcPopoverHorizontalAlign,
   v: HcPopoverVerticalAlign,
+  offset: number[]
 ): ConnectionPositionPair {
   const {originX, overlayX} = getHorizontalConnectionPosPair(h);
   const {originY, overlayY} = getVerticalConnectionPosPair(v);
-  return new ConnectionPositionPair({originX, originY}, {overlayX, overlayY});
+  return new ConnectionPositionPair({originX, originY}, {overlayX, overlayY}, offset[0], offset[1]);
 }
 
 /** Helper function to convert an overlay connection position to equivalent popover alignment. */
@@ -534,6 +551,7 @@ function getHorizontalConnectionPosPair(h: HcPopoverHorizontalAlign):
     case 'before':
       return {originX: 'start', overlayX: 'end'};
     case 'start':
+    case 'mouse':
       return {originX: 'start', overlayX: 'start'};
     case 'end':
       return {originX: 'end', overlayX: 'end'};
@@ -551,6 +569,7 @@ function getVerticalConnectionPosPair(v: HcPopoverVerticalAlign):
     case 'above':
       return {originY: 'top', overlayY: 'bottom'};
     case 'start':
+    case 'mouse':
       return {originY: 'top', overlayY: 'top'};
     case 'end':
       return {originY: 'bottom', overlayY: 'bottom'};

--- a/projects/cashmere/src/lib/pop/popover.component.ts
+++ b/projects/cashmere/src/lib/pop/popover.component.ts
@@ -58,7 +58,7 @@ export class HcPopComponent implements OnInit, OnDestroy {
   /** Whether or not to show a connection arrow when possible. *Defaults to `true`.* */
   @Input() showArrow = true;
 
-  /** Alignment of the popover on the horizontal axis. Can be `before`, `start`, `center`, `end`, or `after`.
+  /** Alignment of the popover on the horizontal axis. Can be `before`, `start`, `center`, `end`, `after`, or `mouse`.
    * *Defaults to `center`.* */
   @Input()
   get horizontalAlign() { return this._horizontalAlign; }
@@ -76,7 +76,8 @@ export class HcPopComponent implements OnInit, OnDestroy {
   get xAlign() { return this.horizontalAlign; }
   set xAlign(val: HcPopoverHorizontalAlign) { this.horizontalAlign = val; }
 
-  /** Alignment of the popover on the vertical axis. *Defaults to `"below"`.* */
+  /** Alignment of the popover on the vertical axis. Can be `above`, `start`, `center`, `end`, `below`, or `mouse`.
+   * *Defaults to `"below"`.* */
   @Input()
   get verticalAlign() { return this._verticalAlign; }
   set verticalAlign(val: HcPopoverVerticalAlign) {
@@ -198,8 +199,8 @@ export class HcPopComponent implements OnInit, OnDestroy {
   /** Set to true if clicking anywhere inside the popover should close it. *Defaults to `false`.* */
   @Input() autoCloseOnContentClick = false;
 
-  /** Emits when the popover is opened. */
-  @Output() opened = new EventEmitter<void>();
+  /** Emits when the popover is opened. If `context` was set on the anchor, it will be emitted with this event. */
+  @Output() opened = new EventEmitter<any>();
 
   /** Emits when the popover is closed. */
   @Output() closed = new EventEmitter<any>();
@@ -218,6 +219,9 @@ export class HcPopComponent implements OnInit, OnDestroy {
 
   /** Reference to template so it can be placed within a portal. */
   @ViewChild(TemplateRef) _templateRef: TemplateRef<any>;
+
+  /** Stores the click coordinates for mouse-based positioning */
+  _offsetPos: number[] = [ 0, 0 ];
 
   /** Classes to be added to the popover for setting the correct transform origin. */
   _classList: any = {};

--- a/projects/cashmere/src/lib/pop/popover.component.ts
+++ b/projects/cashmere/src/lib/pop/popover.component.ts
@@ -38,6 +38,7 @@ import {
   VALID_VERT_ALIGN,
   HcPopoverOpenOptions,
 } from './types';
+import { OverlayRef } from '@angular/cdk/overlay';
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const DEFAULT_TRANSITION = '100ms linear';
@@ -222,6 +223,9 @@ export class HcPopComponent implements OnInit, OnDestroy {
 
   /** Stores the click coordinates for mouse-based positioning */
   _offsetPos: number[] = [ 0, 0 ];
+
+  /** Stores a reference to the associated overlay */
+  _componentOverlay: OverlayRef;
 
   /** Classes to be added to the popover for setting the correct transform origin. */
   _classList: any = {};

--- a/projects/cashmere/src/lib/pop/types.ts
+++ b/projects/cashmere/src/lib/pop/types.ts
@@ -6,30 +6,33 @@ export const VALID_SCROLL: HcPopoverScrollStrategy[] = [
   'close'
 ];
 
-export type HcPopoverTrigger = 'click' | 'mousedown' | 'hover' | 'none';
+export type HcPopoverTrigger = 'click' | 'mousedown' | 'rightclick' | 'hover' | 'none';
 export const VALID_TRIGGER: HcPopoverTrigger[] = [
     'click',
     'mousedown',
+    'rightclick',
     'hover',
     'none'
   ];
 
-export type HcPopoverHorizontalAlign = 'before' | 'start' | 'center' | 'end' | 'after';
+export type HcPopoverHorizontalAlign = 'before' | 'start' | 'center' | 'end' | 'after' | 'mouse';
 export const VALID_HORIZ_ALIGN: HcPopoverHorizontalAlign[] = [
   'before',
   'start',
   'center',
   'end',
-  'after'
+  'after',
+  'mouse'
 ];
 
-export type HcPopoverVerticalAlign = 'above'  | 'start' | 'center' | 'end' | 'below';
+export type HcPopoverVerticalAlign = 'above'  | 'start' | 'center' | 'end' | 'below' | 'mouse';
 export const VALID_VERT_ALIGN: HcPopoverVerticalAlign[] = [
   'above',
   'start',
   'center',
   'end',
-  'below'
+  'below',
+  'mouse'
 ];
 
 export interface HcPopoverOpenOptions {

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -82,7 +82,7 @@ const docs: DocItem[] = [
         id: 'pop',
         name: 'Popover',
         category: 'popups',
-        examples: ['popover-simple', 'popover-menu', 'popover-tooltip', 'popover-overview'  ],
+        examples: ['popover-simple', 'popover-menu', 'popover-tooltip', 'popover-right-click', 'popover-overview'  ],
         usageDoc: true
     },
     {


### PR DESCRIPTION
Adds a right-click trigger to HcPop, the ability to position the popover based on the triggering click, and a popover context parameter that let's the developer store info about the popover (@corykon pointed out similar functionality in [this component](https://www.npmjs.com/package/ngx-contextmenu)).  Also added a new example to demonstrate the right-click context menu functionality, and updated the existing overview example with the new options.

While I was in there, I also submitted a fix for the `autoCloseOnContentClick` bug recently reported.  I saw it coming up in my example.  The reason for the bug was the `_overlayRef` in the service was coming back as `undefined` when close() was called from the component.  My fix is to store a reference to the component's overlay in a reference in the component itself, and use that instead in the service's close function - and that seems to work.  But I look to the steering committee to let me know if there are unintended consequences of that approach.

closes #975 
closes #1029 