### PR TITLE
style(appswitcher): max width

### DIFF
--- a/projects/cashmere/src/lib/sass/app-switcher.scss
+++ b/projects/cashmere/src/lib/sass/app-switcher.scss
@@ -7,7 +7,7 @@
 }
 
 @mixin hc-app-switcher() {
-    max-width: 410px;
+    max-width: 360px;
 }
 
 @mixin hc-app-switcher-header() {


### PR DESCRIPTION
corrects the max-width for the smaller default icon sizes

closes #1155