### PR TITLE
1135 Pagination bugs

### DIFF
--- a/projects/cashmere-examples/src/lib/pagination-load-more/pagination-load-more-example.component.ts
+++ b/projects/cashmere-examples/src/lib/pagination-load-more/pagination-load-more-example.component.ts
@@ -41,7 +41,7 @@ const ELEMENT_DATA: PeriodicElement[] = [
 })
 export class PaginationLoadMoreExampleComponent implements AfterViewInit {
     displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
-    dataSource: HcTableDataSource<PeriodicElement>;
+    dataSource = new HcTableDataSource(ELEMENT_DATA);
     get length(): number {
         return ELEMENT_DATA.length;
     }
@@ -50,7 +50,6 @@ export class PaginationLoadMoreExampleComponent implements AfterViewInit {
     loadMoreBtn: LoadMorePaginationComponent;
 
     ngAfterViewInit(): void {
-        this.dataSource = new HcTableDataSource(ELEMENT_DATA);
         this.dataSource.paginator = this.loadMoreBtn;
     }
 }

--- a/projects/cashmere-examples/src/lib/pagination-standard/pagination-standard-example.component.ts
+++ b/projects/cashmere-examples/src/lib/pagination-standard/pagination-standard-example.component.ts
@@ -41,7 +41,7 @@ const ELEMENT_DATA: PeriodicElement[] = [
 })
 export class PaginationStandardExampleComponent implements AfterViewInit {
     displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
-    dataSource: HcTableDataSource<PeriodicElement>;
+    dataSource = new HcTableDataSource(ELEMENT_DATA);
     pageNumber = 1;
     pageOpts = [5, 10, 20];
     get length(): number {
@@ -52,7 +52,6 @@ export class PaginationStandardExampleComponent implements AfterViewInit {
     paginator: PaginationComponent;
 
     ngAfterViewInit(): void {
-        this.dataSource = new HcTableDataSource(ELEMENT_DATA);
         this.dataSource.paginator = this.paginator;
     }
 }

--- a/projects/cashmere/src/lib/pagination/pagination.component.html
+++ b/projects/cashmere/src/lib/pagination/pagination.component.html
@@ -1,7 +1,7 @@
 <div class="hc-pagination-container">
     <div *ngIf="!hidePageSize" class="hc-font-sm hc-page-detail-container">
         <label class="hc-page-detail-label">Showing:</label>
-        <hc-select class="hc-page-detail-select" [value]="pageSize" (change)="_changePageSize($event.target.value)" (focus)="isFocused = true" (blur)="isFocused = false">
+        <hc-select class="hc-page-detail-select" [value]="pageSize" (change)="_changePageSize($event.value)" (focus)="isFocused = true" (blur)="isFocused = false">
             <option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
                 {{ isFocused ? pageSizeOption : pageSize === pageSizeOption && pageSizeOption > length ? 'all' : pageSizeOption }}
             </option>

--- a/projects/cashmere/src/lib/pagination/pagination.component.html
+++ b/projects/cashmere/src/lib/pagination/pagination.component.html
@@ -6,8 +6,7 @@
                 {{ isFocused ? pageSizeOption : pageSize === pageSizeOption && pageSizeOption > length ? 'all' : pageSizeOption }}
             </option>
         </hc-select>
-        <label
-            >of <strong>{{ length }}</strong> entries</label
+        <label class="hc-page-detail-entries">of <strong>{{ length }}</strong> entries</label
         >
     </div>
 

--- a/projects/cashmere/src/lib/pagination/pagination.component.scss
+++ b/projects/cashmere/src/lib/pagination/pagination.component.scss
@@ -16,6 +16,10 @@
     @include hc-page-detail-select();
 }
 
+.hc-page-detail-entries {
+    @include hc-page-detail-entries();
+}
+
 .hc-range-label {
     @include hc-range-label();
 }

--- a/projects/cashmere/src/lib/sass/pagination.scss
+++ b/projects/cashmere/src/lib/sass/pagination.scss
@@ -28,6 +28,10 @@
     margin: 0 7px;
 }
 
+@mixin hc-page-detail-entries() {
+    white-space: nowrap;
+}
+
 @mixin hc-range-label() {
     flex: 0 0 auto;
     margin-right: 10px;


### PR DESCRIPTION
Fixed the following:
- fix #1135, pageSize change event was broken because of the new `SelectChangeEvent` fired by hc-select
- prevent wrapping on the "of 'x' entries label
![image](https://user-images.githubusercontent.com/12416432/73488051-63012a00-4365-11ea-9f2d-6d677b3ba31a.png)
- prevent `ExpressionChangedAfterItHasBeenCheckedError` on pagination examples