### PR TITLE
feat(multiple): tight parameter

### DIFF
--- a/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.scss
+++ b/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.scss
@@ -1,24 +1,19 @@
 @import "~@healthcatalyst/cashmere/scss/colors";
 
 .drawer-content {
-    height: 200px; /* used to show menu scrolling effect*/
+    height: 200px; /* used to show menu scrolling effect */
 }
 
-.drawer-label {
-    margin: 0 50px 0 0;
-}
+/* positions a plus button to the right edge of a drawer item */
+.hc-drawer-item {
+    .drawer-label {
+        margin: 0 50px 0 0;
+    }
 
-.fa-plus {
-    color: $blue;
-    margin: 0 0 0 auto;
-}
-
-.hc-drawer-right .drawer-label {
-    margin: 0 0 0 50px;
-}
-
-.hc-drawer-right .fa-plus {
-    margin: 0 auto 0 0;
+    .fa-plus {
+        color: $blue;
+        margin: 0 0 0 auto;
+    }
 }
 
 .icon-left {

--- a/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
@@ -1,4 +1,4 @@
-<table hc-table [dataSource]="dataSource" hcSort>
+<table hc-table [dataSource]="dataSource" tight="true" hcSort>
 
     <!-- Position Column -->
     <ng-container hcColumnDef="position">

--- a/projects/cashmere/src/lib/banner/hc-banner.component.ts
+++ b/projects/cashmere/src/lib/banner/hc-banner.component.ts
@@ -42,6 +42,16 @@ export class HcBannerComponent {
         this._clickDismiss = parseBooleanAttribute(dismissVal);
     }
 
+    /** If true, remove the default 10px padding. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+    }
+    private _tight: boolean = false;
+
     _bannerClick(event: MouseEvent) {
         if (this._clickDismiss) {
             this.bannerClose.emit(event);

--- a/projects/cashmere/src/lib/banner/hc-banner.html
+++ b/projects/cashmere/src/lib/banner/hc-banner.html
@@ -1,4 +1,7 @@
-<div class="hc-banner hc-banner-{{type}}" [ngClass]="{'hc-banner-dismiss': clickDismiss}" (click)="_bannerClick($event)">
+<div class="hc-banner hc-banner-{{type}}"
+    [class.hc-banner-dismiss]="clickDismiss"
+    [class.hc-banner-padding]="!tight"
+    (click)="_bannerClick($event)">
     <ng-content></ng-content>
     <span *ngIf="clickDismiss" class="hc-banner-close">
         <div class="hc-banner-close-icon"></div>

--- a/projects/cashmere/src/lib/banner/hc-banner.scss
+++ b/projects/cashmere/src/lib/banner/hc-banner.scss
@@ -4,6 +4,10 @@
     @include hc-banner();
 }
 
+.hc-banner-padding {
+    @include hc-banner-padding();
+}
+
 .hc-banner-dismiss {
     @include hc-banner-dismiss();
 

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.html
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.html
@@ -14,7 +14,7 @@
                (click)="_clickEvent($event)"
                (blur)="_onBlur()"/>
         <label class="hc-checkbox-overlay" [attr.for]="_inputId"></label>
-        <label class="hc-checkbox-label" [attr.for]="_inputId">
+        <label class="hc-checkbox-label" [class.hc-checkbox-padding]="!tight" [attr.for]="_inputId">
             <ng-content></ng-content>
         </label>
     </div>

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.scss
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.scss
@@ -28,6 +28,10 @@
     @include hc-checkbox-label();
 }
 
+.hc-checkbox-padding {
+    @include hc-checkbox-padding();
+}
+
 .hc-checkbox-overlay {
     @include hc-checkbox-overlay();
 

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.ts
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.ts
@@ -60,6 +60,16 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
         this._componentId = idVal ? idVal : this._uniqueId;
     }
 
+    /** If true, remove the default vertical padding. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+    }
+    private _tight: boolean = false;
+
     /** Sets unique name used in a form */
     @Input()
     name: string | null = null;

--- a/projects/cashmere/src/lib/chip/chip.component.html
+++ b/projects/cashmere/src/lib/chip/chip.component.html
@@ -1,4 +1,4 @@
-<div class="hc-chip hc-chip-{{color}}">
+<div class="hc-chip hc-chip-{{color}}" [class.hc-chip-margin]="!tight">
     <ng-content></ng-content>
     <span *ngIf="hasCloseButton" class="hc-chip-close" (click)="_closeClick($event)">
         <span class="hc-chip-close-icon"></span>

--- a/projects/cashmere/src/lib/chip/chip.component.scss
+++ b/projects/cashmere/src/lib/chip/chip.component.scss
@@ -4,6 +4,10 @@
     @include hc-chip();
 }
 
+.hc-chip-margin {
+    @include hc-chip-margin();
+}
+
 .hc-chip-close {
     @include hc-chip-close();
 }

--- a/projects/cashmere/src/lib/chip/chip.component.ts
+++ b/projects/cashmere/src/lib/chip/chip.component.ts
@@ -19,6 +19,7 @@ export function validateColorInput(inputStr: string) {
 export class ChipComponent {
     private _hasCloseButton: boolean = false;
     private _color: string = 'neutral';
+    private _tight: boolean = false;
 
     /** Emitted when the 'X' close button is clicked. `(click)` may be used for clicks on the entire chip */
     @Output()
@@ -33,6 +34,15 @@ export class ChipComponent {
     set color(colorType: string) {
         validateColorInput(colorType);
         this._color = colorType;
+    }
+
+    /** If true, remove the default 5px margin. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
     }
 
     constructor() {}

--- a/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.scss
+++ b/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.scss
@@ -11,7 +11,11 @@
         @include hc-menu-drawer-item-container-visible();
     }
 
-    .hc-drawer-right & {
+    .hc-menu-drawer-padding & {
+        @include hc-menu-drawer-item-container-padding();
+    }
+
+    .hc-menu-drawer-padding.hc-drawer-right & {
         @include hc-menu-drawer-item-container-right();
     }
 }
@@ -22,12 +26,20 @@
 
 .hc-drawer-toolbar {
     @include hc-drawer-toolbar();
+
+    .hc-menu-drawer-padding & {
+        @include hc-drawer-toolbar-padding();
+    }
 }
 
 .hc-drawer-item {
     @include hc-drawer-item();
 
-    .hc-drawer-right & {
+    .hc-menu-drawer-padding & {
+        @include hc-drawer-item-padding();
+    }
+
+    .hc-menu-drawer-padding.hc-drawer-right & {
         @include hc-drawer-item-right();
     }
 }

--- a/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.ts
@@ -13,6 +13,7 @@ import {
 import {Drawer} from '../drawer.component';
 import {animate, state, style, transition, trigger} from '@angular/animations';
 import {DrawerToolbar} from './drawer-header.directive';
+import {parseBooleanAttribute} from '../../util';
 
 const drawerThemes = ['dark-theme'];
 
@@ -75,6 +76,18 @@ export class MenuDrawer extends Drawer implements AfterContentInit {
 
     @HostBinding('class.hc-menu-drawer')
     _hostClass = true;
+
+    @HostBinding('class.hc-menu-drawer-padding')
+    _hasPadding = true;
+
+    /** If true, remove the default padding on the menu drawer. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return !this._hasPadding;
+    }
+    set tight(value) {
+        this._hasPadding = !parseBooleanAttribute(value);
+    }
 
     constructor(elementRef: ElementRef, private renderer: Renderer2) {
         super(elementRef);

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.html
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.html
@@ -1,4 +1,9 @@
-<div [class.hc-form-field-wrapper-inline]="inline" [class.hc-form-field-wrapper]="!inline" [class.hc-form-field-no-label]="!hasLabel">
+<div
+    [class.hc-form-field-wrapper-inline]="inline"
+    [class.hc-form-field-wrapper]="!inline"
+    [class.hc-form-field-no-label]="!hasLabel"
+    [class.hc-form-field-padding]="!tight"
+>
     <span *ngIf="hasLabel" [ngClass]="inline ? 'hc-form-field-label-wrapper-inline' : 'hc-form-field-label-wrapper'">
         <label [ngClass]="inline ? 'hc-form-field-label-inline' : 'hc-form-field-label'" [attr.for]="_control._componentId">
             <ng-content select="hc-label"></ng-content>

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -8,6 +8,10 @@
     @include hc-form-field-wrapper();
 }
 
+.hc-form-field-padding {
+    @include hc-form-field-padding();
+}
+
 .hc-form-field-wrapper-inline {
     @include hc-form-field-wrapper-inline();
 }

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.ts
@@ -72,6 +72,16 @@ export class HcFormFieldComponent implements AfterContentInit {
         this._inline = parseBooleanAttribute(isInline);
     }
 
+    /** If true, remove the default padding-bottom. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+    }
+    private _tight: boolean = false;
+
     constructor(private _elementRef: ElementRef<HTMLInputElement>) {}
 
     ngAfterContentInit(): void {

--- a/projects/cashmere/src/lib/list/list-item/list-item.component.scss
+++ b/projects/cashmere/src/lib/list/list-item/list-item.component.scss
@@ -4,6 +4,10 @@
     @include hc-list-item();
 }
 
+.hc-list-height {
+    @include hc-list-height();
+}
+
 .hc-list-content {
     @include hc-list-content();
 }

--- a/projects/cashmere/src/lib/list/list-item/list-item.component.ts
+++ b/projects/cashmere/src/lib/list/list-item/list-item.component.ts
@@ -1,4 +1,5 @@
-import {Component, HostBinding, ViewEncapsulation} from '@angular/core';
+import {Component, HostBinding, ViewEncapsulation, Input} from '@angular/core';
+import {parseBooleanAttribute} from '../../util';
 
 /**
  * Represents a row within a `<hc-list>`. Multiple `[hcListLine]` can be used
@@ -14,4 +15,16 @@ import {Component, HostBinding, ViewEncapsulation} from '@angular/core';
 export class ListItemComponent {
     @HostBinding('class.hc-list-item')
     _hostClass = true;
+
+    @HostBinding('class.hc-list-height')
+    _hasPadding = true;
+
+    /** If true, remove the default height on the list item. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return !this._hasPadding;
+    }
+    set tight(value) {
+        this._hasPadding = !parseBooleanAttribute(value);
+    }
 }

--- a/projects/cashmere/src/lib/pop/popover.component.html
+++ b/projects/cashmere/src/lib/pop/popover.component.html
@@ -3,6 +3,7 @@
       #focusTrapElement
       class="{{_yAlignClass}} {{_xAlignClass}}"
       [class.hc-pop-container-basic]="!disableStyle"
+      [class.hc-pop-container-padding]="!tight"
       [ngClass]="_classList"
       (click)="_popContainerClicked()"
       [@transformPopover]="_getAnimation()"

--- a/projects/cashmere/src/lib/pop/popover.component.scss
+++ b/projects/cashmere/src/lib/pop/popover.component.scss
@@ -72,9 +72,12 @@ $cdk-z-index-overlay: $zindex-cdk-overlay;
         background-color: $white;
         border: 1px solid $gray-300;
         color: $offblack;
-        padding: 12px;
         box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
         border-radius: 4px;
+    }
+
+    &.hc-pop-container-padding {
+        padding: 12px;
     }
 
     // Arrows

--- a/projects/cashmere/src/lib/pop/popover.component.ts
+++ b/projects/cashmere/src/lib/pop/popover.component.ts
@@ -39,6 +39,7 @@ import {
 import {OverlayRef} from '@angular/cdk/overlay';
 import {MenuItemDirective} from './directives/menu-item.directive';
 import {Subject} from 'rxjs';
+import {parseBooleanAttribute} from '../util';
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const DEFAULT_TRANSITION = '100ms linear';
@@ -57,6 +58,16 @@ export class HcPopComponent implements OnInit, OnDestroy {
 
     /** Whether or not to show a connection arrow when possible. *Defaults to `true`.* */
     @Input() showArrow = true;
+
+    /** If true, remove the default padding of 12px. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+    }
+    private _tight = false;
 
     /** Alignment of the popover on the horizontal axis. Can be `before`, `start`, `center`, `end`, `after`, or `mouse`.
      * *Defaults to `center`.* */

--- a/projects/cashmere/src/lib/radio-button/radio-button.component.scss
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.scss
@@ -39,3 +39,7 @@
         @include hc-radio-input-disabled();
     }
 }
+
+.hc-radio-padding {
+    @include hc-radio-padding();
+}

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -17,7 +17,8 @@ import {
     QueryList,
     DoCheck,
     Self,
-    ElementRef
+    ElementRef,
+    ViewEncapsulation
 } from '@angular/core';
 import {parseBooleanAttribute} from '../util';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
@@ -258,6 +259,7 @@ export class RadioButtonChangeEvent {
     selector: 'hc-radio-button',
     templateUrl: './radio-button.component.html',
     styleUrls: ['./radio-button.component.scss'],
+    encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RadioButtonComponent implements OnInit {
@@ -297,6 +299,18 @@ export class RadioButtonComponent implements OnInit {
     @HostBinding('attr.id')
     get _getHostId(): string {
         return this.id;
+    }
+
+    @HostBinding('class.hc-radio-padding')
+    _hasPadding = true;
+
+    /** If true, remove the default vertical padding. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return !this._hasPadding;
+    }
+    set tight(value) {
+        this._hasPadding = !parseBooleanAttribute(value);
     }
 
     /** Boolean value of whether the radio button is required */

--- a/projects/cashmere/src/lib/sass/banner.scss
+++ b/projects/cashmere/src/lib/sass/banner.scss
@@ -6,9 +6,12 @@
     align-items: center;
     display: flex;
     justify-content: flex-start;
-    padding: 10px;
     width: 100%;
     z-index: $zindex-subnav;
+}
+
+@mixin hc-banner-padding() {
+    padding: 10px;
 }
 
 @mixin hc-banner-dismiss() {

--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -25,7 +25,12 @@
 }
 
 @mixin hc-checkbox-label() {
-    padding: 4px 0 4px 12px;
+    padding-left: 12px;
+}
+
+@mixin hc-checkbox-padding() {
+    padding-top: 4px;
+    padding-bottom: 4px;
     line-height: 1.5;
 }
 

--- a/projects/cashmere/src/lib/sass/chip.scss
+++ b/projects/cashmere/src/lib/sass/chip.scss
@@ -9,9 +9,12 @@
     display: inline-block;
     height: 32px;
     line-height: 32px;
-    margin: 5px;
     padding: 0 15px;
     white-space: nowrap;
+}
+
+@mixin hc-chip-margin() {
+    margin: 5px;
 }
 
 @mixin hc-chip-close() {

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -24,8 +24,11 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 @mixin hc-form-field-wrapper() {
     position: relative;
     border-top: $infix-margin-top solid transparent;
-    padding-bottom: $wrapper-padding-bottom;
     flex-direction: inherit;
+}
+
+@mixin hc-form-field-padding() {
+    padding-bottom: $wrapper-padding-bottom;
 }
 
 @mixin hc-form-field-wrapper-inline() {

--- a/projects/cashmere/src/lib/sass/list.scss
+++ b/projects/cashmere/src/lib/sass/list.scss
@@ -6,6 +6,9 @@
     color: rgba(0, 0, 0, 0.87);
     display: block;
     font-size: 16px;
+}
+
+@mixin hc-list-height() {
     height: 56px;
 }
 

--- a/projects/cashmere/src/lib/sass/menu-drawer.scss
+++ b/projects/cashmere/src/lib/sass/menu-drawer.scss
@@ -11,15 +11,18 @@ $drawer-toolbar-height: 52px;
     background-color: $charcoal-blue;
     height: 100%;
     overflow-y: auto;
-    padding-right: 28px;
 }
 
 @mixin hc-menu-drawer-item-container-visible() {
     height: calc(100% - #{$drawer-toolbar-height});
 }
 
+@mixin hc-menu-drawer-item-container-padding() {
+    padding-right: 15px;
+}
+
 @mixin hc-menu-drawer-item-container-right() {
-    padding: 0 0 0 28px;
+    padding: 0 0 0 15px;
 }
 
 @mixin hc-menu-drawer-toolbar-container() {
@@ -37,22 +40,28 @@ $drawer-toolbar-height: 52px;
     height: $drawer-toolbar-height;
     max-height: $drawer-toolbar-height;
     overflow: hidden;
-    padding: 15px 28px;
+}
+
+@mixin hc-drawer-toolbar-padding() {
+    padding: 15px;
 }
 
 @mixin hc-drawer-item() {
     color: $white;
     display: flex;
     flex-direction: row;
-    padding: 15px 0 15px 15px;
     width: 100%;
 
     &:not(:first-child) {
-        border-bottom: 1px solid #6b737b;
         border-top: 1px solid #6b737b;
     }
 }
 
+@mixin hc-drawer-item-padding() {
+    padding: 15px 0 15px 15px;
+}
+
 @mixin hc-drawer-item-right() {
-    padding: 15px 15px 15px 0;
+    padding-left: 0;
+    padding-right: 15px;
 }

--- a/projects/cashmere/src/lib/sass/radio-button.scss
+++ b/projects/cashmere/src/lib/sass/radio-button.scss
@@ -4,13 +4,17 @@
     cursor: pointer;
     display: block;
     line-height: 1.5;
-    margin: 4px 0;
+    margin: 1px 0;
     padding-left: 35px;
     position: relative;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+}
+
+@mixin hc-radio-padding() {
+    padding: 3px 0;
 }
 
 @mixin hc-radio-container-disabled() {

--- a/projects/cashmere/src/lib/sass/tab.scss
+++ b/projects/cashmere/src/lib/sass/tab.scss
@@ -10,7 +10,6 @@
     background-color: $white;
     color: $offblack;
     display: block;
-    padding: 20px;
     text-decoration: none;
 
     &:hover {
@@ -26,13 +25,16 @@
     padding-left: 12px;
 }
 
+@mixin hc-tab-vertical-padding() {
+    padding: 20px;
+}
+
 @mixin hc-tab-horizontal() {
     background-color: inherit;
     color: $offblack;
     display: block;
     font-size: 14px;
     min-width: 100px;
-    padding: 10px 20px;
     text-align: center;
     text-decoration: none;
 
@@ -45,6 +47,10 @@
     border-bottom: $blue 4px solid;
     color: $offblack;
     font-weight: bold;
+}
+
+@mixin hc-tab-horizontal-padding() {
+    padding: 10px 20px;
 }
 
 // tab-set
@@ -77,8 +83,11 @@
 
 @mixin hc-tab-set-bar-vertical() {
     background-color: $white;
-    padding: 15px 0;
     width: 20%;
+}
+
+@mixin hc-tab-bar-padding() {
+    padding: 15px 0;
 }
 
 @mixin hc-tab-set-content-vertical() {

--- a/projects/cashmere/src/lib/sass/tile.scss
+++ b/projects/cashmere/src/lib/sass/tile.scss
@@ -3,7 +3,6 @@
 @mixin hc-tile {
     width: 100%;
     box-sizing: border-box;
-    padding: 30px 35px;
     background-color: $white;
     border-radius: 5px;
     display: block;
@@ -11,6 +10,14 @@
     margin-bottom: 30px;
 }
 
+@mixin hc-tile-padding {
+    padding: 30px 35px;
+}
+
 .hc-tile {
-    @include hc-tile;
+    @include hc-tile();
+}
+
+.hc-tile-padding {
+    @include hc-tile-padding();
 }

--- a/projects/cashmere/src/lib/table/table.component.ts
+++ b/projects/cashmere/src/lib/table/table.component.ts
@@ -50,6 +50,8 @@ export class HcTable<T> extends CdkTable<T> {
     _hostHcTableClass = true;
     @HostBinding('class.hc-table-borders')
     _hostHcBordersClass = true;
+    @HostBinding('class.hc-table-small')
+    _hostHcTableSmall = false;
 
     /** Sets whether the table should have a 2px border around each cell (defaults to true) */
     @Input()
@@ -59,5 +61,14 @@ export class HcTable<T> extends CdkTable<T> {
 
     set borders(hasBorders) {
         this._hostHcBordersClass = parseBooleanAttribute(hasBorders);
+    }
+
+    /** If true, table has less padding and a smaller font size (defaults to false)  */
+    @Input()
+    get tight(): boolean {
+        return this._hostHcTableSmall;
+    }
+    set tight(value) {
+        this._hostHcTableSmall = parseBooleanAttribute(value);
     }
 }

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.html
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.html
@@ -1,5 +1,5 @@
 <div class="hc-{{direction}}-tab-container">
-    <div class="hc-tab-bar-{{direction}}">
+    <div class="hc-tab-bar-{{direction}}" [class.hc-tab-bar-padding]="!tight && direction=='vertical'">
         <ng-content select="hc-tab"></ng-content>
         <ng-content></ng-content>
     </div>

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.scss
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.scss
@@ -18,6 +18,10 @@
 
 .hc-tab-bar-vertical {
     @include hc-tab-set-bar-vertical();
+
+    &.hc-tab-bar-padding {
+        @include hc-tab-bar-padding();
+    }
 }
 
 .hc-tab-content-vertical {

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
@@ -94,6 +94,16 @@ export class TabSetComponent implements AfterContentInit {
 
     _addContentContainer: boolean = true;
 
+    /** If true, remove the default padding on all included tabs. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+    }
+    private _tight = false;
+
     constructor(private router: Router, private route: ActivatedRoute) {}
 
     ngAfterContentInit(): void {
@@ -115,7 +125,10 @@ export class TabSetComponent implements AfterContentInit {
     }
 
     private setTabDirection(): void {
-        setTimeout(() => this._tabs.forEach(t => (t._direction = this.direction)));
+        setTimeout(() => this._tabs.forEach(t => {
+            t._direction = this.direction;
+            t._tight = this.tight;
+        }));
     }
 
     private subscribeToTabClicks(): void {

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.html
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="_direction">
     <a *ngIf="routerLink; else tabWithoutRouting" class="hc-tab-{{_direction}} hc-text-ellipsis"
+        [class.hc-tab-padding]="!_tight"
         [routerLink]="routerLink"
         routerLinkActive="active"
         (click)="tabClick.emit()">
@@ -10,6 +11,7 @@
 <ng-template #tabWithoutRouting>
     <a class="hc-tab-{{_direction}} hc-text-ellipsis"
         [class.active]="_active"
+        [class.hc-tab-padding]="!_tight"
         (click)="tabClick.emit()">
         <ng-container *ngIf="_htmlTitle" [ngTemplateOutlet]="_htmlTitle.tabTitle"></ng-container>
         {{tabTitle}}

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.scss
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.scss
@@ -10,6 +10,10 @@
     &.active {
         @include hc-tab-vertical-active();
     }
+
+    &.hc-tab-padding {
+        @include hc-tab-vertical-padding();
+    }
 }
 
 .hc-tab-horizontal {
@@ -17,5 +21,9 @@
 
     &.active {
         @include hc-tab-horizontal-active();
+    }
+
+    &.hc-tab-padding {
+        @include hc-tab-horizontal-padding();
     }
 }

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.ts
@@ -28,6 +28,7 @@ export class TabComponent implements AfterContentInit {
 
     _direction: string;
     _active: boolean = false;
+    _tight: boolean = false;
     _htmlTitle: HcTabTitleComponent;
 
     @ContentChildren(HcTabTitleComponent)

--- a/projects/cashmere/src/lib/tile/tile.component.scss
+++ b/projects/cashmere/src/lib/tile/tile.component.scss
@@ -1,5 +1,0 @@
-@import '../sass/tile';
-
-:host {
-    @include hc-tile;
-}

--- a/projects/cashmere/src/lib/tile/tile.component.ts
+++ b/projects/cashmere/src/lib/tile/tile.component.ts
@@ -1,14 +1,27 @@
-import {Component} from '@angular/core';
+import {Component, HostBinding, Input} from '@angular/core';
+import {parseBooleanAttribute} from '../util';
 
 /** Container element to help segment content visually against a gray background.
  * The tile will expand to the height and width of the content it contains. */
 @Component({
     selector: 'hc-tile',
-    template: `
-        <ng-content></ng-content>
-    `,
-    styleUrls: ['./tile.component.scss']
+    template: '<ng-content></ng-content>'
 })
 export class TileComponent {
+    @HostBinding('class.hc-tile')
+    _hostClass = true;
+
+    @HostBinding('class.hc-tile-padding')
+    _hasPadding = true;
+
+    /** If true, remove the default 30px 35px padding on the tile. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return !this._hasPadding;
+    }
+    set tight(value) {
+        this._hasPadding = !parseBooleanAttribute(value);
+    }
+
     constructor() {}
 }

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
@@ -1,4 +1,4 @@
-<div class="hc-tile">
+<hc-tile>
     <div class="header">
         <h3 class="docs-api-h3">{{ exampleTitle }}</h3>
         <button hc-button buttonStyle="minimal" size="md" (click)="launchStackBlitz()">
@@ -13,4 +13,4 @@
             <pre> <code [highlight]="file.contents" ></code> </pre>
         </hc-tab>
     </hc-tab-set>
-</div>
+</hc-tile>

--- a/src/app/shared/markdown/markdown.directive.ts
+++ b/src/app/shared/markdown/markdown.directive.ts
@@ -22,7 +22,7 @@ export class MarkdownDirective implements OnChanges {
         const md = new markdownIt({html: true});
 
         // plugin to markdown-it to interpret :::
-        md.use(container_plugin, 'hc-tile', {
+        md.use(container_plugin, 'hc-tile hc-tile-padding', {
             validate: function(params) {
                 // markdown-it-container allows multiple ::: containers
                 // This function allows you to validate this is the one you want

--- a/tools/dgeni/templates/componentGroup.template.html
+++ b/tools/dgeni/templates/componentGroup.template.html
@@ -45,7 +45,7 @@
   {% include 'interface.template.html' %}
 {% endmacro %}
 
-<div class="hc-tile">
+<div class="hc-tile hc-tile-padding">
     <h3 class="docs-header-link docs-api-h3">
         Module Import
     </h3>
@@ -58,7 +58,7 @@
 </div>
 
 {%- if doc.services.length -%}
-<div class="hc-tile">
+<div class="hc-tile hc-tile-padding">
     <h3 id="services" class="docs-header-link docs-api-h3">
         <span header-link="services"></span>
         Services
@@ -70,7 +70,7 @@
 {%- endif -%}
 
 {%- if doc.directives.length -%}
-<div class="hc-tile">
+<div class="hc-tile hc-tile-padding">
     <h3 id="directives" class="docs-header-link docs-api-h3">
         <span header-link="directives"></span>
         Directives
@@ -82,7 +82,7 @@
 {%- endif -%}
 
 {%- if doc.additionalClasses.length -%}
-<div class="hc-tile">
+<div class="hc-tile hc-tile-padding">
     <h3 id="additional_classes" class="docs-header-link docs-api-h3">
         <span header-link="additional_classes"></span>
         Additional classes
@@ -94,7 +94,7 @@
 {%- endif -%}
 
 {%- if doc.additionalInterfaces.length -%}
-<div class="hc-tile">
+<div class="hc-tile hc-tile-padding">
     <h3 id="additional_interfaces" class="docs-header-link docs-api-h3">
         <span header-link="additional_interfaces"></span>
         Additional interfaces


### PR DESCRIPTION
`tight` param removes default padding or margin on components

Lots of files affected here - but pretty much the same pattern repeating.  Tried to hit every component that had some kind of default margin or padding and give the option to omit that.

@jonest - for the `tight` param on table, I used it to apply the `hc-table-small` class that @corykon had already created in the stylesheet (but was never surfaced in the component).  I updated the second table example in this branch to display that.  Let me know if you think that trims the table enough for what your users are requesting.

closes #944