### PR TITLE
Table tight

### DIFF
--- a/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.component.html
+++ b/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.component.html
@@ -1,5 +1,7 @@
-<hc-checkbox id="light">Standard Checkbox</hc-checkbox>
+<hc-checkbox>Standard Checkbox</hc-checkbox>
 
-<hc-checkbox id="disabled" disabled="true">Disabled Checkbox</hc-checkbox>
+<hc-checkbox disabled="true">Disabled Checkbox</hc-checkbox>
 
-<hc-checkbox id="disabled" [checked]="true" disabled="true">Disabled Checkbox (Checked)</hc-checkbox>
+<hc-checkbox [checked]="true" disabled="true">Disabled Checkbox (Checked)</hc-checkbox>
+
+<hc-checkbox tight="true">Tight Checkbox</hc-checkbox>

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
@@ -1,7 +1,7 @@
 <p>For forms that need to fit in smaller spaces, the <code>tight</code> parameter may be set to true on
-either the <code>hc-form</code> or individual <code>hc-form-field</code> elements.</p>
+either the <code>hcForm</code> or individual <code>hc-form-field</code> elements.</p>
 <br>
-<form hc-form tight="true">
+<form hcForm tight="true">
     <div class="form-sample">
         <hc-form-field>
             <hc-label>Job Name:</hc-label>

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
@@ -1,16 +1,16 @@
 <p>For forms that need to fit in smaller spaces, the <code>tight</code> parameter may be set to true on
-either the form or individual <code>hc-form-field</code> elements.</p>
+either the <code>hc-form</code> or individual <code>hc-form-field</code> elements.</p>
 <br>
-<form>
+<form hc-form tight="true">
     <div class="form-sample">
-        <hc-form-field tight="true">
+        <hc-form-field>
             <hc-label>Job Name:</hc-label>
             <input hcInput required [formControl]="inputControl">
             <hc-error>A job name is required</hc-error>
         </hc-form-field>
     </div>
 
-    <hc-form-field inline="true" tight="true" class="form-padding">
+    <hc-form-field inline="true">
         <hc-label>Data Source:</hc-label>
         <hc-radio-group [formControl]="radioControl" inline="true">
             <hc-radio-button value="SM">Source Mart</hc-radio-button>
@@ -21,7 +21,7 @@ either the form or individual <code>hc-form-field</code> elements.</p>
     </hc-form-field>
 
     <div class="form-sample">
-        <hc-form-field tight="true">
+        <hc-form-field inline="true">
             <hc-label>Run Frequency:</hc-label>
             <hc-select placeholder="Select frequency:" [formControl]="selectControl">
                 <option value="daily">Daily</option>
@@ -33,7 +33,7 @@ either the form or individual <code>hc-form-field</code> elements.</p>
     </div>
 
     <div class="form-sample flex-column">
-        <hc-form-field tight="true">
+        <hc-form-field>
             <hc-label>Requested Notifications:</hc-label>
             <hc-checkbox [formControl]="checkControl">On failure</hc-checkbox>
             <hc-checkbox [formControl]="checkControl">On sucess</hc-checkbox>

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
@@ -1,0 +1,45 @@
+<p>For forms that need to fit in smaller spaces, the <code>tight</code> parameter may be set to true on
+either the form or individual <code>hc-form-field</code> elements.</p>
+<br>
+<form>
+    <div class="form-sample">
+        <hc-form-field tight="true">
+            <hc-label>Job Name:</hc-label>
+            <input hcInput required [formControl]="inputControl">
+            <hc-error>A job name is required</hc-error>
+        </hc-form-field>
+    </div>
+
+    <hc-form-field inline="true" tight="true" class="form-padding">
+        <hc-label>Data Source:</hc-label>
+        <hc-radio-group [formControl]="radioControl" inline="true">
+            <hc-radio-button value="SM">Source Mart</hc-radio-button>
+            <hc-radio-button value="SAM">Subject Area Mart</hc-radio-button>
+            <hc-radio-button value="Other">Other</hc-radio-button>
+        </hc-radio-group>
+        <hc-error>Specified data source does not match description</hc-error>
+    </hc-form-field>
+
+    <div class="form-sample">
+        <hc-form-field tight="true">
+            <hc-label>Run Frequency:</hc-label>
+            <hc-select placeholder="Select frequency:" [formControl]="selectControl">
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+            </hc-select>
+            <hc-error>Please select the run frequency for this item</hc-error>
+        </hc-form-field>
+    </div>
+
+    <div class="form-sample flex-column">
+        <hc-form-field tight="true">
+            <hc-label>Requested Notifications:</hc-label>
+            <hc-checkbox [formControl]="checkControl">On failure</hc-checkbox>
+            <hc-checkbox [formControl]="checkControl">On sucess</hc-checkbox>
+            <hc-checkbox [formControl]="checkControl">On row-count mismatch</hc-checkbox>
+            <hc-checkbox [formControl]="checkControl">On dependency-wait timeout</hc-checkbox>
+            <hc-error>At least one notification must be selected</hc-error>
+        </hc-form-field>
+    </div>
+</form>

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.scss
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.scss
@@ -1,0 +1,12 @@
+.form-sample {
+    max-width: 350px;
+    width: 100%;
+}
+
+.flex-column {
+    flex-direction: column;
+}
+
+.form-padding {
+    padding-bottom: 1.525em;
+}

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.scss
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.scss
@@ -6,7 +6,3 @@
 .flex-column {
     flex-direction: column;
 }
-
-.form-padding {
-    padding-bottom: 1.525em;
-}

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.ts
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+import {FormControl} from '@angular/forms';
+
+/**
+ * @title Tight Form Field Elements
+ */
+@Component({
+    selector: 'hc-form-field-tight-example',
+    templateUrl: 'form-field-tight-example.component.html',
+    styleUrls: ['form-field-tight-example.component.scss']
+})
+export class FormFieldTightExampleComponent {
+    selectControl = new FormControl('daily');
+    inputControl = new FormControl('');
+    radioControl = new FormControl('SM');
+    checkControl = new FormControl('');
+}

--- a/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.component.html
@@ -1,10 +1,14 @@
-<hc-form-field inline="true">
+<p>These inputs have the <code>tight</code> parameter set to true.</p>
+
+<br>
+
+<hc-form-field inline="true" tight="true">
     <hc-label>Minimum Value:</hc-label>
     <input hcInput placeholder="0-100" class="demo-input">
     <hc-icon hcSuffix fontSet="fa" fontIcon="fa-thermometer-0"></hc-icon>
 </hc-form-field>
 
-<hc-form-field inline="true">
+<hc-form-field inline="true" tight="true">
     <hc-label>Maximum Value:</hc-label>
     <input hcInput placeholder="100-500" class="demo-input">
     <hc-icon hcSuffix fontSet="fa" fontIcon="fa-thermometer-full"></hc-icon>

--- a/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.component.html
+++ b/projects/cashmere-examples/src/lib/radio-button-forms/radio-button-forms-example.component.html
@@ -1,5 +1,5 @@
-<hc-form-field inline="true">
-    <hc-label>Select your favorite:</hc-label>
+<hc-form-field inline="true" tight="true">
+    <hc-label>Radio buttons with tight styling:</hc-label>
     <hc-radio-group [(ngModel)]="favoriteShow" inline="true">
         <hc-radio-button *ngFor="let show of shows" [value]="show">{{show}}</hc-radio-button>
     </hc-radio-group>

--- a/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.html
@@ -1,7 +1,7 @@
 <form>
     <div class="select-sample">
-        <hc-form-field>
-            <hc-label>Project Status:</hc-label>
+        <hc-form-field tight="true">
+            <hc-label>Select with Tight Styling:</hc-label>
             <hc-select [formControl]="selectControl" required>
                 <option value="active">Active</option>
                 <option value="inactive">Inactive</option>

--- a/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
@@ -1,3 +1,5 @@
+<p>This is an example of a sortable table with <code>tight</code> styling.</p>
+
 <table hc-table [dataSource]="dataSource" tight="true" hcSort>
 
     <!-- Position Column -->

--- a/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
@@ -1,4 +1,4 @@
-<table hc-table [dataSource]="dataSource" hcSort>
+<table hc-table [dataSource]="dataSource" tight="true" hcSort>
 
     <!-- Position Column -->
     <ng-container hcColumnDef="position">

--- a/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.html
+++ b/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.html
@@ -1,5 +1,5 @@
 <div class="tab-demo">
-    <hc-tab-set defaultTab="1">
+    <hc-tab-set defaultTab="1" [tight]="_tight">
         <hc-tab tabTitle="Nested Tabs">
             <hc-tab-set direction="horizontal">
                 <hc-tab tabTitle="Tab 1">
@@ -43,3 +43,5 @@
         </hc-tab>
     </hc-tab-set>
 </div>
+
+<hc-checkbox [(ngModel)]="_tight">Apply Tight Styling to Tabs</hc-checkbox>

--- a/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.scss
+++ b/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.scss
@@ -4,6 +4,7 @@
 
 .tab-demo {
     border: 1px solid #e0e0e0;
+    margin-bottom: 15px;
 }
 
 .tab-bar-content {

--- a/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.ts
+++ b/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.ts
@@ -8,4 +8,6 @@ import {Component} from '@angular/core';
     templateUrl: 'tabs-vertical-example.component.html',
     styleUrls: ['tabs-vertical-example.component.scss']
 })
-export class TabsVerticalExampleComponent {}
+export class TabsVerticalExampleComponent {
+    _tight: boolean = false;
+}

--- a/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.component.html
@@ -2,3 +2,8 @@
     <h5>Example Tile</h5>
     <p>This paragraph is contained within a <code>hc-tile</code> component.</p>
 </hc-tile>
+
+<hc-tile tight="true">
+    <h5>Tight Tile</h5>
+    <p>This is a tile with <code>tight</code> styling. It has less padding.</p>
+</hc-tile>

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.html
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.html
@@ -1,5 +1,5 @@
 <div class="hc-checkbox-container">
-    <div class="hc-checkbox-content">
+    <div class="hc-checkbox-content" [class.hc-checkbox-tight]="tight">
         <input #checkboxInput
                type="checkbox"
                [id]="_inputId"

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.scss
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.scss
@@ -26,10 +26,18 @@
 
 .hc-checkbox-label {
     @include hc-checkbox-label();
+
+    .hc-checkbox-tight & {
+        @include hc-checkbox-label-tight();
+    }
 }
 
 .hc-checkbox-overlay {
     @include hc-checkbox-overlay();
+
+    .hc-checkbox-tight & {
+        @include hc-checkbox-overlay-tight();
+    }
 
     .hc-checkbox-content:hover & {
         @include hc-checkbox-overlay-hover();
@@ -37,6 +45,10 @@
 
     .hc-checkbox-indeterminate & {
         @include hc-checkbox-overlay-indeterminate();
+    }
+
+    .hc-checkbox-indeterminate .hc-checkbox-tight & {
+        @include hc-checkbox-overlay-indeterminate-tight();
     }
 
     input[type='checkbox']:checked + & {

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.ts
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.ts
@@ -39,6 +39,7 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
     private _form: NgForm | FormGroupDirective | null;
     private _checked: boolean = false;
     private _tabIndex: number;
+    private _tight: boolean = false;
 
     _componentId = this._uniqueId;
 
@@ -58,6 +59,15 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
 
     set id(idVal: string) {
         this._componentId = idVal ? idVal : this._uniqueId;
+    }
+
+    /** If true, condense the default margin and reduce the font size. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
     }
 
     /** Sets unique name used in a form */

--- a/projects/cashmere/src/lib/form-field/hc-form-control.component.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form-control.component.ts
@@ -19,4 +19,7 @@ export abstract class HcFormControlComponent {
 
     /** Whether the control is required */
     _isRequired: boolean = false;
+
+    /** Whether the control should apply tight styling */
+    tight: boolean = false;
 }

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.html
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.html
@@ -1,6 +1,10 @@
-<div [class.hc-form-field-wrapper-inline]="inline" [class.hc-form-field-wrapper]="!inline" [class.hc-form-field-no-label]="!hasLabel">
-    <span *ngIf="hasLabel" [ngClass]="inline ? 'hc-form-field-label-wrapper-inline' : 'hc-form-field-label-wrapper'">
-        <label [ngClass]="inline ? 'hc-form-field-label-inline' : 'hc-form-field-label'" [attr.for]="_control._componentId">
+<div
+    [class.hc-form-field-wrapper-inline]="inline"
+    [class.hc-form-field-wrapper]="!inline"
+    [class.hc-form-field-no-label]="!hasLabel"
+    [class.hc-form-field-wrapper-tight]="tight" >
+    <span *ngIf="hasLabel" [ngClass]="inline ? 'hc-form-field-label-wrapper-inline' : 'hc-form-field-label-wrapper'" [class.hc-form-field-label-wrapper-tight]="tight">
+        <label [ngClass]="inline ? 'hc-form-field-label-inline' : 'hc-form-field-label'" [class.hc-form-field-label-tight]="tight" [attr.for]="_control._componentId">
             <ng-content select="hc-label"></ng-content>
             <span class="hc-required-marker" aria-hidden="true" *ngIf="_control._isRequired && !_control._isDisabled">&nbsp;*</span>
         </label>
@@ -15,7 +19,7 @@
             <div class="hc-form-field-prefix" *ngIf="_prefixChildren.length">
                 <ng-content select="[hcPrefix]"></ng-content>
             </div>
-            <div #inputs class="hc-form-field-infix">
+            <div #inputs class="hc-form-field-infix" [class.hc-form-field-infix-tight]="tight">
                 <ng-content select="[hcInput]"></ng-content>
             </div>
             <div class="hc-form-field-suffix" *ngIf="_suffixChildren.length">
@@ -27,6 +31,7 @@
             *ngIf="!hasInput"
             [class.hc-form-field-non-input]="!inline"
             [class.hc-form-field-non-input-inline]="inline"
+            [class.hc-form-field-non-input-inline-tight]="inline && tight"
             [class.hc-form-field-invalid]="_shouldShowErrorMessages()"
         >
             <ng-content></ng-content>

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -63,6 +63,10 @@
 
     .hc-icon {
         @include hc-form-field-prefix-suffix-icon();
+
+        .hc-form-field-wrapper-tight & {
+            @include hc-form-field-prefix-suffix-tight();
+        }
     }
 
     .hc-form-field-disabled & {

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -6,10 +6,18 @@
 
 .hc-form-field-wrapper {
     @include hc-form-field-wrapper();
+
+    &.hc-form-field-wrapper-tight {
+        @include hc-form-field-wrapper-tight-border();
+    }
 }
 
 .hc-form-field-wrapper-inline {
     @include hc-form-field-wrapper-inline();
+}
+
+.hc-form-field-wrapper-tight {
+    @include hc-form-field-wrapper-tight();
 }
 
 .hc-form-field-content-wrapper {
@@ -45,6 +53,10 @@
     @include hc-form-field-non-input-inline();
 }
 
+.hc-form-field-non-input-inline-tight {
+    @include hc-form-field-non-input-inline-tight();
+}
+
 .hc-form-field-prefix,
 .hc-form-field-suffix {
     @include hc-form-field-prefix-suffix();
@@ -70,11 +82,19 @@
     @include hc-form-field-infix();
 }
 
+.hc-form-field-infix-tight {
+    @include hc-form-field-infix-tight();
+}
+
 .hc-form-field-label-wrapper {
     @include hc-form-field-label-wrapper();
 
     .hc-icon {
         @include hc-form-field-label-wrapper-icon();
+    }
+
+    &.hc-form-field-label-wrapper-tight {
+        @include hc-form-field-label-tight();
     }
 }
 
@@ -84,18 +104,26 @@
     .hc-icon {
         @include hc-form-field-label-wrapper-icon();
     }
+
+    &.hc-form-field-label-wrapper-tight {
+        @include hc-form-field-label-wrapper-tight-inline();
+    }
 }
 
 .hc-form-field-label {
     @include hc-form-field-label();
 }
 
-.hc-form-field-no-label {
-    @include hc-form-field-no-label();
-}
-
 .hc-form-field-label-inline {
     @include hc-form-field-label-inline();
+}
+
+.hc-form-field-label-tight {
+    @include hc-form-field-label-tight();
+}
+
+.hc-form-field-no-label {
+    @include hc-form-field-no-label();
 }
 
 .hc-form-field-error-wrapper {

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.ts
@@ -30,9 +30,12 @@ export function getControlMissing(): Error {
 })
 export class HcFormFieldComponent implements AfterContentInit {
     private _inline: boolean = false;
+    private _tight: boolean = false;
 
     @ContentChild(HcFormControlComponent)
     _control: HcFormControlComponent;
+    @ContentChildren(HcFormControlComponent)
+    _controls: QueryList<HcFormControlComponent>;
     @ContentChildren(HcErrorComponent)
     _errorChildren: QueryList<HcErrorComponent>;
     @ContentChildren(HcPrefixDirective)
@@ -72,11 +75,29 @@ export class HcFormFieldComponent implements AfterContentInit {
         this._inline = parseBooleanAttribute(isInline);
     }
 
+    /** If true, condense the default padding on all included elements and reduce the font size. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+        if (this._controls) {
+            this._controls.forEach(control => {
+                control.tight = this._tight;
+            });
+        }
+    }
+
     constructor(private _elementRef: ElementRef<HTMLInputElement>) {}
 
     ngAfterContentInit(): void {
         if (!this._control) {
             throw getControlMissing();
+        } else {
+            this._controls.forEach(control => {
+                control.tight = this._tight;
+            });
         }
     }
 

--- a/projects/cashmere/src/lib/form-field/hc-form-field.module.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.module.ts
@@ -5,10 +5,11 @@ import {HcErrorComponent} from './hc-error.component';
 import {HcSuffixDirective} from './hc-suffix.directive';
 import {HcPrefixDirective} from './hc-prefix.directive';
 import {HcLabelComponent} from './hc-label.component';
+import {HcFormDirective} from './hc-form.directive';
 
 @NgModule({
     imports: [CommonModule],
-    declarations: [HcFormFieldComponent, HcErrorComponent, HcPrefixDirective, HcSuffixDirective, HcLabelComponent],
-    exports: [HcFormFieldComponent, HcErrorComponent, HcPrefixDirective, HcSuffixDirective, HcLabelComponent]
+    declarations: [HcFormFieldComponent, HcErrorComponent, HcPrefixDirective, HcSuffixDirective, HcLabelComponent, HcFormDirective],
+    exports: [HcFormFieldComponent, HcErrorComponent, HcPrefixDirective, HcSuffixDirective, HcLabelComponent, HcFormDirective]
 })
 export class FormFieldModule {}

--- a/projects/cashmere/src/lib/form-field/hc-form.directive.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form.directive.ts
@@ -1,0 +1,46 @@
+import {Directive, Input, ContentChildren, QueryList, AfterContentInit, OnDestroy} from '@angular/core';
+import {parseBooleanAttribute} from '../util';
+import {HcFormFieldComponent} from './hc-form-field.component';
+import {takeUntil} from 'rxjs/operators';
+import {Subject} from 'rxjs';
+
+/** Directive that allows settings to be applied to all included HcFormFields */
+@Directive({
+    selector: '[hc-form]'
+})
+export class HcFormDirective implements AfterContentInit, OnDestroy {
+    private _tight: boolean = false;
+    private unsubscribe$ = new Subject<void>();
+
+    @ContentChildren(HcFormFieldComponent)
+    _formFields: QueryList<HcFormFieldComponent>;
+
+    /** Set the tight parameter on all enclosed HcFormFields. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+        this._updateTightFields();
+    }
+
+    ngAfterContentInit(): void {
+        this._updateTightFields();
+        // Pass the tight setting to any FormFields added dynamically
+        this._formFields.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this._updateTightFields());
+    }
+
+    ngOnDestroy() {
+        this.unsubscribe$.next();
+        this.unsubscribe$.complete();
+    }
+
+    _updateTightFields() {
+        if (this._formFields) {
+            this._formFields.forEach(field => {
+                field.tight = this._tight;
+            });
+        }
+    }
+}

--- a/projects/cashmere/src/lib/form-field/hc-form.directive.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form.directive.ts
@@ -4,9 +4,9 @@ import {HcFormFieldComponent} from './hc-form-field.component';
 import {takeUntil} from 'rxjs/operators';
 import {Subject} from 'rxjs';
 
-/** Directive that allows settings to be applied to all included HcFormFields */
+/** `hcForm` directive that allows settings to be applied to all included HcFormFields */
 @Directive({
-    selector: '[hc-form]'
+    selector: '[hcForm]'
 })
 export class HcFormDirective implements AfterContentInit, OnDestroy {
     private _tight: boolean = false;

--- a/projects/cashmere/src/lib/form-field/index.ts
+++ b/projects/cashmere/src/lib/form-field/index.ts
@@ -6,4 +6,5 @@ export {HcErrorComponent} from './hc-error.component';
 export {HcPrefixDirective} from './hc-prefix.directive';
 export {HcSuffixDirective} from './hc-suffix.directive';
 export {HcLabelComponent} from './hc-label.component';
+export {HcFormDirective} from './hc-form.directive';
 export {FormFieldModule} from './hc-form-field.module';

--- a/projects/cashmere/src/lib/radio-button/radio-button.component.html
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.html
@@ -1,4 +1,7 @@
-<label class="hc-radio-container" [class.disabled]="disabled">
+<label class="hc-radio-container"
+    [class.disabled]="disabled"
+    [class.hc-radio-inline]="_inlineGroup"
+    [class.hc-radio-tight]="tight" >
     <input class="hc-radio-input"
            [class.disabled]="disabled"
            type="radio"

--- a/projects/cashmere/src/lib/radio-button/radio-button.component.scss
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.scss
@@ -6,6 +6,24 @@
     &.disabled {
         @include hc-radio-container-disabled();
     }
+
+    &.hc-radio-inline {
+        @include hc-radio-container-inline();
+    }
+
+    &.hc-radio-tight {
+        @include hc-radio-container-tight();
+    }
+}
+
+.hc-radio-tight {
+    .hc-radio-overlay {
+        @include hc-radio-overlay-tight();
+    }
+
+    .hc-radio-content {
+        @include hc-radio-content-tight();
+    }
 }
 
 .hc-radio-overlay {

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -151,7 +151,9 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
     }
     set tight(value) {
         this._tight = parseBooleanAttribute(value);
-        this._markRadiosForCheck();
+        if (this._initialized) {
+            setTimeout(() => this._markRadiosForCheck());
+        }
     }
 
     constructor(

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -51,6 +51,7 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
     private _uniqueName = `hc-radio-group-${nextUniqueId++}`;
     private _name = this._uniqueName;
     private _inline = false;
+    private _tight: boolean = false;
     private _initialized = false; // if value of radio group has been set to initial value
     private _selected: RadioButtonComponent | null = null; // the currently selected radio
     private _form: NgForm | FormGroupDirective | null;
@@ -141,6 +142,16 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
         this._inline = parseBooleanAttribute(value);
         this._verticalClass = !this._inline;
         this._horizontalClass = this._inline;
+    }
+
+    /** If true, condense the default margin and reduce the font size on all contained radios. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+        this._markRadiosForCheck();
     }
 
     constructor(
@@ -275,6 +286,7 @@ export class RadioButtonComponent implements OnInit {
     private _value: any = null;
     private _required: boolean = false;
     private _disabled: boolean = false;
+    private _tight: boolean = false;
     private readonly radioGroup: RadioGroupDirective | null;
 
     /** Value of radio buttons */
@@ -336,6 +348,28 @@ export class RadioButtonComponent implements OnInit {
             }
             this.cdRef.markForCheck();
         }
+    }
+
+    get _inlineGroup(): boolean {
+        if (this.radioGroup !== null) {
+            return this.radioGroup.inline;
+        } else {
+            return false;
+        }
+    }
+
+    /** If true, condense the default margin, reduce the font size, and decrease the circle size.
+     * Inherits value from parent radio group if part of one. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        if (this.radioGroup !== null) {
+            return this.radioGroup.tight;
+        } else {
+            return this._tight;
+        }
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
     }
 
     get _inputId() {

--- a/projects/cashmere/src/lib/sass/_radio-group.scss
+++ b/projects/cashmere/src/lib/sass/_radio-group.scss
@@ -7,11 +7,6 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-
-    .hc-radio-container {
-        padding-left: 32px !important;
-        margin-right: 25px !important;
-    }
 }
 
 .hc-form-field-invalid {

--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -60,7 +60,7 @@
     height: 18px;
 
     &:after {
-        top: 0px;
+        top: 0.5px;
         left: 0.5px;
         width: 12.5px;
         height: 12.5px;

--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -1,4 +1,5 @@
 @import './colors';
+@import './functions';
 
 @mixin hc-checkbox-container() {
     overflow: hidden;
@@ -29,6 +30,11 @@
     line-height: 1.5;
 }
 
+@mixin hc-checkbox-label-tight() {
+    padding: 2px 0 2px 8px;
+    font-size: calculateRem(13px);
+}
+
 @mixin hc-checkbox-overlay() {
     position: relative;
     width: 22px;
@@ -46,6 +52,18 @@
         width: 15.5px;
         height: 15.5px;
         opacity: 0;
+    }
+}
+
+@mixin hc-checkbox-overlay-tight() {
+    width: 18px;
+    height: 18px;
+
+    &:after {
+        top: 0px;
+        left: 0.5px;
+        width: 12.5px;
+        height: 12.5px;
     }
 }
 
@@ -75,6 +93,13 @@
         height: 7px;
         border-bottom: 3px solid $gray-300;
         background-image: none;
+    }
+}
+
+@mixin hc-checkbox-overlay-indeterminate-tight() {
+    &:after {
+        top: 1.5px;
+        width: 8px;
     }
 }
 

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -119,6 +119,10 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     line-height: $line-height;
 }
 
+@mixin hc-form-field-prefix-suffix-tight() {
+    line-height: 1.3;
+}
+
 @mixin hc-form-field-prefix {
     padding-left: 7px;
 }
@@ -162,6 +166,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
 @mixin hc-form-field-label-wrapper-tight-inline() {
     padding-top: 0;
+    line-height: 1.9;
 }
 
 @mixin hc-form-field-label-wrapper-icon() {

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -5,9 +5,11 @@ $line-height: 1.5;
 $label-font-scale: 1;
 $error-font-scale: 0.75;
 $infix-margin-top: 1.143em * $line-height * $label-font-scale;
+$infix-margin-top-tight: 1.143em * $line-height * 0.93;
 $prefix-suffix-icon-font-size: 125%;
 
 $infix-padding: 0.393em;
+$infix-padding-tight: $infix-padding / 2;
 $error-margin-top: 0.4em / $error-font-scale;
 $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
@@ -26,6 +28,14 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     border-top: $infix-margin-top solid transparent;
     padding-bottom: $wrapper-padding-bottom;
     flex-direction: inherit;
+}
+
+@mixin hc-form-field-wrapper-tight() {
+    padding-bottom: 10px;
+}
+
+@mixin hc-form-field-wrapper-tight-border() {
+    border-top: $infix-margin-top-tight solid transparent;
 }
 
 @mixin hc-form-field-wrapper-inline() {
@@ -89,6 +99,10 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     align-items: center;
 }
 
+@mixin hc-form-field-non-input-inline-tight() {
+    min-height: auto;
+}
+
 @mixin hc-form-field-prefix-suffix() {
     white-space: nowrap;
     flex: none;
@@ -120,6 +134,11 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     padding: $infix-padding 10px;
 }
 
+@mixin hc-form-field-infix-tight() {
+    padding: $infix-padding-tight 7px;
+    font-size: calculateRem(13px);
+}
+
 @mixin hc-form-field-label-wrapper() {
     position: absolute;
     left: 0;
@@ -132,8 +151,17 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     padding-top: $infix-margin-top;
 }
 
+@mixin hc-form-field-label-wrapper-tight() {
+    top: -$infix-margin-top-tight;
+    padding-top: $infix-margin-top-tight;
+}
+
 @mixin hc-form-field-label-wrapper-inline() {
     padding: 7px 15px 0 0;
+}
+
+@mixin hc-form-field-label-wrapper-tight-inline() {
+    padding-top: 0;
 }
 
 @mixin hc-form-field-label-wrapper-icon() {
@@ -177,6 +205,10 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+}
+
+@mixin hc-form-field-label-tight() {
+    font-size: calculateRem(13px);
 }
 
 @mixin hc-form-field-error-wrapper() {

--- a/projects/cashmere/src/lib/sass/radio-button.scss
+++ b/projects/cashmere/src/lib/sass/radio-button.scss
@@ -1,4 +1,5 @@
 @import './colors';
+@import './functions';
 
 @mixin hc-radio-container() {
     cursor: pointer;
@@ -16,6 +17,16 @@
 @mixin hc-radio-container-disabled() {
     color: $gray-300;
     cursor: not-allowed;
+}
+
+@mixin hc-radio-container-inline() {
+    padding-left: 32px;
+    margin-right: 25px;
+}
+
+@mixin hc-radio-container-tight() {
+    margin: 1px 15px 1px 0;
+    padding-left: 25px;
 }
 
 @mixin hc-radio-overlay() {
@@ -38,6 +49,17 @@
         position: absolute;
         top: 5px;
         width: 8px;
+    }
+}
+
+@mixin hc-radio-overlay-tight() {
+    height: 18px;
+    width: 18px;
+    top: 1px;
+
+    &:after {
+        left: 3px;
+        top: 3px;
     }
 }
 
@@ -77,4 +99,8 @@
 
 @mixin hc-radio-input-disabled() {
     cursor: not-allowed;
+}
+
+@mixin hc-radio-content-tight() {
+    font-size: calculateRem(13px);
 }

--- a/projects/cashmere/src/lib/sass/select.scss
+++ b/projects/cashmere/src/lib/sass/select.scss
@@ -50,6 +50,10 @@
     }
 }
 
+@mixin hc-select-chevron-tight() {
+    height: 28px;
+}
+
 @mixin hc-select-input() {
     @include fontSize(14px);
 
@@ -81,6 +85,11 @@
         color: tint($text, 60%);
         cursor: not-allowed;
     }
+}
+
+@mixin hc-select-input-tight() {
+    @include fontSize(13px);
+    height: 28px;
 }
 
 @mixin hc-select-chevron-disabled() {

--- a/projects/cashmere/src/lib/sass/tab.scss
+++ b/projects/cashmere/src/lib/sass/tab.scss
@@ -26,6 +26,10 @@
     padding-left: 12px;
 }
 
+@mixin hc-tab-vertical-tight() {
+    padding: 10px 20px;
+}
+
 @mixin hc-tab-horizontal() {
     background-color: inherit;
     color: $offblack;
@@ -45,6 +49,10 @@
     border-bottom: $blue 4px solid;
     color: $offblack;
     font-weight: bold;
+}
+
+@mixin hc-tab-horizontal-tight() {
+    padding: 10px;
 }
 
 // tab-set

--- a/projects/cashmere/src/lib/sass/tile.scss
+++ b/projects/cashmere/src/lib/sass/tile.scss
@@ -11,6 +11,15 @@
     margin-bottom: 30px;
 }
 
+@mixin hc-tile-tight {
+    padding: 10px 15px;
+    margin-bottom: 15px;
+}
+
 .hc-tile {
-    @include hc-tile;
+    @include hc-tile();
+}
+
+.hc-tile-tight {
+    @include hc-tile-tight();
 }

--- a/projects/cashmere/src/lib/select/select.component.html
+++ b/projects/cashmere/src/lib/select/select.component.html
@@ -1,4 +1,4 @@
-<div class="hc-select-container">
+<div class="hc-select-container" [class.hc-select-tight]="tight">
     <span class="hc-select-chevron"></span>
     <select
         #selectInput

--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -14,6 +14,10 @@
     .hc-select-disabled & {
         @include hc-select-chevron-disabled();
     }
+
+    .hc-select-tight & {
+        @include hc-select-chevron-tight();
+    }
 }
 
 .hc-select-input {
@@ -21,6 +25,10 @@
 
     .hc-form-field-invalid & {
         @include hc-select-input-invalid();
+    }
+
+    .hc-select-tight & {
+        @include hc-select-input-tight();
     }
 }
 

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -32,6 +32,7 @@ export class SelectChangeEvent {
 export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck {
     private _uniqueInputId = `hc-select-${uniqueId++}`;
     private _form: NgForm | FormGroupDirective | null;
+    private _tight: boolean = false;
 
     _componentId = this._uniqueInputId;
 
@@ -83,6 +84,15 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
             this._value = val;
             this.onChange(val);
         }
+    }
+
+    /** If true, condense the default margin and reduce the font size. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
     }
 
     @Output()

--- a/projects/cashmere/src/lib/table/table.component.ts
+++ b/projects/cashmere/src/lib/table/table.component.ts
@@ -50,6 +50,8 @@ export class HcTable<T> extends CdkTable<T> {
     _hostHcTableClass = true;
     @HostBinding('class.hc-table-borders')
     _hostHcBordersClass = true;
+    @HostBinding('class.hc-table-small')
+    _hostHcTableSmall = false;
 
     /** Sets whether the table should have a 2px border around each cell (defaults to true) */
     @Input()
@@ -59,5 +61,14 @@ export class HcTable<T> extends CdkTable<T> {
 
     set borders(hasBorders) {
         this._hostHcBordersClass = parseBooleanAttribute(hasBorders);
+    }
+
+    /** If true, table has less padding and a smaller font size (defaults to false)  */
+    @Input()
+    get tight(): boolean {
+        return this._hostHcTableSmall;
+    }
+    set tight(value) {
+        this._hostHcTableSmall = parseBooleanAttribute(value);
     }
 }

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
@@ -94,6 +94,16 @@ export class TabSetComponent implements AfterContentInit {
 
     _addContentContainer: boolean = true;
 
+    /** If true, condense the default padding on all included tabs. *Defaults to `false`.*  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+    }
+    private _tight = false;
+
     constructor(private router: Router, private route: ActivatedRoute) {}
 
     ngAfterContentInit(): void {
@@ -115,7 +125,10 @@ export class TabSetComponent implements AfterContentInit {
     }
 
     private setTabDirection(): void {
-        setTimeout(() => this._tabs.forEach(t => (t._direction = this.direction)));
+        setTimeout(() => this._tabs.forEach(t => {
+            t._direction = this.direction;
+            t._tight = this.tight;
+        }));
     }
 
     private subscribeToTabClicks(): void {

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
@@ -101,6 +101,7 @@ export class TabSetComponent implements AfterContentInit {
     }
     set tight(value) {
         this._tight = parseBooleanAttribute(value);
+        this.setTabDirection();
     }
     private _tight = false;
 

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.html
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="_direction">
     <a *ngIf="routerLink; else tabWithoutRouting" class="hc-tab-{{_direction}} hc-text-ellipsis"
+        [class.hc-tab-tight]="_tight"
         [routerLink]="routerLink"
         routerLinkActive="active"
         (click)="tabClick.emit()">
@@ -9,6 +10,7 @@
 </ng-container>
 <ng-template #tabWithoutRouting>
     <a class="hc-tab-{{_direction}} hc-text-ellipsis"
+        [class.hc-tab-tight]="_tight"
         [class.active]="_active"
         (click)="tabClick.emit()">
         <ng-container *ngIf="_htmlTitle" [ngTemplateOutlet]="_htmlTitle.tabTitle"></ng-container>

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.scss
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.scss
@@ -10,6 +10,10 @@
     &.active {
         @include hc-tab-vertical-active();
     }
+
+    &.hc-tab-tight {
+        @include hc-tab-vertical-tight();
+    }
 }
 
 .hc-tab-horizontal {
@@ -17,5 +21,9 @@
 
     &.active {
         @include hc-tab-horizontal-active();
+    }
+
+    &.hc-tab-tight {
+        @include hc-tab-horizontal-tight();
     }
 }

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.ts
@@ -28,6 +28,7 @@ export class TabComponent implements AfterContentInit {
 
     _direction: string;
     _active: boolean = false;
+    _tight: boolean = false;
     _htmlTitle: HcTabTitleComponent;
 
     @ContentChildren(HcTabTitleComponent)

--- a/projects/cashmere/src/lib/tile/tile.component.scss
+++ b/projects/cashmere/src/lib/tile/tile.component.scss
@@ -1,5 +1,0 @@
-@import '../sass/tile';
-
-:host {
-    @include hc-tile;
-}

--- a/projects/cashmere/src/lib/tile/tile.component.ts
+++ b/projects/cashmere/src/lib/tile/tile.component.ts
@@ -1,14 +1,27 @@
-import {Component} from '@angular/core';
+import {Component, Input, HostBinding} from '@angular/core';
+import {parseBooleanAttribute} from '../util';
 
 /** Container element to help segment content visually against a gray background.
  * The tile will expand to the height and width of the content it contains. */
 @Component({
     selector: 'hc-tile',
-    template: `
-        <ng-content></ng-content>
-    `,
-    styleUrls: ['./tile.component.scss']
+    template: '<ng-content></ng-content>'
 })
 export class TileComponent {
+    @HostBinding('class.hc-tile')
+    _hostClass = true;
+
+    @HostBinding('class.hc-tile-tight')
+    _tight = false;
+
+    /** If true, compress the default padding in the tile. Defaults to false  */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+    set tight(value) {
+        this._tight = parseBooleanAttribute(value);
+    }
+
     constructor() {}
 }

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.html
@@ -1,4 +1,4 @@
-<div class="hc-tile">
+<hc-tile>
     <div class="header">
         <h3 class="docs-api-h3">{{ exampleTitle }}</h3>
         <button hc-button buttonStyle="minimal" size="md" (click)="launchStackBlitz()">
@@ -13,4 +13,4 @@
             <pre> <code [highlight]="file.contents" ></code> </pre>
         </hc-tab>
     </hc-tab-set>
-</div>
+</hc-tile>

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -53,7 +53,7 @@ const docs: DocItem[] = [
         examples: ['drawer-basic', 'drawer-overlay', 'drawer-side', 'drawer-menu']
     },
     {id: 'ellipsis-pipe', name: 'Ellipsis', category: 'pipes', usageDoc: true, hideApi: true, examples: ['ellipsis-overview']},
-    {id: 'form-field', name: 'Form Field', category: 'forms', examples: ['form-field-overview']},
+    {id: 'form-field', name: 'Form Field', category: 'forms', examples: ['form-field-overview', 'form-field-tight']},
     {id: 'icon', name: 'Icon', category: 'buttons', examples: ['icon-overview']},
     {
         id: 'input',


### PR DESCRIPTION
Adds a tight parameter to the following:

**Table**: applies the hc-table-small class to the table component

**Tabs**: compresses the padding on vertical or horizontal tabs

**Tile**: reduces the padding to 10px 15px

**FormField**: for any components that leverage HcFormField (checkbox, radio, select, input), the tight param compresses the padding and margin on the element.  A new directive was added, `hc-form` which can be added to a `<form>` and the tight param set.  If so, it will apply tight styling to all contained hc-form-fields.  A new example was added to FormField to demonstrate the difference between a tight form and default one.  The tight version saves about 120px vertically (see screenshot).

<img width="1022" alt="Screen Shot 2020-02-07 at 10 15 26 AM" src="https://user-images.githubusercontent.com/22795893/74050842-0bca0d80-4994-11ea-86f1-82f417db7f8e.png">

closes #944 