### PR TITLE
fix(datepicker): today button disabled

### DIFF
--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
@@ -2,7 +2,7 @@
     <div class="example-date-input">
         <hc-form-field>
             <hc-label>Date:</hc-label>
-            <input hcInput [hcDatepicker]="picker1" [(ngModel)]="date1" placeholder="Select date..." />
+            <input hcInput [hcDatepicker]="picker1" [max]="maxStr" [(ngModel)]="date1" placeholder="Select date..." />
             <hc-datepicker-toggle hcSuffix [for]="picker1"></hc-datepicker-toggle>
             <hc-datepicker #picker1></hc-datepicker>
             <hc-error>Please enter a valid date</hc-error>

--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
@@ -10,4 +10,6 @@ export class DatepickerExampleComponent {
     date2 = new Date();
     date3 = new Date("2010-01-01T20:15:00.00");
     hourCycle = false;
+
+    maxStr: string = this.date2.toISOString();
 }

--- a/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
+++ b/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
@@ -139,9 +139,24 @@ export class CalendarHeaderComponent {
     }
 
     _todayEnabled(): boolean {
+        let minDate;
+        let maxDate;
+        let today = new Date( this._dateAdapter.today().toDateString() );
+
+        /** Normalize the compare dates to all be on the first day of the month because we are only concerned
+         * about whether today falls outside of the month than min or max is in */
+        today.setDate(1);
+        if ( this.calendar.minDate ) {
+            minDate = new Date( this.calendar.minDate.toDateString() );
+            minDate.setDate(1);
+        }
+        if ( this.calendar.maxDate ) {
+            maxDate = new Date( this.calendar.maxDate.toDateString() );
+            maxDate.setDate(1);
+        }
         return (
-            (!this.calendar.minDate || this._dateAdapter.compareDate(this.calendar.minDate, this._dateAdapter.today()) < 1) &&
-            (!this.calendar.maxDate || this._dateAdapter.compareDate(this.calendar.maxDate, this._dateAdapter.today()) > -1)
+            (!minDate || this._dateAdapter.compareDate(minDate, today) < 1) &&
+            (!maxDate || this._dateAdapter.compareDate(maxDate, today) > -1)
         );
     }
 


### PR DESCRIPTION
Disables today button only if current month is outside min or max.

I'm glad you brought this one up @Techgeekster because it had been bugging me too.  The calculation for disabling the Today button came from when clicking Today selected the current date.  Now it just jumps to the current date, but the user still needs to make a selection.  So the today button should only be disabled if the entire month that today falls under is outside of the range of the min or max.

closes #1125