### PR TITLE
fix(navbar): support two line username

### DIFF
--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
@@ -9,7 +9,10 @@
     <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-question-circle-o" [hcPop]="options"></hc-icon>
     <span class="hc-navbar-vertical-separator"></span>
     <div class="hc-navbar-username" *ngIf="user" [hcPop]="user">
-        <span class="hc-text-ellipsis">{{username}}</span>
+        <span>
+            <span>{{username}}</span><br>
+            <span style="color:#c0c5cc">{{organization}}</span>
+        </span>
         <hc-icon fontSet="fa" fontIcon="fa-angle-down"></hc-icon>
     </div>
 </hc-navbar>

--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
@@ -11,7 +11,7 @@
     <div class="hc-navbar-username" *ngIf="user" [hcPop]="user">
         <span>
             <span>{{username}}</span><br>
-            <span style="color:#c0c5cc">{{organization}}</span>
+            <span class="hc-navbar-username-subtext">{{organization}}</span>
         </span>
         <hc-icon fontSet="fa" fontIcon="fa-angle-down"></hc-icon>
     </div>

--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.ts
@@ -9,4 +9,5 @@ import {Component} from '@angular/core';
 })
 export class NavbarOverviewExampleComponent {
     username = 'Christine K.';
+    organization = 'Millrock Hospital';
 }

--- a/projects/cashmere/src/lib/navbar/navbar.component.scss
+++ b/projects/cashmere/src/lib/navbar/navbar.component.scss
@@ -35,6 +35,10 @@
         @include hc-navbar-username();
     }
 
+    .hc-navbar-username-subtext {
+        @include hc-navbar-username-subtext();
+    }
+
     .hc-navbar-vertical-separator {
         @include hc-navbar-vertical-separator();
     }

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -168,6 +168,10 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     white-space: nowrap;
 }
 
+@mixin hc-navbar-username-subtext {
+    color: $slate-gray-300;
+}
+
 @mixin hc-navbar-vertical-separator {
     display: flex;
     align-items: center;

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -158,15 +158,14 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
 
 @mixin hc-navbar-username {
     @include navbar-item();
-    padding: 20px 15px 0;
+    padding: 2px 15px 0;
     > hc-icon {
         font-size: 12pt;
+        padding-top: 2px;
     }
-    > span {
-        max-width: 130px;
-    }
-    max-width: 150px;
     display: flex;
+    align-items: center;
+    white-space: nowrap;
 }
 
 @mixin hc-navbar-vertical-separator {


### PR DESCRIPTION
Allow the navbar username block to support two lines of text. Also removes the 150px `max-width` cap on the username.  Updated one of the navbar examples to demonstrate a username block with two lines.  Let me know what you all think.

closes #1105