### PR TITLE
fix(popover): hcMenuItem support anchors

### DIFF
--- a/guides/styles/about-modal.md
+++ b/guides/styles/about-modal.md
@@ -25,52 +25,54 @@ Beyond these items, other app specific information may include "web server", "da
 The following code snippet leverages styles in the `about-modal.scss` stylesheet and can be used as a starting point which you can build on to create an About modal specific to your app. Note that the content below should be displayed in a [hc-modal](https://cashmere.healthcatalyst.net/components/modal/).
 
 ```html
-<div class="about-modal-content">
-    <div class="about-header">
-        <img src="./assets/HealthCatalyst_Horizontal.svg" class="about-logo" alt="" />
-        <div class="about-app">
-            <div class="about-icon">
-                <img src="./assets/CashmereIcon.svg" alt="" />
-            </div>
-            <div class="about-name">
-                <img src="./assets/CashmereAppLogo.svg" alt="" />
-                <div class="about-version">
-                    Version 5.3.0.0
+<hc-modal>
+    <div class="about-modal-content">
+        <div class="about-header">
+            <img src="./assets/HealthCatalyst_Horizontal.svg" class="about-logo" alt="" />
+            <div class="about-app">
+                <div class="about-icon">
+                    <img src="./assets/CashmereIcon.svg" alt="" />
+                </div>
+                <div class="about-name">
+                    <img src="./assets/CashmereAppLogo.svg" alt="" />
+                    <div class="about-version">
+                        Version 5.3.0.0
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-    <div class="about-reference">
-        <div>
-            <hc-icon fontSet="fa" fontIcon="fa-cloud" hcIconLg></hc-icon>
+        <div class="about-reference">
             <div>
-                <strong>Web Server</strong>
-                <div class="about-reference-detail">HC2370</div>
+                <hc-icon fontSet="fa" fontIcon="fa-cloud" hcIconLg></hc-icon>
+                <div>
+                    <strong>Web Server</strong>
+                    <div class="about-reference-detail">HC2370</div>
+                </div>
+            </div>
+            <div>
+                <hc-icon fontSet="fa" fontIcon="fa-server" hcIconLg></hc-icon>
+                <div>
+                    <strong>Metadata Server</strong>
+                    <div class="about-reference-detail">localhost</div>
+                </div>
+            </div>
+            <div>
+                <hc-icon fontSet="fa" fontIcon="fa-database" hcIconLg></hc-icon>
+                <div>
+                    <strong>Database Name</strong>
+                    <div class="about-reference-detail">EDWAdmin</div>
+                </div>
             </div>
         </div>
-        <div>
-            <hc-icon fontSet="fa" fontIcon="fa-server" hcIconLg></hc-icon>
-            <div>
-                <strong>Metadata Server</strong>
-                <div class="about-reference-detail">localhost</div>
-            </div>
-        </div>
-        <div>
-            <hc-icon fontSet="fa" fontIcon="fa-database" hcIconLg></hc-icon>
-            <div>
-                <strong>Database Name</strong>
-                <div class="about-reference-detail">EDWAdmin</div>
-            </div>
+        <div class="about-footer">
+            Copyright 2019 <a href="https://www.healthcatalyst.com/">Health Catalyst</a>. All rights reserved
+            <br>
+            <a href="https://www.healthcatalyst.com/terms-conditions/">Terms and Conditions</a>  |  <a href="https://www.healthcatalyst.com/privacy-policy/">Privacy Policy</a>
         </div>
     </div>
-    <div class="about-footer">
-        Copyright 2019 <a href="https://www.healthcatalyst.com/">Health Catalyst</a>. All rights reserved
-        <br>
-        <a href="https://www.healthcatalyst.com/terms-conditions/">Terms and Conditions</a>  |  <a href="https://www.healthcatalyst.com/privacy-policy/">Privacy Policy</a>
-    </div>
-</div>
-<hr>
-<div class="about-close-container"><button hc-button class="about-close">Close</button></div>
+    <hr class="about-divider">
+    <div class="about-close-container"><button hc-button class="about-close">Close</button></div>
+</hc-modal>
 ```
 
 :::

--- a/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
@@ -41,26 +41,26 @@
 
 <hc-pop #options [autoCloseOnContentClick]="true" [showArrow]="false" horizontalAlign="end">
     <div hcMenu>
-        <button hcMenuItem>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-book"></hc-icon>
             <span hcMenuText>Read the docs</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-lightbulb-o"></hc-icon>
             <span hcMenuText>Request a feature</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-users"></hc-icon>
             <span hcMenuText>Ask the community</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-bullhorn"></hc-icon>
             <span hcMenuText>Find out what's new</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-comments"></hc-icon>
             <span hcMenuText>Send feedback</span>
-        </button>
+        </a>
         <div hcMenuItem hcDivider></div>
         <button hcMenuItem>
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-info-circle"></hc-icon>

--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
@@ -16,26 +16,26 @@
 
 <hc-pop #options [autoCloseOnContentClick]="true" [showArrow]="false" horizontalAlign="end">
     <div hcMenu>
-        <button hcMenuItem>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-book"></hc-icon>
             <span hcMenuText>Read the docs</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-lightbulb-o"></hc-icon>
             <span hcMenuText>Request a feature</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-users"></hc-icon>
             <span hcMenuText>Ask the community</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-bullhorn"></hc-icon>
             <span hcMenuText>Find out what's new</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-comments"></hc-icon>
             <span hcMenuText>Send feedback</span>
-        </button>
+        </a>
         <div hcMenuItem hcDivider></div>
         <button hcMenuItem>
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-info-circle"></hc-icon>

--- a/projects/cashmere-examples/src/lib/popover-menu/popover-menu-example.component.html
+++ b/projects/cashmere-examples/src/lib/popover-menu/popover-menu-example.component.html
@@ -2,11 +2,11 @@
 
 <hc-pop #menu [autoCloseOnContentClick]="true" [showArrow]="false" horizontalAlign="start">
     <div hcMenu>
-        <button hcMenuItem>
+        <a hcMenuItem href="http://example.com">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-snowflake-o"></hc-icon>
             <span hcMenuText>Snowflake</span>
             <span hcMenuSubText>Ctrl + S</span>
-        </button>
+        </a>
         <button hcMenuItem>
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-plus"></hc-icon>
             <span hcMenuText>Add a new one</span>

--- a/projects/cashmere/src/lib/navbar/navbar.md
+++ b/projects/cashmere/src/lib/navbar/navbar.md
@@ -25,26 +25,26 @@ You may not have all these items available. However, include what you have in th
 ```html
 <hc-pop #helpMenu [autoCloseOnContentClick]="true" [showArrow]="false" horizontalAlign="end">
     <div hcMenu>
-        <button hcMenuItem>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-book"></hc-icon>
             <span hcMenuText>Read the docs</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-lightbulb-o"></hc-icon>
             <span hcMenuText>Request a feature</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-users"></hc-icon>
             <span hcMenuText>Ask the community</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-bullhorn"></hc-icon>
             <span hcMenuText>Find out what's new</span>
-        </button>
-        <button hcMenuItem>
+        </a>
+        <a hcMenuItem href="http://example.com" target="_blank">
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-comments"></hc-icon>
             <span hcMenuText>Send feedback</span>
-        </button>
+        </a>
         <div hcMenuItem hcDivider></div>
         <button hcMenuItem>
             <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-info-circle"></hc-icon>

--- a/projects/cashmere/src/lib/sass/_menu.scss
+++ b/projects/cashmere/src/lib/sass/_menu.scss
@@ -26,7 +26,8 @@ $cdk-z-index-overlay: $zindex-cdk-overlay;
     margin: 5px -16px;
 }
 
-button.hc-menu-item {
+button.hc-menu-item,
+a.hc-menu-item {
     @include fontSize(14px);
     font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     color: $offblack;
@@ -44,6 +45,7 @@ button.hc-menu-item {
 
     &:hover:not([disabled]) {
         background-color: tint($blue, 70%);
+        color: $offblack;
         cursor: pointer;
     }
 

--- a/projects/cashmere/src/lib/sass/about-modal.scss
+++ b/projects/cashmere/src/lib/sass/about-modal.scss
@@ -6,6 +6,7 @@
     padding: 15px 0;
     color: $gray-500;
     text-align: center;
+    overflow-y: auto;
 }
 
 .about-header {
@@ -87,6 +88,13 @@
     color: $text;
     @include fontSize(16px);
     line-height: 24px;
+}
+
+.about-divider {
+    border: none;
+    height: 1px;
+    background-color:#e0e0e0;
+    margin: 0;
 }
 
 .about-close-container {

--- a/src/app/styles/about/about-modal.component.html
+++ b/src/app/styles/about/about-modal.component.html
@@ -47,7 +47,7 @@
             <a href="https://www.healthcatalyst.com/terms-conditions/">Terms and Conditions</a>  |  <a href="https://www.healthcatalyst.com/privacy-policy/">Privacy Policy</a>
         </div>
     </div>
-    <hr>
+    <hr class="about-divider">
     <div class="about-close-container">
         <button hc-button class="about-close">Close</button>
     </div>


### PR DESCRIPTION
Allow hcMenuItem to support anchors as well as buttons. Also two small adjustments to the about-modal stylesheet (based on my implementation of it in AccessControl).

closes #1069