### PR TITLE
feat(hc-menu): keyboard navigation

### DIFF
--- a/projects/cashmere-examples/src/lib/popover-menu/popover-menu-example.component.html
+++ b/projects/cashmere-examples/src/lib/popover-menu/popover-menu-example.component.html
@@ -3,23 +3,23 @@
 <hc-pop #menu [autoCloseOnContentClick]="true" [showArrow]="false" horizontalAlign="start">
     <div hcMenu>
         <a hcMenuItem href="http://example.com">
-            <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-snowflake-o"></hc-icon>
-            <span hcMenuText>Snowflake</span>
+            <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-floppy-o "></hc-icon>
+            <span hcMenuText>Save document</span>
             <span hcMenuSubText>Ctrl + S</span>
         </a>
         <button hcMenuItem>
-            <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-plus"></hc-icon>
-            <span hcMenuText>Add a new one</span>
+            <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-arrow-circle-down"></hc-icon>
+            <span hcMenuText>Press an arrow key</span>
         </button>
         <div hcMenuItem hcDivider></div>
         <button hcMenuItem>
-            <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-camera-retro"></hc-icon>
-            <span hcMenuText>Hip Photo</span>
+            <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-keyboard-o"></hc-icon>
+            <span hcMenuText>Or the tab key</span>
             <span hcMenuSubText>Ctrl + P</span>
         </button>
         <button hcMenuItem disabled>
             <span hcMenuIcon></span>
-            <span hcMenuText>Menu item 3</span>
+            <span hcMenuText>Disabled Item</span>
             <span hcMenuSubText>I'm disabled</span>
         </button>
     </div>
@@ -28,4 +28,5 @@
 <p class="hc-font-sm">
     The directives <code>hcMenu</code>, <code>hcMenuItem</code>, <code>hcMenuIcon</code>,
     <code>hcMenuText</code>, and <code>hcMenuSubText</code> may be used to create menus using the popover component.
+    When a menu is open, the arrow or tab keys may be used to navigate.
 </p>

--- a/projects/cashmere/src/lib/pop/directives/menu-item.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/menu-item.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, HostBinding} from '@angular/core';
+import {Directive, HostBinding, ElementRef, HostListener} from '@angular/core';
 
 /** Use `hcMenuItem` for a selectable item in an hcMenu. */
 @Directive({
@@ -7,4 +7,19 @@ import {Directive, HostBinding} from '@angular/core';
 export class MenuItemDirective {
     @HostBinding('class.hc-menu-item')
     _hostClass = true;
+
+    // Menu Item uses focus for hover highlighting to sync with keyboard navigation of the menu
+    @HostListener('mouseenter')
+    focus(): void {
+        this.ref.nativeElement.focus();
+    }
+
+    @HostListener('touchend')
+    @HostListener('touchcancel')
+    @HostListener('mouseleave')
+    blur(): void {
+        this.ref.nativeElement.blur();
+    }
+
+    constructor(public ref: ElementRef) {}
 }

--- a/projects/cashmere/src/lib/pop/directives/menu.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/menu.directive.ts
@@ -1,4 +1,5 @@
-import {Directive, HostBinding} from '@angular/core';
+import {Directive, HostBinding, ContentChildren, QueryList} from '@angular/core';
+import {MenuItemDirective} from './menu-item.directive';
 
 /** The `hcMenu` directive provides a standard way of displaying a series of selectable elements in a popover. */
 @Directive({
@@ -7,4 +8,34 @@ import {Directive, HostBinding} from '@angular/core';
 export class MenuDirective {
     @HostBinding('class.hc-menu-panel')
     _hostClass = true;
+
+    @ContentChildren(MenuItemDirective)
+    _menuItems: QueryList<MenuItemDirective>;
+
+    keyFocus(downPress: boolean) {
+        let itemArray = this._menuItems.toArray();
+        if (!downPress) {
+            itemArray.reverse();
+        }
+        let selected = false;
+
+        // Determine if any item in the menu is currently focused, and select the next (or previous)
+        for (let i = 0; i < itemArray.length; i++) {
+            if (selected && !itemArray[i].ref.nativeElement.classList.contains('hc-divider') && !itemArray[i].ref.nativeElement.disabled) {
+                itemArray[i].focus();
+                return;
+            }
+            if (itemArray[i].ref.nativeElement === document.activeElement) {
+                selected = true;
+            }
+        }
+
+        // If no item is focused, selected the first (or last) item that isn't a divider or disabled
+        for (let i = 0; i < itemArray.length; i++) {
+            if (!itemArray[i].ref.nativeElement.classList.contains('hc-divider') && !itemArray[i].ref.nativeElement.disabled) {
+                itemArray[i].focus();
+                return;
+            }
+        }
+    }
 }

--- a/projects/cashmere/src/lib/pop/popover.component.html
+++ b/projects/cashmere/src/lib/pop/popover.component.html
@@ -4,7 +4,7 @@
       class="{{_yAlignClass}} {{_xAlignClass}}"
       [class.hc-pop-container-basic]="!disableStyle"
       [ngClass]="_classList"
-      (click)="popContainerClicked()"
+      (click)="_popContainerClicked()"
       [@transformPopover]="_getAnimation()"
       (@transformPopover.done)="_onAnimationDone($event)">
     <ng-content></ng-content>

--- a/projects/cashmere/src/lib/pop/popover.component.ts
+++ b/projects/cashmere/src/lib/pop/popover.component.ts
@@ -10,7 +10,10 @@ import {
     OnDestroy,
     OnInit,
     Optional,
-    Output
+    Output,
+    HostListener,
+    ContentChild
+
 } from '@angular/core';
 import {AnimationEvent} from '@angular/animations';
 import {DOCUMENT} from '@angular/common';
@@ -35,10 +38,17 @@ import {
     HcPopoverOpenOptions
 } from './types';
 import {OverlayRef} from '@angular/cdk/overlay';
+import {MenuDirective} from './directives/menu.directive';
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const DEFAULT_TRANSITION = '100ms linear';
 const EMPTY_TRANSITION = '0ms linear';
+
+export enum KEY_CODE {
+    DOWN_ARROW = 40,
+    UP_ARROW = 38,
+    TAB = 9
+}
 
 @Component({
     selector: 'hc-pop',
@@ -273,6 +283,25 @@ export class HcPopComponent implements OnInit, OnDestroy {
     /** Reference to a focus trap around the popover. */
     private _focusTrap: FocusTrap | undefined;
 
+    /** Reference to the hcMenu (if the popover contains one) */
+    @ContentChild(MenuDirective) _popMenu: MenuDirective;
+
+    @HostListener('window:keydown', ['$event'])
+    _keyEvent(event: KeyboardEvent) {
+        if ( this._open && this._popMenu ) {
+            if (event.keyCode === KEY_CODE.UP_ARROW) {
+                event.stopPropagation();
+                event.preventDefault();
+                this._popMenu.keyFocus(false);
+            }
+            if (event.keyCode === KEY_CODE.DOWN_ARROW || event.keyCode === KEY_CODE.TAB) {
+                event.stopPropagation();
+                event.preventDefault();
+                this._popMenu.keyFocus(true);
+            }
+        }
+    }
+
     constructor(
         public _elementRef: ElementRef,
         private _focusTrapFactory: FocusTrapFactory,
@@ -289,7 +318,7 @@ export class HcPopComponent implements OnInit, OnDestroy {
         }
     }
 
-    popContainerClicked(): void {
+    _popContainerClicked(): void {
         if (this.autoCloseOnContentClick) {
             this.close();
         }

--- a/projects/cashmere/src/lib/sass/_menu.scss
+++ b/projects/cashmere/src/lib/sass/_menu.scss
@@ -43,7 +43,12 @@ a.hc-menu-item {
         opacity: 0.5;
     }
 
-    &:hover:not([disabled]) {
+    &:active,
+    &:hover {
+        color: $offblack;
+    }
+
+    &:focus:not([disabled]) {
         background-color: tint($blue, 70%);
         color: $offblack;
         cursor: pointer;


### PR DESCRIPTION
Allows users to navigate hcMenus using arrows or tab keys.  

Give this one a look over @corykon.  I noticed when I was looking at Google docs that it's important keyboard navigation and mouse highlighting need to stay synced up.  So that's why I used focus as a way for all of them to work together.

closes #1049