### PR TITLE
1034 documentation rewrite example

### DIFF
--- a/projects/cashmere-examples/src/lib/button/button-example.component.html
+++ b/projects/cashmere-examples/src/lib/button/button-example.component.html
@@ -1,0 +1,3 @@
+<button hc-button buttonStyle="primary" size="md">
+    Primary, Medium
+</button>

--- a/projects/cashmere-examples/src/lib/button/button-example.component.scss
+++ b/projects/cashmere-examples/src/lib/button/button-example.component.scss
@@ -1,0 +1,3 @@
+button {
+    margin: 10px;
+}

--- a/projects/cashmere-examples/src/lib/button/button-example.component.scss
+++ b/projects/cashmere-examples/src/lib/button/button-example.component.scss
@@ -1,3 +1,0 @@
-button {
-    margin: 10px;
-}

--- a/projects/cashmere-examples/src/lib/button/button-example.component.ts
+++ b/projects/cashmere-examples/src/lib/button/button-example.component.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title Button (basic example)
+ */
+@Component({
+    selector: 'hc-button-example',
+    templateUrl: 'button-example.component.html',
+    styleUrls: ['button-example.component.scss']
+})
+export class ButtonExampleComponent {}

--- a/projects/cashmere/src/lib/button/button.md
+++ b/projects/cashmere/src/lib/button/button.md
@@ -106,6 +106,8 @@ For a split button (a button with a caret and a dropdown menu), replace `<button
 
 ##### Methods
 
+First, get a reference to the element.
+
 ```html
 <button hc-button #buttonElement></button>
 

--- a/projects/cashmere/src/lib/button/button.md
+++ b/projects/cashmere/src/lib/button/button.md
@@ -1,9 +1,148 @@
-##### Split Buttons
+##### Attributes
 
-**hc-split-button**
+**[buttonStyle]**
 
-To use `hc-split-button` you encapsulate the content you want to be shown on the button. Anything marked with the directive `hcButtonItem` will get transferred into the dropdown menu. Everything else will be shown as the main button's content
+`buttonStyle: 'primary' | 'primary-alt' | 'secondary' | 'destructive' | 'neutral' | 'minimal' | 'link' | 'link-inline' = 'primary'`
 
-**hcButtonItem**
+Sets the color and style of the button.
 
-Marks an element for being put into the dropdown menu of the button. Multiple things can be marked with this directive
+```html
+<button hc-button buttonStyle="primary">button</button>
+```
+
+**[size]**
+
+`size: 'sm' | 'md' | 'lg' = 'md'`
+
+Sets the size of the button.
+
+```html
+<button hc-button size="md">button</button>
+```
+
+**[disabled]**
+
+`disabled: boolean = false`
+
+Puts the button in a disabled state.
+
+```html
+<button [disabled]="true">button</button>
+```
+
+**[hc-icon-button]**
+
+Use this instead of the `buttonStyle` attribute to designate this as a textless icon button.
+
+```html
+<button hc-icon-button>
+    <hc-icon fontSet="fa" fontIcon="fa-anchor"></hc-icon>
+</button>
+```
+
+**[autoCloseMenuOnClick]**
+
+`autoCloseMenuOnClick: boolean = true`
+
+True if clicking anywhere in the dropdown menu should automatically close it.
+
+```html
+<hc-split-button [autoCloseMenuOnClick]="false">
+    Split button
+    <div hcButtonItem>Menu Item</div>
+</hc-split-button>
+```
+
+**[menuPosition]**
+
+`menuPosition: 'start' | 'end' | 'center' = 'end'`
+
+Positions the dropdown menu horizontally, relative to the left and right edges of the button.
+
+```html
+<hc-split-button menuPosition="start">
+    Split button
+    <div hcButtonItem>Menu Item</div>
+</hc-split-button>
+```
+
+**[...]**
+
+The common HTML button attributes `name`, `title`, `type`, and `value` can be used on an `<hc-split-button>` in the normal way.
+
+##### Events
+
+**(click)**
+
+Buttons are generally used with a click event handler.
+
+```html
+<button hc-button (click)="handleClick()"></button>
+```
+
+##### Related Components
+
+**HcIcon**
+
+You can use a Cashmere icon in any button. It's recommended that you style it with some extra margin so it doesn't abut button text.
+
+```html
+<button hc-button>
+    <hc-icon fontSet="fa" fontIcon="fa-cog" style="margin-right: 5px">
+    Options
+</button>
+```
+
+**HcSplitButton**
+
+For a split button (a button with a caret and a dropdown menu), replace `<button>` with `<hc-split-button>`. Put menu options inside the `<hc-split-button>`, tagged with the `hcButtonItem` attribute.
+
+```html
+<hc-split-button buttonStyle="primary">
+    Split Button
+    <div hcButtonItem>Menu Item</div>
+</hc-split-button>
+```
+
+##### Methods
+
+```html
+<button hc-button #buttonElement></button>
+
+<hc-split-button #splitButtonElement>
+    Split button
+    <div hcButtonItem>Menu Item</div>
+</hc-split-button>
+```
+
+```typescript
+export class ExampleComponent {
+    @ViewChild('buttonElement') buttonRef: ButtonComponent;
+    @ViewChild('splitButtonElement') splitButtonRef: SplitButtonComponent;
+}
+```
+
+**focus()**
+
+Gives focus to the button.
+
+```typescript
+this.buttonRef.focus();
+this.splitButtonRef.focus();
+```
+
+**openMenu()**
+
+Opens the dropdown menu.
+
+```typescript
+this.splitButtonRef.openMenu();
+```
+
+**closeMenu()**
+
+Closes the dropdown menu.
+
+```typescript
+this.splitButtonRef.closeMenu();
+```

--- a/projects/cashmere/src/lib/button/button.md
+++ b/projects/cashmere/src/lib/button/button.md
@@ -1,4 +1,8 @@
-##### Attributes
+## Key Attributes
+
+Below is a list of the primary attributes that you'll be likely to use when working with a `hc-button`. For a complete list of attributes, refer to the [API Section](/components/button/api).
+
+<br>
 
 **[buttonStyle]**
 
@@ -10,6 +14,8 @@ Sets the color and style of the button.
 <button hc-button buttonStyle="primary">button</button>
 ```
 
+<br>
+
 **[size]**
 
 `size: 'sm' | 'md' | 'lg' = 'md'`
@@ -19,6 +25,8 @@ Sets the size of the button.
 ```html
 <button hc-button size="md">button</button>
 ```
+
+<br>
 
 **[disabled]**
 
@@ -30,6 +38,8 @@ Puts the button in a disabled state.
 <button [disabled]="true">button</button>
 ```
 
+<br>
+
 **[hc-icon-button]**
 
 Use this instead of the `buttonStyle` attribute to designate this as a textless icon button.
@@ -40,7 +50,9 @@ Use this instead of the `buttonStyle` attribute to designate this as a textless 
 </button>
 ```
 
-##### Split Button Attributes
+<br><br>
+
+## Split Button Attributes
 
 **[autoCloseMenuOnClick]**
 
@@ -55,6 +67,8 @@ True if clicking anywhere in the dropdown menu should automatically close it.
 </hc-split-button>
 ```
 
+<br>
+
 **[menuPosition]**
 
 `menuPosition: 'start' | 'end' | 'center' = 'end'`
@@ -68,11 +82,15 @@ Positions the dropdown menu horizontally, relative to the left and right edges o
 </hc-split-button>
 ```
 
+<br>
+
 **[...]**
 
 The common HTML button attributes `name`, `title`, `type`, and `value` can be used on an `<hc-split-button>` in the normal way.
 
-##### Events
+<br><br>
+
+## Events
 
 **(click)**
 
@@ -82,7 +100,9 @@ Buttons are generally used with a click event handler.
 <button hc-button (click)="handleClick()"></button>
 ```
 
-##### Related Components
+<br><br>
+
+## Related Components
 
 **HcIcon**
 
@@ -95,6 +115,8 @@ You can use a Cashmere icon in any button. It's recommended that you style it wi
 </button>
 ```
 
+<br>
+
 **HcSplitButton**
 
 For a split button (a button with a caret and a dropdown menu), replace `<button>` with `<hc-split-button>`. Put menu options inside the `<hc-split-button>`, tagged with the `hcButtonItem` attribute.
@@ -106,7 +128,9 @@ For a split button (a button with a caret and a dropdown menu), replace `<button
 </hc-split-button>
 ```
 
-##### Methods
+<br><br>
+
+## Methods
 
 First, get a reference to the element.
 
@@ -126,6 +150,8 @@ export class ExampleComponent {
 }
 ```
 
+<br>
+
 **focus()**
 
 Gives focus to the button.
@@ -135,6 +161,8 @@ this.buttonRef.focus();
 this.splitButtonRef.focus();
 ```
 
+<br>
+
 **openMenu()**
 
 Opens the dropdown menu.
@@ -142,6 +170,8 @@ Opens the dropdown menu.
 ```typescript
 this.splitButtonRef.openMenu();
 ```
+
+<br>
 
 **closeMenu()**
 

--- a/projects/cashmere/src/lib/button/button.md
+++ b/projects/cashmere/src/lib/button/button.md
@@ -40,6 +40,8 @@ Use this instead of the `buttonStyle` attribute to designate this as a textless 
 </button>
 ```
 
+##### Split Button Attributes
+
 **[autoCloseMenuOnClick]**
 
 `autoCloseMenuOnClick: boolean = true`

--- a/src/app/components/component-viewer/component-examples/usage-example-viewer/usage-example-viewer.component.html
+++ b/src/app/components/component-viewer/component-examples/usage-example-viewer/usage-example-viewer.component.html
@@ -1,0 +1,4 @@
+<div>
+    <div class="example-container" #exampleContainer></div>
+    <pre *ngIf="getHtmlFile()"> <code [highlight]="getHtmlFile().contents"></code> </pre>
+</div>

--- a/src/app/components/component-viewer/component-examples/usage-example-viewer/usage-example-viewer.component.scss
+++ b/src/app/components/component-viewer/component-examples/usage-example-viewer/usage-example-viewer.component.scss
@@ -1,0 +1,19 @@
+@import 'scss/colors';
+@import 'scss/functions';
+@import 'scss/mixins.scss';
+@import '~highlight.js/styles/github.css';
+
+:host {
+    display: block;
+    margin-bottom: 40px;
+}
+
+pre {
+    overflow: hidden;
+    padding: 0;
+
+    code {
+        margin-bottom: -15px;
+        margin-top: -15px;
+    }
+}

--- a/src/app/components/component-viewer/component-examples/usage-example-viewer/usage-example-viewer.component.ts
+++ b/src/app/components/component-viewer/component-examples/usage-example-viewer/usage-example-viewer.component.ts
@@ -1,16 +1,15 @@
 import {Component, Input, ViewChild, OnInit, ViewContainerRef, ComponentFactoryResolver} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {titleCase} from 'change-case';
-import stackblitz from '@stackblitz/sdk';
 import {EXAMPLE_COMPONENTS} from '@healthcatalyst/cashmere-examples';
 import {ApplicationInsightsService} from '../../../../shared/application-insights/application-insights.service';
 
 @Component({
-    selector: 'hc-example-viewer',
-    templateUrl: 'example-viewer.component.html',
-    styleUrls: ['example-viewer.component.scss']
+    selector: 'hc-usage-example-viewer',
+    templateUrl: 'usage-example-viewer.component.html',
+    styleUrls: ['usage-example-viewer.component.scss']
 })
-export class ExampleViewerComponent implements OnInit {
+export class UsageExampleViewerComponent implements OnInit {
     @ViewChild('exampleContainer', {read: ViewContainerRef})
     exampleContainer: ViewContainerRef;
 
@@ -92,27 +91,12 @@ export class ExampleViewerComponent implements OnInit {
             .sort((a, b) => b.name.localeCompare(a.name));
     }
 
-    async launchStackBlitz() {
-        const exampleFiles = this.allExampleFiles;
-        const containerPath = `src/app/example-container.component.ts`;
-        exampleFiles[containerPath] = exampleFiles[containerPath].replace(/hc-example/g, `hc-${this.example}-example`);
-        const dependencies = JSON.parse(exampleFiles['package.json']).dependencies;
+    getHtmlFile() {
+        if (!this.exampleFiles || !this.exampleFiles.length) {
+            return {};
+        }
 
-        this.appInsights.logEvent(this._example, 'StackBlitz');
-
-        await stackblitz.openProject(
-            {
-                files: exampleFiles,
-                template: 'angular-cli',
-                title: this.exampleTitle,
-                description: this.exampleTitle,
-                dependencies: dependencies
-            },
-            {
-                openFile: `src/app/${this.example}/${this.example}-example.component.html`,
-                hideDevTools: true
-            }
-        );
+        return this.exampleFiles.find(f => f.name.endsWith('.html'));
     }
 }
 

--- a/src/app/components/component-viewer/component-usage/component-usage.component.html
+++ b/src/app/components/component-viewer/component-usage/component-usage.component.html
@@ -1,8 +1,8 @@
 <hc-tile *ngIf="componentViewer.docItem.usageDoc">
     <div *ngIf="componentViewer.docItem.usageExamples">
-        <h3 class="examples-title">
+        <h2>
             <span>Quick Example</span>
-        </h3>
+        </h2>
         <hc-usage-example-viewer
             *ngFor="let example of componentViewer.docItem.usageExamples"
             [example]="example"

--- a/src/app/components/component-viewer/component-usage/component-usage.component.html
+++ b/src/app/components/component-viewer/component-usage/component-usage.component.html
@@ -1,3 +1,3 @@
-<hc-tile>
-    <hc-doc-viewer documentUrl="assets/docs/usage/{{componentViewer.docItem?.id}}.html"></hc-doc-viewer>
+<hc-tile *ngIf="componentViewer.docItem.usageDoc">
+    <hc-doc-viewer documentUrl="assets/docs/usage/{{ componentViewer.docItem?.id }}.html"></hc-doc-viewer>
 </hc-tile>

--- a/src/app/components/component-viewer/component-usage/component-usage.component.html
+++ b/src/app/components/component-viewer/component-usage/component-usage.component.html
@@ -1,3 +1,13 @@
 <hc-tile *ngIf="componentViewer.docItem.usageDoc">
+    <div *ngIf="componentViewer.docItem.usageExamples">
+        <h3 class="examples-title">
+            <span>Quick Example</span>
+        </h3>
+        <hc-usage-example-viewer
+            *ngFor="let example of componentViewer.docItem.usageExamples"
+            [example]="example"
+        ></hc-usage-example-viewer>
+    </div>
+
     <hc-doc-viewer documentUrl="assets/docs/usage/{{ componentViewer.docItem?.id }}.html"></hc-doc-viewer>
 </hc-tile>

--- a/src/app/components/component-viewer/component-usage/component-usage.component.scss
+++ b/src/app/components/component-viewer/component-usage/component-usage.component.scss
@@ -1,3 +1,26 @@
+@import 'scss/colors';
+
 hc-tile {
     margin-top: 20px;
+}
+
+.examples-title {
+    color: $dark-blue;
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 20px 0;
+    text-transform: uppercase;
+}
+
+::ng-deep h5 {
+    margin-bottom: 5px;
+    margin-top: 30px;
+}
+
+::ng-deep pre {
+    padding: 2px;
+}
+
+::ng-deep code {
+    display: inline-block;
 }

--- a/src/app/components/component-viewer/component-usage/component-usage.component.ts
+++ b/src/app/components/component-viewer/component-usage/component-usage.component.ts
@@ -1,10 +1,15 @@
 import {Component} from '@angular/core';
 import {ComponentViewerComponent} from '../component-viewer.component';
+import {Router, ActivatedRoute} from '@angular/router';
 
 @Component({
     templateUrl: 'component-usage.component.html',
     styleUrls: ['component-usage.component.scss']
 })
 export class ComponentUsageComponent {
-    constructor(public componentViewer: ComponentViewerComponent) {}
+    constructor(public componentViewer: ComponentViewerComponent, public router: Router, public route: ActivatedRoute) {
+        if (this.componentViewer.docItem && !this.componentViewer.docItem.usageDoc) {
+            this.router.navigate(['..', 'examples'], {relativeTo: this.route, replaceUrl: true});
+        }
+    }
 }

--- a/src/app/components/component-viewer/component-viewer.component.ts
+++ b/src/app/components/component-viewer/component-viewer.component.ts
@@ -9,7 +9,7 @@ import {ActivatedRoute} from '@angular/router';
 })
 export class ComponentViewerComponent implements OnInit {
     docItem: DocItem | undefined;
-    sections: Set<string>;
+    sections: string[];
 
     constructor(private activatedRoute: ActivatedRoute, private docItems: DocumentItemsService) {}
 
@@ -26,16 +26,16 @@ export class ComponentViewerComponent implements OnInit {
 
                 if (this.docItem) {
                     const examples = this.docItem.examples;
+                    if (this.docItem.usageDoc) {
+                        availableSections.push('Usage');
+                    }
                     if (examples && examples.length > 0) {
-                        availableSections = ['Examples'];
+                        availableSections.push('Examples');
                     }
                     if (!this.docItem.hideApi) {
                         availableSections.push('API');
                     }
-                    if (this.docItem.usageDoc) {
-                        availableSections.push('Usage');
-                    }
-                    this.sections = new Set<string>(availableSections);
+                    this.sections = availableSections.slice();
                 }
             });
     }

--- a/src/app/components/component-viewer/component-viewer.component.ts
+++ b/src/app/components/component-viewer/component-viewer.component.ts
@@ -26,11 +26,11 @@ export class ComponentViewerComponent implements OnInit {
 
                 if (this.docItem) {
                     const examples = this.docItem.examples;
-                    if (this.docItem.usageDoc) {
-                        availableSections.push('Usage');
-                    }
                     if (examples && examples.length > 0) {
                         availableSections.push('Examples');
+                    }
+                    if (this.docItem.usageDoc) {
+                        availableSections.push('Usage');
                     }
                     if (!this.docItem.hideApi) {
                         availableSections.push('API');

--- a/src/app/components/components-router.module.ts
+++ b/src/app/components/components-router.module.ts
@@ -15,10 +15,10 @@ const routes: Route[] = [
                 path: ':id',
                 component: ComponentViewerComponent,
                 children: [
+                    {path: 'usage', component: ComponentUsageComponent, pathMatch: 'full'},
                     {path: 'api', component: ComponentApiComponent, pathMatch: 'full'},
                     {path: 'examples', component: ComponentExamplesComponent, pathMatch: 'full'},
-                    {path: 'usage', component: ComponentUsageComponent, pathMatch: 'full'},
-                    {path: '**', redirectTo: 'examples'}
+                    {path: '**', redirectTo: 'usage'}
                 ]
             }
         ]

--- a/src/app/components/components-router.module.ts
+++ b/src/app/components/components-router.module.ts
@@ -18,7 +18,7 @@ const routes: Route[] = [
                     {path: 'usage', component: ComponentUsageComponent, pathMatch: 'full'},
                     {path: 'api', component: ComponentApiComponent, pathMatch: 'full'},
                     {path: 'examples', component: ComponentExamplesComponent, pathMatch: 'full'},
-                    {path: '**', redirectTo: 'usage'}
+                    {path: '**', redirectTo: 'examples'}
                 ]
             }
         ]

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -15,6 +15,7 @@ import {ApplicationInsightsService} from '../shared/application-insights/applica
 import xml from 'highlight.js/lib/languages/xml';
 import scss from 'highlight.js/lib/languages/scss';
 import typescript from 'highlight.js/lib/languages/typescript';
+import {UsageExampleViewerComponent} from './component-viewer/component-examples/usage-example-viewer/usage-example-viewer.component';
 
 /**
  * Import every language you wish to highlight here
@@ -45,6 +46,7 @@ export function hljsLanguages() {
         DocumentViewerComponent,
         ComponentExamplesComponent,
         ExampleViewerComponent,
+        UsageExampleViewerComponent,
         ComponentUsageComponent
     ]
 })

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -5,6 +5,7 @@ export interface DocItem {
     name: string;
     category: 'forms' | 'nav' | 'layout' | 'buttons' | 'popups' | 'table' | 'pipes';
     examples?: string[];
+    usageExamples?: string[];
     usageDoc?: boolean;
     hideApi?: boolean;
 }
@@ -25,6 +26,7 @@ const docs: DocItem[] = [
         name: 'Button',
         category: 'buttons',
         examples: ['button-type', 'button-split', 'button-size', 'button-anchor', 'button-link', 'button-icon'],
+        usageExamples: ['button'],
         usageDoc: true
     },
     {

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -24,7 +24,8 @@ const docs: DocItem[] = [
         id: 'button',
         name: 'Button',
         category: 'buttons',
-        examples: ['button-type', 'button-split', 'button-size', 'button-anchor', 'button-link', 'button-icon']
+        examples: ['button-type', 'button-split', 'button-size', 'button-anchor', 'button-link', 'button-icon'],
+        usageDoc: true
     },
     {
         id: 'chip',

--- a/src/app/styles/chart/chart-demo.component.html
+++ b/src/app/styles/chart/chart-demo.component.html
@@ -24,7 +24,7 @@
     <hc-tile>
         <div class="header-row">
             <button hc-button title="Patient Readmissions" buttonStyle="link" class="chart-header" [hcPop]="options" popperPlacement="bottom">
-                <h2>Patient Readmissions</h2>
+                <h2 class="chart-header">Patient Readmissions</h2>
                 <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="header-icon-right"></hc-icon>
             </button>
             <span class="header-right">

--- a/src/app/styles/chart/chart-demo.component.scss
+++ b/src/app/styles/chart/chart-demo.component.scss
@@ -72,6 +72,7 @@ hc-swatch-demo-component {
 
 .chart-header {
     padding: 0 !important;
+    margin: 0;
 
     .light {
         font-weight: 300;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -123,7 +123,7 @@ h1 {
 }
 
 h2 {
-    margin: 0;
+    margin-bottom: 20px;
 }
 
 h3 {


### PR DESCRIPTION
This is a draft of how we might want the documentation for the Button component to look, based on #1034. Feel free to poke about and offer suggestions.

I anticipate the following concerns:

_This is one of the simplest components in Cashmere but it required ~150 lines of handwritten documentation, a non-trivial amount of research, and a new example. And it didn't even need an FAQ, like some components will. That portends a **lot** of work to get all the documentation finished._

Yeah, good documentation is no joke. 😅

_How will we keep all this handwritten documentation up to date as components change?_

Dedicated effort; see above.

_The Usage page is a little hard to navigate without a table of contents._

True. @joeskeen and I have discussed that a TOC would be great to have. I'm not sure how to pull that off yet, so I'm saving the effort for another time.

_Could we use a more declarative style on the Usage page to reduce duplication?_

Potentially, yes, but I don't know if Markdown will play nice. Maybe it can give us partials, at least? Something to look into.