### PR TITLE
fix(datepicker): init values with reactive forms

### DIFF
--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
@@ -20,13 +20,16 @@
         <hc-checkbox [(ngModel)]="hourCycle">Use 24-hour clock</hc-checkbox>
     </div>
 
-    <div class="example-date-input">
-        <hc-form-field>
-            <hc-label>Date & Time:</hc-label>
-            <input hcInput [hcDatepicker]="picker3" [(ngModel)]="date3" placeholder="Select date & time..." />
-            <hc-datepicker-toggle hcSuffix [for]="picker3"></hc-datepicker-toggle>
-            <hc-datepicker mode="date-time" #picker3 ></hc-datepicker>
-            <hc-error>Please enter a valid date & time</hc-error>
-        </hc-form-field>
-    </div>
+    <!-- An example of using a datepicker within a FormGroup -->
+    <form [formGroup]="form">
+        <div class="example-date-input">
+            <hc-form-field>
+                <hc-label>Date & Time:</hc-label>
+                <input hcInput [hcDatepicker]="picker3" formControlName="dateForm" placeholder="Select date & time..." />
+                <hc-datepicker-toggle hcSuffix [for]="picker3"></hc-datepicker-toggle>
+                <hc-datepicker mode="date-time" #picker3 ></hc-datepicker>
+                <hc-error>Please enter a valid date & time</hc-error>
+            </hc-form-field>
+        </div>
+    </form>
 </div>

--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import {FormControl, FormGroup} from '@angular/forms';
 
 @Component({
     selector: 'hc-datepicker-example',
@@ -8,7 +9,10 @@ import {Component} from '@angular/core';
 export class DatepickerExampleComponent {
     date1 = new Date(2010, 1, 1);
     date2 = new Date();
-    date3 = new Date("2010-01-01T20:15:00.00");
+    form = new FormGroup({
+        dateForm: new FormControl( new Date("2010-01-01T20:15:00.00") )
+    });
+
     hourCycle = false;
 
     maxStr: string = this.date2.toISOString();

--- a/projects/cashmere/src/lib/datepicker/datepicker.component.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker.component.ts
@@ -73,7 +73,16 @@ export class DatepickerComponent implements OnDestroy {
      * Whether the datepicker includes the calendar, time selector, or both. Defaults to `date`.
      */
     @Input()
-    mode: 'date' | 'time' | 'date-time' = 'date';
+    get mode(): 'date' | 'time' | 'date-time' {
+        return this._mode;
+    }
+    set mode( value: 'date' | 'time' | 'date-time' ) {
+        this._mode = value;
+        if ( this._selected ) {
+            this._selectedChanged.next(this._selected);
+        }
+    }
+    private _mode: 'date' | 'time' | 'date-time' = 'date';
 
     /**
      * Whether the time picker uses a 12 or 24 hour clock. Defaults to 12.


### PR DESCRIPTION
Correctly display init values when the mode is something other than date.  Thanks for finding this one @Techgeekster!

closes #1141