### PR TITLE
fix(datepicker): support preset overlapping values

### DIFF
--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
@@ -7,7 +7,7 @@
         popperPlacement="bottom"
         (selectedDateRangeChanged)="updateRange($event)"
         (selectedPresetChanged)="updatePreset($event)"
-        [selectedDate]="range"
+        [selectedDate]="selected"
         [options]="options"
         #pickerOne
     >

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
@@ -77,7 +77,7 @@ export class DateRangeExampleComponent implements OnInit {
                 range: {fromDate: currMonthStart, toDate: currMonthEnd}
             },
             {
-                presetLabel: '1 Month to Date',
+                presetLabel: '1 Month to End',
                 range: {fromDate: currMonthStart, toDate: currMonthEnd}
             },
             {

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
@@ -8,6 +8,7 @@ import {DateRangeOptions, PresetItem, DateRange} from '@healthcatalyst/cashmere'
 })
 export class DateRangeExampleComponent implements OnInit {
     range: DateRange = {fromDate: new Date(), toDate: new Date()};
+    selected: number | DateRange = this.range;
     options: DateRangeOptions;
     presets: Array<PresetItem> = [];
     presetSelection: string = 'None';
@@ -36,8 +37,10 @@ export class DateRangeExampleComponent implements OnInit {
     updatePreset(index: number | DateRange) {
         if (typeof index === 'number') {
             this.presetSelection = this.presets[index].presetLabel;
+            this.selected = index;
         } else {
             this.presetSelection = 'None';
+            this.selected = this.range;
         }
     }
 
@@ -71,6 +74,10 @@ export class DateRangeExampleComponent implements OnInit {
             },
             {
                 presetLabel: 'This Month',
+                range: {fromDate: currMonthStart, toDate: currMonthEnd}
+            },
+            {
+                presetLabel: '1 Month to Date',
                 range: {fromDate: currMonthStart, toDate: currMonthEnd}
             },
             {

--- a/projects/cashmere/src/lib/date-range/date-range/date-range.directive.spec.ts
+++ b/projects/cashmere/src/lib/date-range/date-range/date-range.directive.spec.ts
@@ -25,7 +25,7 @@ class MockOverlayService {
 })
 class TestComponent {
     options: DateRangeOptions;
-    range: DateRange = {fromDate: new Date(), toDate: new Date()};
+    range: number | DateRange = {fromDate: new Date(), toDate: new Date()};
     constructor() {
         this.options = {
             presets: [
@@ -105,12 +105,9 @@ describe('DateRangeDirective', () => {
         expect(overlay.open).toHaveBeenCalled();
     });
 
-    it('should return the index of the selected preset', () => {
-        const resetRange = {fromDate: new Date(2000, 1, 1), toDate: new Date(2000, 1, 2)};
-        directive.selectedDate = resetRange;
-
+    it('should set the selected preset from an index', () => {
         spyOn(component, 'updatePreset');
-        component.range = resetRange;
+        component.range = 1;
         fixture.detectChanges();
 
         expect(component.updatePreset).toHaveBeenCalledWith(1);

--- a/projects/cashmere/src/lib/date-range/date-range/date-range.directive.ts
+++ b/projects/cashmere/src/lib/date-range/date-range/date-range.directive.ts
@@ -2,7 +2,7 @@ import {OnInit, Output, EventEmitter, Input, OnDestroy, ElementRef, Directive, H
 import {DatePipe} from '@angular/common';
 import {OverlayRef} from '@angular/cdk/overlay';
 import {CalendarOverlayService} from '../services/calendar-overlay.service';
-import {DateRange, DateRangeOptions, PresetItem} from '../model/model';
+import {DateRange, DateRangeOptions} from '../model/model';
 import {ConfigStoreService} from '../services/config-store.service';
 
 @Directive({
@@ -14,9 +14,9 @@ export class DateRangeDirective implements OnInit, OnDestroy, OnChanges {
     @Output()
     readonly selectedDateRangeChanged: EventEmitter<DateRange> = new EventEmitter<DateRange>();
 
-    /** Selected date range. */
+    /** Sets the selected date range. Accepts either a `DateRange` or a numerical index for preset. */
     @Input()
-    selectedDate: DateRange;
+    selectedDate: number | DateRange;
 
     /** Emits either a numerical index for the selected preset, or a `DateRange` if the selected value is not a preset */
     @Output()
@@ -55,22 +55,12 @@ export class DateRangeDirective implements OnInit, OnDestroy, OnChanges {
             this.configStoreService.updateDateRangeOptions(options);
         }
         if (changes['selectedDate']) {
-            const selectedDate: DateRange = changes['selectedDate'].currentValue;
-            this.configStoreService.updateRange(selectedDate);
+            const selectedDate: number | DateRange = changes['selectedDate'].currentValue;
 
-            if (this.options.presets) {
-                let selectedPreset = -1;
-                for (let i = 0; i < this.options.presets.length; i++) {
-                    let tempRange = this.options.presets[i].range;
-                    if ( tempRange.fromDate && selectedDate.fromDate &&
-                        tempRange.fromDate.toDateString() === selectedDate.fromDate.toDateString() &&
-                        tempRange.toDate && selectedDate.toDate &&
-                        tempRange.toDate.toDateString() === selectedDate.toDate.toDateString()
-                    ) {
-                        selectedPreset = i;
-                    }
-                }
-                this.configStoreService.updatePreset(selectedPreset >= 0 ? selectedPreset : selectedDate);
+            if ( typeof selectedDate === 'number' ) {
+                this.configStoreService.updatePreset(selectedDate);
+            } else {
+                this.configStoreService.updateRange(selectedDate);
             }
         }
     }

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
@@ -32,13 +32,13 @@
     <div class="hc-date-range-calendar-item">
         <div class="hc-date-range-menu">
             <hc-radio-group class="presets" [(ngModel)]="_selectedPreset">
-                <hc-radio-button *ngFor="let p of options.presets; let i = index" [value]="p.range" [id]="'hc-date-range-preset-'+i" (change)="_updateRangeByPreset(p.range)">{{ p.presetLabel }}</hc-radio-button>
+                <hc-radio-button *ngFor="let p of options.presets; let i = index" [value]="i" (change)="_updateRangeByPreset(i)">{{ p.presetLabel }}</hc-radio-button>
             </hc-radio-group>
             <div class="hc-date-range-controls">
                 <button hc-button buttonStyle="link" type="button" (click)="_discardNewDates()">
                     {{ options.cancelLabel }}
                 </button>
-                <button hc-button buttonStyle="primary" type="button" [disabled]="_disabled" (click)="_applyNewDates()">
+                <button hc-button buttonStyle="primary" type="button" [disabled]="!(this._toDate && this._fromDate)" (click)="_applyNewDates()">
                     {{ options.applyLabel }}
                 </button>
             </div>

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
@@ -48,14 +48,13 @@ describe('RangeComponent', () => {
     });
 
     it("should select a preset radio if the current dates match that preset's range", () => {
-        let radioDebugElement = fixture.debugElement.query(By.directive(RadioButtonComponent));
-        expect(radioDebugElement.componentInstance.checked).toBe(false);
+        expect(component._selectedPreset).toBeFalsy();
 
         component._updateFromDate(new Date(2010, 1, 1));
         component._updateToDate(new Date(2010, 1, 2));
         fixture.detectChanges();
 
-        expect(radioDebugElement.componentInstance.checked).toBe(true);
+        expect(component._selectedPreset).toBe(0);
     });
 
     describe('fromMaxDate', () => {

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
@@ -77,7 +77,14 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
             this._skipRangeCheck = true;
             this._fromDate = this._presetValues[index].range.fromDate;
             this._toDate = this._presetValues[index].range.toDate;
+
             setTimeout(() => {
+                if ( this._fromDate ) {
+                    this.calendarWrappers.first.hcCalendar.activeDate = this._fromDate;
+                }
+                if ( this._toDate ) {
+                    this.calendarWrappers.last.hcCalendar.activeDate = this._toDate;
+                }
                 this._skipRangeCheck = false;
             });
         }

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
@@ -1,5 +1,5 @@
-import {Component, OnInit, ViewEncapsulation, ChangeDetectorRef, AfterViewInit, ViewChildren, QueryList} from '@angular/core';
-import {DateRangeOptions} from '../model/model';
+import {Component, OnInit, ViewEncapsulation, AfterViewInit, ViewChildren, QueryList} from '@angular/core';
+import {DateRangeOptions, PresetItem} from '../model/model';
 import {OverlayRef} from '@angular/cdk/overlay';
 import {ConfigStoreService} from '../services/config-store.service';
 import {DateRange} from '../model/model';
@@ -7,7 +7,6 @@ import {D} from '../../datepicker/datetime/date-formats';
 import {CalendarWrapperComponent} from '../calendar-wrapper/calendar-wrapper.component';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {RadioButtonComponent, RadioGroupDirective} from '../../radio-button/radio';
 
 // ** Date range wrapper component */
 @Component({
@@ -20,24 +19,21 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
     options$: Observable<DateRangeOptions>;
     _fromDate: D | undefined;
     _toDate: D | undefined;
-    _disabled: boolean;
-    _selectedPreset: DateRange | null;
+    _selectedPreset: number | null;
+    _presetValues: PresetItem[] | undefined;
+    _skipRangeCheck: boolean = false;
 
     @ViewChildren(CalendarWrapperComponent)
     calendarWrappers: QueryList<CalendarWrapperComponent>;
 
-    @ViewChildren(RadioButtonComponent)
-    _presetRadios: QueryList<RadioButtonComponent>;
-
-    @ViewChildren(RadioGroupDirective)
-    _presetGroup: QueryList<RadioGroupDirective>;
-
-    constructor(public configStoreService: ConfigStoreService, private overlayRef: OverlayRef, private cd: ChangeDetectorRef) {
+    constructor(public configStoreService: ConfigStoreService, private overlayRef: OverlayRef) {
         this.options$ = configStoreService.dateRangeOptions$;
     }
 
     ngOnInit() {
-        this._setValidity();
+        this.options$.subscribe((options: DateRangeOptions) => {
+            this._presetValues = options.presets;
+        });
         this.configStoreService.rangeUpdate$.subscribe((dateRange: DateRange) => {
             if (dateRange) {
                 this._fromDate = dateRange.fromDate;
@@ -47,66 +43,66 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
                 this._toDate = undefined;
             }
         });
+        this.configStoreService.presetUpdate$.subscribe((presetIndex: number | DateRange) => {
+            if (typeof presetIndex === 'number') {
+                this._selectedPreset = presetIndex;
+                this._updateRangeByPreset( presetIndex );
+            }
+        });
     }
 
     ngAfterViewInit(): void {
         if (this.calendarWrappers.first) {
             this.calendarWrappers.first.focusInput();
         }
-        setTimeout(() => {
-            this._isRangePreset();
-        });
     }
 
     _updateFromDate(date?: D) {
-        this._fromDate = date;
-        if (this._selectedPreset && this._selectedPreset.fromDate !== date) {
-            setTimeout(() => {
-                this._selectedPreset = null;
-                this.cd.detectChanges();
-            });
+        if ( !this._skipRangeCheck ) {
+            this._fromDate = date;
+            this._isRangePreset();
         }
-        this._setValidity();
-        this._isRangePreset();
     }
 
     _updateToDate(date?: D) {
-        this._toDate = date;
-        if (this._selectedPreset && this._selectedPreset.toDate !== date) {
-            setTimeout(() => {
-                this._selectedPreset = null;
-                this.cd.detectChanges();
-            });
+        if ( !this._skipRangeCheck ) {
+            this._toDate = date;
+            this._isRangePreset();
         }
-        this._setValidity();
-        this._isRangePreset();
     }
 
-    _updateRangeByPreset(range: DateRange) {
-        this._fromDate = range.fromDate;
-        this._toDate = range.toDate;
-        this._setValidity();
+    _updateRangeByPreset(index: number) {
+        if (this._presetValues && index < this._presetValues.length && index >= 0 ) {
+            // Prevent the system from assigning a preset if one has specifically been selected
+            this._skipRangeCheck = true;
+            this._fromDate = this._presetValues[index].range.fromDate;
+            this._toDate = this._presetValues[index].range.toDate;
+            setTimeout(() => {
+                this._skipRangeCheck = false;
+            });
+        }
     }
 
     _isRangePreset() {
-        if (this._presetRadios) {
-            this._presetRadios.forEach((radio: RadioButtonComponent) => {
-                let radioRange: DateRange = radio.value;
+        this._selectedPreset = null;
+        if (this._presetValues) {
+            for (let i = 0; i < this._presetValues.length; i++) {
+                let radioRange: DateRange = this._presetValues[i].range;
                 if (this._fromDate && radioRange.fromDate && this._toDate && radioRange.toDate) {
-                    radio.checked =
-                        this._fromDate.toDateString() === radioRange.fromDate.toDateString() &&
-                        this._toDate.toDateString() === radioRange.toDate.toDateString();
+                    if ( this._fromDate.toDateString() === radioRange.fromDate.toDateString() &&
+                        this._toDate.toDateString() === radioRange.toDate.toDateString() ) {
+                            this._selectedPreset = i;
+                    }
                 }
-            });
+            }
         }
     }
 
     _applyNewDates() {
         if (!!this._toDate && !!this._fromDate) {
             this.configStoreService.updateRange({fromDate: this._fromDate, toDate: this._toDate});
-            if ( this._presetGroup.first.selected ) {
-                let presetStr = this._presetGroup.first.selected.id.substr(21);
-                this.configStoreService.updatePreset( +presetStr );
+            if (this._selectedPreset !== null) {
+                this.configStoreService.updatePreset(this._selectedPreset);
             } else {
                 this.configStoreService.updatePreset({fromDate: this._fromDate, toDate: this._toDate});
             }
@@ -116,10 +112,6 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
 
     _discardNewDates() {
         this.overlayRef.dispose();
-    }
-
-    _setValidity() {
-        this._disabled = !this._toDate || !this._fromDate;
     }
 
     get _fromMaxDate(): Observable<Date | undefined> {


### PR DESCRIPTION
Allow multiple presets with same date ranges & selectedDate may be number.  @jacquie the DatePicker definitely wasn't set up to support your use case, so it required some well needed house cleaning.  The good news is that it's leaner and meaner than before - and I believe it now should do what you need it to.  I've updated our example a prove out the functionality (it has two presets with the same value).

Please give it a good look over and ensure that the functionality looks like it's got you covered.

closes #1111