### PR TITLE
fix(table styles): fix small table header styles

### DIFF
--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -37,6 +37,10 @@
     td,
     th {
         @include hc-small-table-cell();
+
+        &.hc-col-sortable, &.hc-col-sortable-left {
+            @include hc-small-table-header-sortable();
+        }
     }
 }
 
@@ -136,12 +140,12 @@
     }
 }
 
-th.hc-col-sortable,
-th.hc-col-sortable-left {
+.hc-table th.hc-col-sortable,
+.hc-table th.hc-col-sortable-left {
     @include hc-table-header-sortable();
 }
 
-th.hc-col-sortable-left {
+.hc-table th.hc-col-sortable-left {
     @include hc-table-header-sortable-left();
 }
 

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -132,6 +132,12 @@ $row-selected-border-color: $white;
     padding: $cell-padding-condensed;
 }
 
+@mixin hc-small-table-header-sortable() {
+    &:after {
+        bottom: 7px;
+    }
+}
+
 @mixin hc-action-table-row() {
     &:hover {
         background-color: $row-color-action-hover;


### PR DESCRIPTION
fix #1114

So sort icons are position correctly when applying `.hc-table-small`