### PR TITLE
fix(table): table style fix

### DIFF
--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -159,14 +159,14 @@
     @include hc-table-header-sortable-left();
 }
 
-.hc-active-sort {
+.hc-table th.hc-active-sort {
     @include hc-table-header-active-sort();
 
     &.hc-sort-asc {
         @include hc-table-header-active-sort-asc();
     }
 
-    &.hc-sort-desc:after {
+    &.hc-sort-desc {
         @include hc-table-header-active-sort-desc();
     }
 }


### PR DESCRIPTION
correctly override the default style when active-sort is applied

@corykon the problem here was the specificity of the base class was greater than `active-sort`, so the browser wasn't overriding it (even though it came after in the stylesheet).  Also, I have no idea why there was an `:after` with the desc style...but that was broken too.  Glad you noticed these...

closes #1161