### PR TITLE
1084 convert dialog

### DIFF
--- a/projects/cashmere-examples/src/lib/datepicker-touchui/datepicker-touchui-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker-touchui/datepicker-touchui-example.component.html
@@ -1,0 +1,11 @@
+<div class="example-date-pickers">
+    <div class="example-date-input">
+        <hc-form-field>
+            <hc-label>Date:</hc-label>
+            <input hcInput [hcDatepicker]="picker1" [max]="maxStr" [(ngModel)]="date1" placeholder="Select date..." />
+            <hc-datepicker-toggle hcSuffix [for]="picker1"></hc-datepicker-toggle>
+            <hc-datepicker #picker1 [touchUi]="true"></hc-datepicker>
+            <hc-error>Please enter a valid date</hc-error>
+        </hc-form-field>
+    </div>
+</div>

--- a/projects/cashmere-examples/src/lib/datepicker-touchui/datepicker-touchui-example.component.scss
+++ b/projects/cashmere-examples/src/lib/datepicker-touchui/datepicker-touchui-example.component.scss
@@ -1,0 +1,10 @@
+.example-date-input {
+    max-width: 225px;
+    margin-right: 25px;
+    flex: 1;
+}
+
+.example-date-pickers {
+    display: flex;
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/datepicker-touchui/datepicker-touchui-example.component.ts
+++ b/projects/cashmere-examples/src/lib/datepicker-touchui/datepicker-touchui-example.component.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+
+@Component({
+    selector: 'hc-datepicker-touchui-example',
+    templateUrl: './datepicker-touchui-example.component.html',
+    styleUrls: ['datepicker-touchui-example.component.scss']
+})
+export class DatepickerTouchuiExampleComponent {
+    date1 = new Date(2010, 1, 1);
+
+    maxStr: string = new Date().toISOString();
+}

--- a/projects/cashmere/src/lib/datepicker/datepicker.component.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker.component.ts
@@ -82,10 +82,10 @@ export class DatepickerComponent implements OnDestroy {
     get hourCycle(): string | number {
         return this._hourCycle;
     }
-    set hourCycle( value: string | number ) {
-        if ( +value !== this._hourCycle) {
+    set hourCycle(value: string | number) {
+        if (+value !== this._hourCycle) {
             this._hourCycle = +value;
-            if ( this._selected ) {
+            if (this._selected) {
                 this._selectedChanged.next(this._selected);
             }
         }

--- a/projects/cashmere/src/lib/dialog/dialog-container.component.scss
+++ b/projects/cashmere/src/lib/dialog/dialog-container.component.scss
@@ -1,74 +1,32 @@
-// @import '../core/style/vendor-prefixes';
-//  @import '~@angular/cdk/a11y/a11y';
-
-$hc-dialog-padding: 24px !default;
-$hc-dialog-border-radius: 4px !default;
-$hc-dialog-max-height: 65vh !default;
-$hc-dialog-button-margin: 8px !default;
+@import '../sass/dialog.scss';
 
 .hc-dialog-container {
-    display: block;
-    padding: $hc-dialog-padding;
-    border-radius: $hc-dialog-border-radius;
-    box-sizing: border-box;
-    overflow: auto;
-    outline: 0;
-
-    // The dialog container should completely fill its parent overlay element.
-    width: 100%;
-    height: 100%;
-
-    // Since the dialog won't stretch to fit the parent, if the height
-    // isn't set, we have to inherit the min and max values explicitly.
-    min-height: inherit;
-    max-height: inherit;
-
-    // @include cdk-high-contrast {
-    outline: solid 1px;
-    // }
+    @include hc-dialog-container();
 }
 
 .hc-dialog-content {
-    display: block;
-    margin: 0 $hc-dialog-padding * -1;
-    padding: 0 $hc-dialog-padding;
-    max-height: $hc-dialog-max-height;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
+    @include hc-dialog-content();
 }
 
 .hc-dialog-title {
-    margin: 0 0 20px;
-    display: block;
+    @include hc-dialog-title();
 }
 
 .hc-dialog-actions {
-    padding: 8px 0;
-    display: flex;
-    flex-wrap: wrap;
-    min-height: 52px;
-    align-items: center;
-
-    // Pull the actions down to avoid their padding stacking with the dialog's padding.
-    margin-bottom: -$hc-dialog-padding;
+    @include hc-dialog-actions();
 
     &[align='end'] {
-        justify-content: flex-end;
+        @include hc-dialog-actions-end();
     }
 
     &[align='center'] {
-        justify-content: center;
+        @include hc-dialog-actions-center();
     }
 
     .hc-button + .hc-button,
     .hc-raised-button + .hc-raised-button,
     .hc-button + .hc-raised-button,
     .hc-raised-button + .hc-button {
-        margin-left: $hc-dialog-button-margin;
-
-        [dir='rtl'] & {
-            margin-left: 0;
-            margin-right: $hc-dialog-button-margin;
-        }
+        @include hc-dialog-actions-margin-left();
     }
 }

--- a/projects/cashmere/src/lib/sass/dialog.scss
+++ b/projects/cashmere/src/lib/sass/dialog.scss
@@ -1,0 +1,64 @@
+$hc-dialog-padding: 24px !default;
+$hc-dialog-border-radius: 4px !default;
+$hc-dialog-max-height: 65vh !default;
+$hc-dialog-button-margin: 8px !default;
+
+@mixin hc-dialog-container() {
+    border-radius: $hc-dialog-border-radius;
+    box-sizing: border-box;
+    display: block;
+    outline: solid 1px;
+    overflow: auto;
+    padding: $hc-dialog-padding;
+
+    // The dialog container should completely fill its parent overlay element.
+    height: 100%;
+    width: 100%;
+
+    // Since the dialog won't stretch to fit the parent, if the height
+    // isn't set, we have to inherit the min and max values explicitly.
+    max-height: inherit;
+    min-height: inherit;
+}
+
+@mixin hc-dialog-content() {
+    display: block;
+    margin: 0 $hc-dialog-padding * -1;
+    max-height: $hc-dialog-max-height;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 0 $hc-dialog-padding;
+}
+
+@mixin hc-dialog-title() {
+    display: block;
+    margin: 0 0 20px;
+}
+
+@mixin hc-dialog-actions() {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    min-height: 52px;
+    padding: 8px 0;
+
+    // Pull the actions down to avoid their padding stacking with the dialog's padding.
+    margin-bottom: -$hc-dialog-padding;
+}
+
+@mixin hc-dialog-actions-end() {
+    justify-content: flex-end;
+}
+
+@mixin hc-dialog-actions-center() {
+    justify-content: center;
+}
+
+@mixin hc-dialog-actions-margin-left() {
+    margin-left: $hc-dialog-button-margin;
+
+    [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: $hc-dialog-button-margin;
+    }
+}

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -36,7 +36,7 @@ const docs: DocItem[] = [
         id: 'datepicker',
         name: 'Datepicker',
         category: 'forms',
-        examples: ['datepicker', 'datepicker-sugar', 'datepicker-selected-value'],
+        examples: ['datepicker', 'datepicker-sugar', 'datepicker-selected-value', 'datepicker-touchui'],
         usageDoc: true
     },
     {


### PR DESCRIPTION
Fixes #1084.

I added an example that uses the `[touchUi]` Input field. It's the only thing in Cashmere that uses the dialog element.