### PR TITLE
fix(navbar): improved more menu

### DIFF
--- a/projects/cashmere/src/lib/navbar/navbar.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar.component.html
@@ -4,9 +4,9 @@
             <img src="{{brandIcon}}">
         </a>
     </div>
-    <div class="navbar-app" [ngClass]="{'logo-condense': _logoCondense}">
+    <div class="navbar-app">
         <a [routerLink]="homeUri" class="app" *ngIf="appIcon">
-            <img src="{{appIcon}}" (load)="appIconLoaded()">
+            <img src="{{appIcon}}">
         </a>
     </div>
     <div #navlinks class="hc-navbar-link-container">

--- a/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
+++ b/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
@@ -73,11 +73,15 @@ describe('NavbarComponent', () => {
                 const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
                 spyOnProperty(linkContainer.nativeElement, 'offsetWidth', 'get').and.returnValue(300);
 
+                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
+                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(110);
+                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(110);
+
                 testHostComponent.navbarComponent['_collectNavLinkWidths']();
                 testHostComponent.navbarComponent._navResize();
 
                 expect(linkContainer.nativeElement['offsetWidth']).toEqual(300);
-                expect(testHostComponent.navbarComponent['_linksTotalWidth']).toEqual(211);
+                expect(testHostComponent.navbarComponent['_linksTotalWidth']).toEqual(220);
                 expect(testHostComponent.navbarComponent._moreList.length).toEqual(0);
                 expect(testHostComponent.navbarComponent['_collapse']).toBeFalsy();
             });
@@ -85,11 +89,15 @@ describe('NavbarComponent', () => {
                 const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
                 spyOnProperty(linkContainer.nativeElement, 'offsetWidth', 'get').and.returnValue(50);
 
+                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
+                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(110);
+                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(110);
+
                 testHostComponent.navbarComponent['_collectNavLinkWidths']();
                 testHostComponent.navbarComponent._navResize();
 
                 expect(linkContainer.nativeElement['offsetWidth']).toEqual(50);
-                expect(testHostComponent.navbarComponent['_linksTotalWidth']).toEqual(211);
+                expect(testHostComponent.navbarComponent['_linksTotalWidth']).toEqual(220);
                 expect(testHostComponent.navbarComponent._moreList.length).toEqual(2);
                 expect(testHostComponent.navbarComponent['_collapse']).toBeTruthy();
             });

--- a/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
+++ b/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
@@ -51,245 +51,47 @@ describe('NavbarComponent', () => {
             expect(testHostComponent.navbarComponent._navLinks['_results'][0]._getWidth()).toEqual(2400);
             expect(testHostComponent.navbarComponent._navLinks['_results'][1]._getWidth()).toEqual(3400);
             testHostComponent.navbarComponent['_collectNavLinkWidths']();
-            expect(testHostComponent.navbarComponent['_linksMax']).toEqual(5800);
+            expect(testHostComponent.navbarComponent['_linksTotalWidth']).toEqual(5800);
             expect(testHostComponent.navbarComponent['_linkWidths'].length).toEqual(2);
-            expect(testHostComponent.navbarComponent['_linkWidths'][0]).toEqual(3400);
-            expect(testHostComponent.navbarComponent['_linkWidths'][1]).toEqual(2400);
+            expect(testHostComponent.navbarComponent['_linkWidths'][0]).toEqual(2400);
+            expect(testHostComponent.navbarComponent['_linkWidths'][1]).toEqual(3400);
         });
     });
 
     describe('on calling all the lifecycle hooks', () => {
         it('should call _navResize', async(() => {
             spyOn(testHostComponent.navbarComponent, '_navResize');
-            testHostComponent.navbarComponent.ngOnInit();
-            testHostComponent.navbarComponent.appIconLoaded();
             testHostComponent.navbarComponent.ngAfterViewInit();
-            testHostComponent.navbarComponent.ngAfterContentInit();
             testHostFixture.whenStable().then(() => {
                 expect(testHostComponent.navbarComponent._navResize).toHaveBeenCalled();
             });
         }));
     });
     describe('on calling _navResize', () => {
-        it('should adjust the elements according to the navbar size', () => {
-            const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-            spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(0);
-            testHostComponent.navbarComponent._navResize();
-            expect(testHostComponent.navbarComponent._moreList.length).toEqual(0);
-            expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-        });
-    });
-    describe('on calling _navResize', () => {
-        // The cut off points are between regularWidth which in thiscase = switcher(55) +
-        // logowidth(200) +
-        // linkWidths (200 + 300) +
-        // icons (400) = 1155
-        // and condensedWidth = 1155 - 50 = 1105
         describe('and adjust the elements according to the navbar size', () => {
-            it('should have nothing in the moreList if the navbar > regularWidth', () => {
-                spyOn(testHostComponent.navbarComponent['ref'], 'detectChanges');
+            it('should have nothing in moreList if navbar links container > linksTotalWidth', () => {
                 const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(85);
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][0], 'show');
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][1], 'show');
+                spyOnProperty(linkContainer.nativeElement, 'offsetWidth', 'get').and.returnValue(300);
 
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(2400);
-
+                testHostComponent.navbarComponent['_collectNavLinkWidths']();
                 testHostComponent.navbarComponent._navResize();
+
+                expect(linkContainer.nativeElement['offsetWidth']).toEqual(300);
+                expect(testHostComponent.navbarComponent['_linksTotalWidth']).toEqual(211);
                 expect(testHostComponent.navbarComponent._moreList.length).toEqual(0);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
                 expect(testHostComponent.navbarComponent['_collapse']).toBeFalsy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeFalsy();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][0].show).toHaveBeenCalled();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][1].show).toHaveBeenCalled();
-                expect(testHostComponent.navbarComponent['ref'].detectChanges).toHaveBeenCalled();
             });
-            it('should have two items in the moreList if the navbar is 0', () => {
-                spyOn(testHostComponent.navbarComponent, '_navResize').and.callThrough();
+            it('should have two items in moreList if navbar links container is 50px', () => {
                 const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(0);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(85);
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][0], 'hide');
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][1], 'hide');
+                spyOnProperty(linkContainer.nativeElement, 'offsetWidth', 'get').and.returnValue(50);
 
+                testHostComponent.navbarComponent['_collectNavLinkWidths']();
                 testHostComponent.navbarComponent._navResize();
+
+                expect(linkContainer.nativeElement['offsetWidth']).toEqual(50);
+                expect(testHostComponent.navbarComponent['_linksTotalWidth']).toEqual(211);
                 expect(testHostComponent.navbarComponent._moreList.length).toEqual(2);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
                 expect(testHostComponent.navbarComponent['_collapse']).toBeTruthy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeTruthy();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][0].hide).toHaveBeenCalled();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][1].hide).toHaveBeenCalled();
-            });
-            it('should have a condensed logo if the width is between regular and condensed', () => {
-                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
-                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(300);
-                const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(1155);
-
-                testHostComponent.navbarComponent._navResize();
-                expect(testHostComponent.navbarComponent._moreList.length).toEqual(0);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-                expect(testHostComponent.navbarComponent['_collapse']).toBeFalsy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeFalsy();
-            });
-            it('should have a condensed logo if the width is between regular and condensed', () => {
-                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
-                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(300);
-                const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(1106);
-
-                testHostComponent.navbarComponent._navResize();
-                expect(testHostComponent.navbarComponent._moreList.length).toEqual(0);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-                expect(testHostComponent.navbarComponent['_collapse']).toBeFalsy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeFalsy();
-            });
-            it('should have a condensed logo if the width is between regular and condensed', () => {
-                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
-                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(300);
-                const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(1154);
-
-                testHostComponent.navbarComponent._navResize();
-                expect(testHostComponent.navbarComponent._moreList.length).toEqual(0);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-                expect(testHostComponent.navbarComponent['_collapse']).toBeFalsy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeFalsy();
-            });
-            // tslint:disable-next-line:max-line-length
-            it('should have a condensed logo if the width is less than condensed and takes the width of the more element into account', () => {
-                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
-                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(300);
-                const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][0], 'show');
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][1], 'show');
-
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(1105);
-
-                testHostComponent.navbarComponent._navResize();
-
-                expect(testHostComponent.navbarComponent._moreList.length).toEqual(0);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-                expect(testHostComponent.navbarComponent['_collapse']).toBeFalsy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeFalsy();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][0].show).toHaveBeenCalled();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][1].show).toHaveBeenCalled();
-            });
-            // tslint:disable-next-line:max-line-length
-            it('should have a condensed logo if the width is less than condensed and takes the width of the more element into account', () => {
-                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
-                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(300);
-                const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][0], 'hide');
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][1], 'hide');
-
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(721);
-
-                testHostComponent.navbarComponent._navResize();
-                expect(testHostComponent.navbarComponent._moreList.length).toEqual(2);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-                expect(testHostComponent.navbarComponent['_collapse']).toBeTruthy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeTruthy();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][0].hide).toHaveBeenCalled();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][1].hide).toHaveBeenCalled();
-            });
-            // tslint:disable-next-line:max-line-length
-            it('should have a condensed logo if the width is less than condensed and takes the width of the more element into account', () => {
-                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
-                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(300);
-                const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][0], 'show');
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][1], 'hide');
-
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(922);
-
-                testHostComponent.navbarComponent._navResize();
-                expect(testHostComponent.navbarComponent._moreList.length).toEqual(1);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-                expect(testHostComponent.navbarComponent['_collapse']).toBeTruthy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeTruthy();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][0].show).toHaveBeenCalled();
-                expect(testHostComponent.navbarComponent._navLinks['_results'][1].hide).toHaveBeenCalled();
-            });
-            // tslint:disable-next-line:max-line-length
-            it('should have a condensed logo if the width is less than condensed and takes the width of the more element into account', () => {
-                const link = testHostFixture.debugElement.queryAll(By.css('.link'));
-                spyOnProperty(link[0].nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOnProperty(link[1].nativeElement, 'scrollWidth', 'get').and.returnValue(300);
-                const linkContainer = testHostFixture.debugElement.query(By.css('.hc-navbar-link-container'));
-                spyOnProperty(linkContainer.nativeElement, 'clientWidth', 'get').and.returnValue(100);
-                const icons = testHostFixture.debugElement.query(By.css('.hc-navbar-right-container'));
-                spyOnProperty(icons.nativeElement, 'scrollWidth', 'get').and.returnValue(400);
-                const logo = testHostFixture.debugElement.query(By.css('.navbar-app'));
-                spyOnProperty(logo.nativeElement, 'scrollWidth', 'get').and.returnValue(200);
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][0], 'show');
-                spyOn(testHostComponent.navbarComponent._navLinks['_results'][1], 'show');
-
-                const navbar = testHostFixture.debugElement.query(By.css('.hc-navbar'));
-                spyOnProperty(navbar.nativeElement, 'scrollWidth', 'get').and.returnValue(921);
-
-                testHostComponent.navbarComponent._navResize();
-                expect(testHostComponent.navbarComponent._moreList.length).toEqual(1);
-                expect(testHostComponent.navbarComponent['_logoWidth']).toEqual(85);
-                expect(testHostComponent.navbarComponent['_collapse']).toBeTruthy();
-                expect(testHostComponent.navbarComponent['_logoCondense']).toBeTruthy();
-                // expect(testHostComponent.navbarComponent._navLinks['_results'][0].show).toHaveBeenCalled();
-                // expect(testHostComponent.navbarComponent._navLinks['_results'][1].show).toHaveBeenCalled();
             });
         });
     });

--- a/projects/cashmere/src/lib/navbar/navbar.component.ts
+++ b/projects/cashmere/src/lib/navbar/navbar.component.ts
@@ -1,5 +1,4 @@
 import {
-    AfterContentInit,
     AfterViewInit,
     ChangeDetectorRef,
     Component,
@@ -7,12 +6,10 @@ import {
     ElementRef,
     HostListener,
     Input,
-    OnInit,
     QueryList,
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import {forkJoin, Subject} from 'rxjs';
 import {HcPopoverAnchorDirective} from '../pop/directives/popover-anchor.directive';
 import {MoreItem} from './more-item';
 import {NavbarLinkComponent} from './navbar-link/navbar-link.component';
@@ -25,7 +22,7 @@ import {NavbarMobileMenuComponent} from './navbar-mobile-menu/navbar-mobile-menu
     styleUrls: ['./navbar.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
-export class NavbarComponent implements OnInit, AfterViewInit, AfterContentInit {
+export class NavbarComponent implements AfterViewInit {
     /** Display name of current user */
     @Input()
     user: string = '';
@@ -53,22 +50,15 @@ export class NavbarComponent implements OnInit, AfterViewInit, AfterContentInit 
     _navLinks: QueryList<NavbarLinkComponent>;
 
     @ViewChild('navbar') navbarContent: ElementRef;
-    @ViewChild('rightcontainer') rightContent: ElementRef;
     @ViewChild('navlinks') navContent: ElementRef;
 
     @ViewChild('moreLink')
     _navbarMore: HcPopoverAnchorDirective;
 
-    private _logoReady: Subject<boolean> = new Subject();
-    private _navLinksReady: Subject<boolean> = new Subject();
-    private _rightLinksReady: Subject<boolean> = new Subject();
     private _menuOpen: boolean = false;
     private _linkWidths: Array<number> = [];
-    private _rightWidth: number = 0;
-    private _linksMax: number = 0;
-    private _logoWidth: number = 0;
+    private _linksTotalWidth: number = 0;
     public _collapse: boolean = false;
-    public _logoCondense: boolean = false;
     public _moreList: Array<MoreItem> = [];
 
     @HostListener('window:resize')
@@ -76,106 +66,54 @@ export class NavbarComponent implements OnInit, AfterViewInit, AfterContentInit 
         if (this._navbarMore) {
             this._navbarMore.closePopover();
         }
+
         this._moreList = [];
+        this._collapse = false;
 
         // If links is zero the page is smaller than the first responsive breakpoint
         if (this.navbarContent.nativeElement.clientWidth <= 0) {
             return;
         }
 
-        // Figure out all the relevant element widths
-        this._collectNavLinkWidths();
-        this._setRightContainerWidth();
+        let linksContainerWidth: number = this.navContent.nativeElement.offsetWidth;
+        let curLinks: number = 0;
 
-        const navbarWidth: number = this.navbarContent.nativeElement.scrollWidth;
-        const icons: number = this._rightWidth;
-        const more: number = 116;
-        const switcher: number = 55;
-        let links: number = this._linksMax;
-        const logoWidth = this._logoWidth;
-        const condensedLogoWidth = logoWidth - 50;
-        const regularWidth = switcher + logoWidth + links + icons;
-        const condensedWidth = switcher + condensedLogoWidth + links + more + icons;
+        // Step through the links until we hit the end of the container, then collapse the
+        // remaining into a more menu
+        this._navLinks.forEach((t, i) => {
+            curLinks += this._linkWidths[i];
 
-        if (navbarWidth <= regularWidth) {
-            this._logoCondense = true;
-            let tempArray = this._navLinks.toArray();
-            tempArray.reverse();
-
-            if (navbarWidth <= condensedWidth) {
-                this._collapse = true;
-                tempArray[0].hide();
-                links -= this._linkWidths[0];
-                this._moreList.push({name: tempArray[0].linkText, uri: tempArray[0].uri} as MoreItem);
-
-                for (let i = 1; i < tempArray.length; i++) {
-                    if (navbarWidth <= switcher + condensedLogoWidth + links + icons + more) {
-                        tempArray[i].hide();
-                        links -= this._linkWidths[i];
-                        this._moreList.push({name: tempArray[i].linkText, uri: tempArray[i].uri});
-                    } else {
-                        tempArray[i].show();
-                    }
-                }
-
-                this._moreList.reverse();
+            let moreWidth: number = this._linksTotalWidth > linksContainerWidth ? 116 : 0;
+            if (curLinks + moreWidth < linksContainerWidth) {
+                t.show();
             } else {
-                this._collapse = false;
-                this._navLinks.forEach(t => t.show());
+                t.hide();
+                this._collapse = true;
+                this._moreList.push({name: t.linkText, uri: t.uri});
             }
-        } else {
-            this._collapse = false;
-            this._logoCondense = false;
-            this._navLinks.forEach(t => t.show());
-        }
+        });
+
         this.ref.detectChanges();
     }
 
     constructor(private el: ElementRef, private ref: ChangeDetectorRef) {}
 
-    private _setRightContainerWidth() {
-        if (this._rightWidth === 0) {
-            this._rightWidth = this.rightContent.nativeElement.scrollWidth;
-        }
-    }
-
     private _collectNavLinkWidths() {
         if (this._linkWidths.length === 0 || this._linkWidths.every(linkWidth => linkWidth === 0)) {
             this._linkWidths = [];
             this._navLinks.forEach(t => {
-                this._linksMax += t._getWidth();
+                this._linksTotalWidth += t._getWidth();
                 this._linkWidths.push(t._getWidth());
             });
-            this._linkWidths.reverse();
         }
-    }
-
-    ngOnInit() {
-        forkJoin([this._logoReady, this._navLinksReady, this._rightLinksReady]).subscribe(() => {
-            this._navResize();
-        });
-        if (!this.appIcon) {
-            this.appIconLoaded();
-        }
-    }
-    appIconLoaded() {
-        this._logoWidth = this.el.nativeElement.querySelector('.navbar-app').scrollWidth;
-        this._logoReady.next(true);
-        this._logoReady.complete();
-    }
-    ngAfterContentInit() {
-        setTimeout(() => {
-            this._navLinksReady.next(true);
-            this._navLinksReady.complete();
-        }, 100);
     }
     ngAfterViewInit() {
         setTimeout(() => {
-            this._setRightContainerWidth();
-            this._rightLinksReady.next(true);
-            this._rightLinksReady.complete();
+            this._collectNavLinkWidths();
+            this._navResize();
         }, 100);
     }
+
     _toggleMobileMenu() {
         if (this._mobileMenu.first) {
             if (this._menuOpen) {

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -5,7 +5,7 @@
 $navbar-color: $charcoal-blue !default;
 $navbar-brand: $primary-brand !default;
 $navbar-height: 53px !default;
-$navbar-app-padding: 0 60px 0 25px !default;
+$navbar-app-padding: 0 50px 0 25px !default;
 $navbar-text: $white !default;
 $navbar-text-inactive: $gray-300 !default;
 $navbar-fixed-shadow: 0px 2px 6px $shadow;
@@ -58,10 +58,6 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     height: 100%;
     padding: $navbar-app-padding;
 
-    &.logo-condense {
-        padding-right: 25px;
-    }
-
     a {
         display: flex;
         align-items: center;
@@ -87,6 +83,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     padding: 0;
     padding-left: 0;
     overflow: hidden;
+    width: 100%;
     @include media-breakpoint-down(md) {
         display: none;
     }
@@ -98,6 +95,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     box-sizing: border-box;
     padding: 22px 30px 0 30px;
     text-align: center;
+    white-space: nowrap;
     color: $navbar-text-inactive;
     border-bottom: 5px solid transparent;
     transition: background-color 0.25s;


### PR DESCRIPTION
Improves collapsing links into more menu; prevents link text wrapping.  Still doesn't eliminate the `setTimeout` on `ngAfterViewInit` - but @corykon and I were struggling to come up with a way to clever remove that hack.

closes #1066
closes #671