### PR TITLE
docs(form-fields): form field formatting

### DIFF
--- a/projects/cashmere-examples/src/lib/banner-overview/banner-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/banner-overview/banner-overview-example.component.html
@@ -9,7 +9,7 @@
 
 <div class="example-content">
     <hc-form-field>
-        <hc-label>Notification Banner Type:</hc-label>
+        <hc-label>Notification banner type:</hc-label>
         <hc-select [(ngModel)]="bannerType">
             <option value="info">Info</option> <option value="success">Success</option> <option value="warning">Warning</option>
             <option value="alert">Alert</option>
@@ -17,7 +17,7 @@
     </hc-form-field>
 
     <hc-form-field>
-        <hc-label>Event Handling:</hc-label>
+        <hc-label>Event handling:</hc-label>
         <hc-checkbox [(ngModel)]="bannerClick">Allow clicks to dismiss banner</hc-checkbox>
     </hc-form-field>
 </div>

--- a/projects/cashmere-examples/src/lib/checkbox-forms/checkbox-forms-example.component.ts
+++ b/projects/cashmere-examples/src/lib/checkbox-forms/checkbox-forms-example.component.ts
@@ -11,6 +11,6 @@ export class CheckboxFormsExampleComponent {
     isChecked: boolean;
 
     getCheckboxText() {
-        return `${this.isChecked ? 'Disable' : 'Enable'} Button`;
+        return `${this.isChecked ? 'Disable' : 'Enable'} button`;
     }
 }

--- a/projects/cashmere-examples/src/lib/checkbox-indeterminate/checkbox-indeterminate-example.component.html
+++ b/projects/cashmere-examples/src/lib/checkbox-indeterminate/checkbox-indeterminate-example.component.html
@@ -1,10 +1,10 @@
 <hc-checkbox [checked]="isChecked()" [indeterminate]="isIndeterminate()" (change)="parentClick()">
-    Parent Checkbox (indeterminate)
+    Parent checkbox (indeterminate)
 </hc-checkbox>
 
 <form [formGroup]="checkboxGroup" class="checkbox-group">
     <div *ngFor="let control of getChecks()">
-        <hc-checkbox [formControl]="control">Child Checkbox</hc-checkbox>
+        <hc-checkbox [formControl]="control">Child checkbox</hc-checkbox>
     </div>
 </form>
 

--- a/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.component.html
+++ b/projects/cashmere-examples/src/lib/checkbox-standard/checkbox-standard-example.component.html
@@ -1,7 +1,7 @@
-<hc-checkbox>Standard Checkbox</hc-checkbox>
+<hc-checkbox>Standard checkbox</hc-checkbox>
 
-<hc-checkbox disabled="true">Disabled Checkbox</hc-checkbox>
+<hc-checkbox disabled="true">Disabled checkbox</hc-checkbox>
 
-<hc-checkbox [checked]="true" disabled="true">Disabled Checkbox (Checked)</hc-checkbox>
+<hc-checkbox [checked]="true" disabled="true">Disabled checkbox (checked)</hc-checkbox>
 
-<hc-checkbox tight="true">Tight Checkbox</hc-checkbox>
+<hc-checkbox tight="true">Tight checkbox</hc-checkbox>

--- a/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
@@ -10,7 +10,7 @@
         [options]="options"
         #pickerOne
     >
-        <span class="label">Time Range:</span> <span class="value"> {{ range.fromDate | date:'h:mm a' }} - {{ range.toDate | date:'h:mm a' }} </span>
+        <span class="label">Time range:</span> <span class="value"> {{ range.fromDate | date:'h:mm a' }} - {{ range.toDate | date:'h:mm a' }} </span>
         <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="icon-right" hcIconSm></hc-icon>
     </button>
 </div>

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
@@ -11,11 +11,11 @@
         [options]="options"
         #pickerOne
     >
-        <span class="label">Date Range:</span> <span class="value"> {{ range.fromDate | date:'MM/dd/yyyy' }} - {{ range.toDate | date:'MM/dd/yyyy' }} </span>
+        <span class="label">Date range:</span> <span class="value"> {{ range.fromDate | date:'MM/dd/yyyy' }} - {{ range.toDate | date:'MM/dd/yyyy' }} </span>
         <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="icon-right" hcIconSm></hc-icon>
     </button>
 
     <div class="preset-selection">
-        Selected Preset: <strong>{{ presetSelection }}</strong>
+        Selected preset: <strong>{{ presetSelection }}</strong>
     </div>
 </div>

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
@@ -65,23 +65,23 @@ export class DateRangeExampleComponent implements OnInit {
                 range: {fromDate: yesterday, toDate: today}
             },
             {
-                presetLabel: 'Last 7 Days',
+                presetLabel: 'Last 7 days',
                 range: {fromDate: minus7, toDate: today}
             },
             {
-                presetLabel: 'Last 30 Days',
+                presetLabel: 'Last 30 days',
                 range: {fromDate: minus30, toDate: today}
             },
             {
-                presetLabel: 'This Month',
+                presetLabel: 'This month',
                 range: {fromDate: currMonthStart, toDate: currMonthEnd}
             },
             {
-                presetLabel: '1 Month to End',
+                presetLabel: '1 month to end',
                 range: {fromDate: currMonthStart, toDate: currMonthEnd}
             },
             {
-                presetLabel: 'Last Month',
+                presetLabel: 'Last month',
                 range: {fromDate: lastMonthStart, toDate: lastMonthEnd}
             }
         ];

--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.html
@@ -1,17 +1,17 @@
 <form>
     <div class="form-sample">
         <hc-form-field>
-            <hc-label>Job Name:</hc-label>
+            <hc-label>Job name:</hc-label>
             <input hcInput required [formControl]="inputControl">
             <hc-error>A job name is required</hc-error>
         </hc-form-field>
     </div>
 
     <hc-form-field inline="true" class="form-padding">
-        <hc-label>Data Source:</hc-label>
+        <hc-label>Data source:</hc-label>
         <hc-radio-group [formControl]="radioControl" inline="true">
-            <hc-radio-button value="SM">Source Mart</hc-radio-button>
-            <hc-radio-button value="SAM">Subject Area Mart</hc-radio-button>
+            <hc-radio-button value="SM">Source mart</hc-radio-button>
+            <hc-radio-button value="SAM">Subject area mart</hc-radio-button>
             <hc-radio-button value="Other">Other</hc-radio-button>
         </hc-radio-group>
         <hc-error>Specified data source does not match description</hc-error>
@@ -19,7 +19,7 @@
 
     <div class="form-sample">
         <hc-form-field>
-            <hc-label>Run Frequency:</hc-label>
+            <hc-label>Run frequency:</hc-label>
             <hc-select placeholder="Select frequency:" [formControl]="selectControl">
                 <option value="daily">Daily</option>
                 <option value="weekly">Weekly</option>
@@ -31,9 +31,9 @@
 
     <div class="form-sample flex-column">
         <hc-form-field>
-            <hc-label>Requested Notifications:</hc-label>
+            <hc-label>Requested notifications:</hc-label>
             <hc-checkbox [formControl]="checkControl">On failure</hc-checkbox>
-            <hc-checkbox [formControl]="checkControl">On sucess</hc-checkbox>
+            <hc-checkbox [formControl]="checkControl">On success</hc-checkbox>
             <hc-checkbox [formControl]="checkControl">On row-count mismatch</hc-checkbox>
             <hc-checkbox [formControl]="checkControl">On dependency-wait timeout</hc-checkbox>
             <hc-error>At least one notification must be selected</hc-error>

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
@@ -4,17 +4,17 @@ either the <code>hcForm</code> or individual <code>hc-form-field</code> elements
 <form hcForm tight="true">
     <div class="form-sample">
         <hc-form-field>
-            <hc-label>Job Name:</hc-label>
+            <hc-label>Job name:</hc-label>
             <input hcInput required [formControl]="inputControl">
             <hc-error>A job name is required</hc-error>
         </hc-form-field>
     </div>
 
     <hc-form-field inline="true">
-        <hc-label>Data Source:</hc-label>
+        <hc-label>Data source:</hc-label>
         <hc-radio-group [formControl]="radioControl" inline="true">
-            <hc-radio-button value="SM">Source Mart</hc-radio-button>
-            <hc-radio-button value="SAM">Subject Area Mart</hc-radio-button>
+            <hc-radio-button value="SM">Source mart</hc-radio-button>
+            <hc-radio-button value="SAM">Subject area mart</hc-radio-button>
             <hc-radio-button value="Other">Other</hc-radio-button>
         </hc-radio-group>
         <hc-error>Specified data source does not match description</hc-error>
@@ -22,7 +22,7 @@ either the <code>hcForm</code> or individual <code>hc-form-field</code> elements
 
     <div class="form-sample">
         <hc-form-field inline="true">
-            <hc-label>Run Frequency:</hc-label>
+            <hc-label>Run frequency:</hc-label>
             <hc-select placeholder="Select frequency:" [formControl]="selectControl">
                 <option value="daily">Daily</option>
                 <option value="weekly">Weekly</option>
@@ -34,9 +34,9 @@ either the <code>hcForm</code> or individual <code>hc-form-field</code> elements
 
     <div class="form-sample flex-column">
         <hc-form-field>
-            <hc-label>Requested Notifications:</hc-label>
+            <hc-label>Requested notifications:</hc-label>
             <hc-checkbox [formControl]="checkControl">On failure</hc-checkbox>
-            <hc-checkbox [formControl]="checkControl">On sucess</hc-checkbox>
+            <hc-checkbox [formControl]="checkControl">On success</hc-checkbox>
             <hc-checkbox [formControl]="checkControl">On row-count mismatch</hc-checkbox>
             <hc-checkbox [formControl]="checkControl">On dependency-wait timeout</hc-checkbox>
             <hc-error>At least one notification must be selected</hc-error>

--- a/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.component.html
@@ -3,13 +3,13 @@
 <br>
 
 <hc-form-field inline="true" tight="true">
-    <hc-label>Minimum Value:</hc-label>
+    <hc-label>Minimum value:</hc-label>
     <input hcInput placeholder="0-100" class="demo-input">
     <hc-icon hcSuffix fontSet="fa" fontIcon="fa-thermometer-0"></hc-icon>
 </hc-form-field>
 
 <hc-form-field inline="true" tight="true">
-    <hc-label>Maximum Value:</hc-label>
+    <hc-label>Maximum value:</hc-label>
     <input hcInput placeholder="100-500" class="demo-input">
     <hc-icon hcSuffix fontSet="fa" fontIcon="fa-thermometer-full"></hc-icon>
 </hc-form-field>

--- a/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/popover-overview/popover-overview-example.component.html
@@ -19,7 +19,7 @@
 
 <div class="property-form-row">
     <hc-form-field>
-        <hc-label>Vertical Alignment:</hc-label>
+        <hc-label>Vertical alignment:</hc-label>
         <hc-select placeholder="Select yAlign setting:" [(ngModel)]="vAlign">
             <option value="above">Above</option>
             <option value="start">Start</option>
@@ -31,7 +31,7 @@
     </hc-form-field>
 
     <hc-form-field>
-        <hc-label>Horizontal Alignment:</hc-label>
+        <hc-label>Horizontal alignment:</hc-label>
         <hc-select placeholder="Select xAlign setting:" [(ngModel)]="hAlign">
             <option value="before">Before</option>
             <option value="start">Start</option>
@@ -43,7 +43,7 @@
     </hc-form-field>
 
     <hc-form-field>
-        <hc-label>Scroll Strategy:</hc-label>
+        <hc-label>Scroll strategy:</hc-label>
         <hc-select placeholder="Select scroll strategy:" [(ngModel)]="scrollStrat">
             <option value="noop">Noop</option>
             <option value="block">Block scrolling</option>
@@ -64,7 +64,7 @@
     </hc-form-field>
 
     <hc-form-field>
-        <hc-label>Popover Text:</hc-label>
+        <hc-label>Popover text:</hc-label>
         <input hcInput [(ngModel)]="popText"/>
     </hc-form-field>
 

--- a/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.component.html
+++ b/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.component.html
@@ -17,7 +17,7 @@
             <hc-label>Diameter:</hc-label>
             <input hcInput type="number" min="20" max="250" class="form-control" id="diameter" [(ngModel)]="spinnerDiameter" name="diameter">
         </hc-form-field>
-        <hc-checkbox id="checkbox-bg" [(ngModel)]="spinnerHasChannel" [checked]="spinnerHasChannel">BG Channel</hc-checkbox>
+        <hc-checkbox id="checkbox-bg" [(ngModel)]="spinnerHasChannel" [checked]="spinnerHasChannel">BG channel</hc-checkbox>
         <hc-checkbox id="checkbox-center" [(ngModel)]="spinnerCentered" [checked]="spinnerCentered">Centered</hc-checkbox>
         <hr>
         <hc-checkbox id="checkbox-determinate" [(ngModel)]="spinnerIsDeterminate">Determinate</hc-checkbox>

--- a/projects/cashmere-examples/src/lib/select-standard/select-standard-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-standard/select-standard-example.component.html
@@ -1,6 +1,6 @@
 <div class="select-sample">
     <hc-form-field>
-        <hc-label>Facility Location:</hc-label>
+        <hc-label>Facility location:</hc-label>
         <hc-select placeholder="Select a city:">
             <option value="1">Philadelphia</option>
             <option value="2">Atlanta</option>

--- a/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.html
@@ -1,7 +1,7 @@
 <form>
     <div class="select-sample">
         <hc-form-field tight="true">
-            <hc-label>Select with Tight Styling:</hc-label>
+            <hc-label>Select with tight styling:</hc-label>
             <hc-select [formControl]="selectControl" required>
                 <option value="active">Active</option>
                 <option value="inactive">Inactive</option>

--- a/projects/cashmere-examples/src/lib/stepper-overview/stepper-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/stepper-overview/stepper-overview-example.component.html
@@ -1,21 +1,21 @@
 <div class="stepper-options">
     <hc-form-field>
-        <hc-label>Stepper Type:</hc-label>
+        <hc-label>Stepper type:</hc-label>
         <hc-select [(ngModel)]="currentType">
             <option *ngFor="let type of typeOptions" [value]="type">{{type | titlecase}}</option>
         </hc-select>
     </hc-form-field>
 
     <hc-form-field>
-        <hc-label>Stepper Color:</hc-label>
+        <hc-label>Stepper color:</hc-label>
         <hc-select [(ngModel)]="currentColor">
             <option *ngFor="let color of colorOptions" [value]="color">{{color | titlecase}}</option>
         </hc-select>
     </hc-form-field>
 
     <hc-form-field>
-        <hc-label>Step Count (Isolated type only):</hc-label>
-        <hc-checkbox [(ngModel)]="showSteps">Show Step Count</hc-checkbox>
+        <hc-label>Step count (isolated type only):</hc-label>
+        <hc-checkbox [(ngModel)]="showSteps">Show step count</hc-checkbox>
     </hc-form-field>
 </div>
 

--- a/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.html
+++ b/projects/cashmere-examples/src/lib/tabs-vertical/tabs-vertical-example.component.html
@@ -44,4 +44,4 @@
     </hc-tab-set>
 </div>
 
-<hc-checkbox [(ngModel)]="_tight">Apply Tight Styling to Tabs</hc-checkbox>
+<hc-checkbox [(ngModel)]="_tight">Apply tight styling to tabs</hc-checkbox>

--- a/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.html
@@ -7,17 +7,17 @@
 
 <div class="example-column">
     <hc-form-field class="example-field">
-        <hc-label>Header Text:</hc-label>
+        <hc-label>Header text:</hc-label>
         <input hcInput [(ngModel)]="toastHeader" />
     </hc-form-field>
 
     <hc-form-field class="example-field">
-        <hc-label>Body Text:</hc-label>
+        <hc-label>Body text:</hc-label>
         <input hcInput [(ngModel)]="toastBody" />
     </hc-form-field>
 
     <hc-form-field class="example-field">
-        <hc-label>Toast Type:</hc-label>
+        <hc-label>Toast type:</hc-label>
         <hc-select [(ngModel)]="toastType">
             <option value="success">Success</option>
             <option value="info">Info</option>
@@ -31,7 +31,7 @@
 </div>
 <div class="example-column">
     <hc-form-field class="example-field">
-        <hc-label>Toast Position:</hc-label>
+        <hc-label>Toast position:</hc-label>
         <hc-select [(ngModel)]="toastPosition">
             <option value="top-right">Top right</option> <option value="top-center">Top center</option>
             <option value="top-left">Top left</option> <option value="top-full-width">Top full-width</option>
@@ -47,18 +47,18 @@
     </hc-form-field>
 
     <hc-form-field class="example-field-half">
-        <hc-label>Toast Width:</hc-label>
+        <hc-label>Toast width:</hc-label>
         <input hcInput type="number" [(ngModel)]="toastWidth" />
     </hc-form-field>
 
     <hc-form-field class="example-field">
-        <hc-label>Event Handling:</hc-label>
+        <hc-label>Event handling:</hc-label>
         <hc-checkbox [(ngModel)]="toastClick">Allow clicks to dismiss toast</hc-checkbox>
     </hc-form-field>
 </div>
 <div class="progress-row">
     <hc-form-field>
-        <hc-label>Progress Bar:</hc-label>
+        <hc-label>Progress bar:</hc-label>
         <hc-radio-group [(ngModel)]="toastProgress" inline="true">
             <hc-radio-button value="0">Off</hc-radio-button>
             <hc-radio-button value="1">Indeterminate</hc-radio-button>

--- a/projects/cashmere/src/lib/button/button.md
+++ b/projects/cashmere/src/lib/button/button.md
@@ -1,3 +1,9 @@
+##### Button Text Formatting
+
+The text inside a button should be formatted in title case. In title case, all major words are capitalized, while minor words are lowercased (e.g. Lord of the Flies).
+
+&nbsp;
+
 ##### Split Buttons
 
 **hc-split-button**

--- a/projects/cashmere/src/lib/checkbox/checkbox.md
+++ b/projects/cashmere/src/lib/checkbox/checkbox.md
@@ -1,8 +1,18 @@
+##### Checkbox Text Formatting
+
+For both the label on checkboxes and their contents, please use the following formatting:
+
+Capitalize first word only, except in cases where the selection is an actual program name or proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient; Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes, Salt Lake City, etc.).
+
+&nbsp;
+
+##### Form Fields
+
 hc-checkbox components may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.
 
 ```html
 <hc-form-field>
-    <hc-label>Requested Notifications:</hc-label>
+    <hc-label>Requested notifications:</hc-label>
     <hc-checkbox [formControl]="checkControl">On failure</hc-checkbox>
     <hc-checkbox [formControl]="checkControl">On sucess</hc-checkbox>
     <hc-error>At least one notification must be selected</hc-error>

--- a/projects/cashmere/src/lib/date-range/model/model.ts
+++ b/projects/cashmere/src/lib/date-range/model/model.ts
@@ -36,9 +36,9 @@ export interface DateRangeOptions {
     applyLabel?: string;
     /** Text label of cancel button Default 'Cancel' */
     cancelLabel?: string;
-    /** Text label above start date. Default 'Start Date' */
+    /** Text label above start date. Default 'Start date' */
     startDatePrefix?: string;
-    /** Text label above end date. Default 'End Date' */
+    /** Text label above end date. Default 'End date' */
     endDatePrefix?: string;
     /** Text label of invalid date. Default 'Please enter valid date' */
     invalidDateLabel?: string;

--- a/projects/cashmere/src/lib/date-range/services/config-store.service.ts
+++ b/projects/cashmere/src/lib/date-range/services/config-store.service.ts
@@ -15,8 +15,8 @@ export class ConfigStoreService {
         locale: 'en-us',
         applyLabel: 'Apply',
         cancelLabel: 'Cancel',
-        startDatePrefix: 'Start Date',
-        endDatePrefix: 'End Date',
+        startDatePrefix: 'Start date',
+        endDatePrefix: 'End date',
         invalidDateLabel: 'Please enter valid date'
     };
 

--- a/projects/cashmere/src/lib/form-field/form-field.md
+++ b/projects/cashmere/src/lib/form-field/form-field.md
@@ -1,0 +1,5 @@
+##### Form Field Text Formatting
+
+For both the labels and contents of form fields, please use the following formatting:
+
+Capitalize first word only, except in cases where the selection is an actual program name or proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient; Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes, Salt Lake City, etc.).

--- a/projects/cashmere/src/lib/input/input.md
+++ b/projects/cashmere/src/lib/input/input.md
@@ -1,3 +1,13 @@
+##### Input Text Formatting
+
+For input labels please use the following formatting:
+
+Capitalize first word only, except in cases where the selection is an actual program name or proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient; Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes, Salt Lake City, etc.).
+
+&nbsp;
+
+##### Form Fields
+
 To use the input element you must include [hcInput] on an input element and nest the input element within a hc-form-field component. hc-form-field acts as a coordinator between multiple components and is essential to be able to use all of the features of hcInput
 
 To add a label use an hc-label within a hc-form-field. If the input is required add the required attribute and an asterisk will be shown next to the label.

--- a/projects/cashmere/src/lib/radio-button/radio-button.md
+++ b/projects/cashmere/src/lib/radio-button/radio-button.md
@@ -1,3 +1,13 @@
+##### Radio Text Formatting
+
+For both the label on radio buttons and their contents, please use the following formatting:
+
+Capitalize first word only, except in cases where the selection is an actual program name or proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient; Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes, Salt Lake City, etc.).
+
+&nbsp;
+
+##### Form Fields
+
 RadioButtonComponents are contained in a RadioGroupDirective which may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.
 
 ```html

--- a/projects/cashmere/src/lib/select/select.md
+++ b/projects/cashmere/src/lib/select/select.md
@@ -1,6 +1,8 @@
 ##### Select Text Formatting
 
-Capitalize first word only, except in cases where the selection is an actual program name or proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient; Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes, Salt Lake City, etc.)
+For both the label on select boxes and their contents, please use the following formatting:
+
+Capitalize first word only, except in cases where the selection is an actual program name or proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient; Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes, Salt Lake City, etc.).
 
 &nbsp;
 

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -24,6 +24,7 @@ const docs: DocItem[] = [
         id: 'button',
         name: 'Button',
         category: 'buttons',
+        usageDoc: true,
         examples: ['button-type', 'button-split', 'button-size', 'button-anchor', 'button-link', 'button-icon']
     },
     {
@@ -53,7 +54,7 @@ const docs: DocItem[] = [
         examples: ['drawer-basic', 'drawer-overlay', 'drawer-side', 'drawer-menu']
     },
     {id: 'ellipsis-pipe', name: 'Ellipsis', category: 'pipes', usageDoc: true, hideApi: true, examples: ['ellipsis-overview']},
-    {id: 'form-field', name: 'Form Field', category: 'forms', examples: ['form-field-overview', 'form-field-tight']},
+    {id: 'form-field', name: 'Form Field', category: 'forms', usageDoc: true, examples: ['form-field-overview', 'form-field-tight']},
     {id: 'icon', name: 'Icon', category: 'buttons', examples: ['icon-overview']},
     {
         id: 'input',


### PR DESCRIPTION
Updates standards for text formatting on all form fields (following the model established for Select).  Also updates the examples on the Cashmere site to follow the new standards.

closes #1178