### PR TITLE
docs(formfields): form field label standards

### DIFF
--- a/guides/styles/login-page.md
+++ b/guides/styles/login-page.md
@@ -111,11 +111,11 @@ The following example uses angular and cashmere and is the preffered method. It 
         <div class="logo"><img src="../assets/HealthCatalyst_Horizontal.svg" alt="Health Catalyst Logo" /></div>
         <div>
             <hc-form-field>
-                <hc-label>Email</hc-label>
+                <hc-label>Email:</hc-label>
                 <input hcInput required />
             </hc-form-field>
             <hc-form-field>
-                <hc-label>Password</hc-label>
+                <hc-label>Password:</hc-label>
                 <input type="password" hcInput required />
             </hc-form-field>
             <a href="#" class="forgot-password" hidden="hidden">Forgot Password</a>

--- a/projects/cashmere-examples/src/lib/datepicker-selected-value/datepicker-selected-value-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker-selected-value/datepicker-selected-value-example.component.html
@@ -1,19 +1,19 @@
 <hc-form-field class="example-date-input">
-    <hc-label>Angular forms</hc-label>
+    <hc-label>Angular forms:</hc-label>
     <input hcInput [hcDatepicker]="picker1" placeholder="Angular forms" [formControl]="date" />
     <hc-datepicker-toggle hcSuffix [for]="picker1"></hc-datepicker-toggle>
     <hc-datepicker #picker1></hc-datepicker>
 </hc-form-field>
 
 <hc-form-field class="example-date-input">
-    <hc-label>Angular forms (w/ deserialization)</hc-label>
+    <hc-label>Angular forms (w/ deserialization):</hc-label>
     <input hcInput [hcDatepicker]="picker2" placeholder="Angular forms (w/ deserialization)" [formControl]="serializedDate" />
     <hc-datepicker-toggle hcSuffix [for]="picker2"></hc-datepicker-toggle>
     <hc-datepicker #picker2></hc-datepicker>
 </hc-form-field>
 
 <hc-form-field class="example-date-input">
-    <hc-label>Value binding</hc-label>
+    <hc-label>Value binding:</hc-label>
     <input hcInput [hcDatepicker]="picker3" placeholder="Value binding" [value]="date.value" />
     <hc-datepicker-toggle hcSuffix [for]="picker3"></hc-datepicker-toggle>
     <hc-datepicker #picker3></hc-datepicker>

--- a/projects/cashmere-examples/src/lib/ellipsis-overview/ellipsis-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/ellipsis-overview/ellipsis-overview-example.component.html
@@ -1,15 +1,15 @@
 <p>{{ value | ellipsis: length:mode }}</p>
 
 <hc-form-field>
-    <hc-label>Value</hc-label>
+    <hc-label>Value:</hc-label>
     <textarea hcInput [(ngModel)]="value"></textarea>
 </hc-form-field>
 <hc-form-field>
-    <hc-label>Length</hc-label>
+    <hc-label>Length:</hc-label>
     <input hcInput [(ngModel)]="length" type="number" />
 </hc-form-field>
 <hc-form-field>
-    <hc-label>Mode</hc-label>
+    <hc-label>Mode:</hc-label>
     <hc-select [(ngModel)]="mode">
         <option value="characters">Characters</option>
         <option value="words">Words</option>

--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.component.html
@@ -1,7 +1,7 @@
 <form>
     <div class="form-container">
         <hc-form-field>
-            <hc-label>Validate an email address</hc-label>
+            <hc-label>Validate an email address:</hc-label>
             <input hcInput [formControl]="formDemo" required>
             <hc-error>A valid email address is required</hc-error>
         </hc-form-field>

--- a/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.html
+++ b/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.html
@@ -1,5 +1,5 @@
-<hc-form-field> <hc-label>Total number of items</hc-label> <input hcInput type="number" [(ngModel)]="totalItems" /> </hc-form-field>
-<hc-form-field> <hc-label>Page number</hc-label> <input hcInput type="number" [(ngModel)]="pageNumber" /> </hc-form-field>
-<hc-form-field> <hc-label>Page size</hc-label> <input hcInput type="number" [(ngModel)]="pageSize" /> </hc-form-field>
+<hc-form-field> <hc-label>Total number of items:</hc-label> <input hcInput type="number" [(ngModel)]="totalItems" /> </hc-form-field>
+<hc-form-field> <hc-label>Page number:</hc-label> <input hcInput type="number" [(ngModel)]="pageNumber" /> </hc-form-field>
+<hc-form-field> <hc-label>Page size:</hc-label> <input hcInput type="number" [(ngModel)]="pageSize" /> </hc-form-field>
 
 <hc-pagination [(pageNumber)]="pageNumber" [(pageSize)]="pageSize" [length]="totalItems"></hc-pagination>

--- a/projects/cashmere-examples/src/lib/table-filter/table-filter-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-filter/table-filter-example.component.html
@@ -1,5 +1,5 @@
 <hc-form-field>
-    <hc-label>Filter</hc-label>
+    <hc-label>Filter:</hc-label>
     <input hcInput (keyup)="applyFilter($event.target.value)">
 </hc-form-field>
 

--- a/projects/cashmere/src/lib/checkbox/checkbox.md
+++ b/projects/cashmere/src/lib/checkbox/checkbox.md
@@ -6,6 +6,12 @@ Capitalize first word only, except in cases where the selection is an actual pro
 
 &nbsp;
 
+##### Checkbox Labels
+
+Use a colon at the end of checkbox labels (e.g. Email address:). A colon implies a direct connection between the label text and a particular control or set of controls. The only situation where a colon should not be used is when the label and control work together to form a single sentence.
+
+&nbsp;
+
 ##### Form Fields
 
 hc-checkbox components may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.

--- a/projects/cashmere/src/lib/date-range/services/config-store.service.ts
+++ b/projects/cashmere/src/lib/date-range/services/config-store.service.ts
@@ -15,8 +15,8 @@ export class ConfigStoreService {
         locale: 'en-us',
         applyLabel: 'Apply',
         cancelLabel: 'Cancel',
-        startDatePrefix: 'Start date',
-        endDatePrefix: 'End date',
+        startDatePrefix: 'Start date:',
+        endDatePrefix: 'End date:',
         invalidDateLabel: 'Please enter valid date'
     };
 

--- a/projects/cashmere/src/lib/form-field/form-field.md
+++ b/projects/cashmere/src/lib/form-field/form-field.md
@@ -3,3 +3,9 @@
 For both the labels and contents of form fields, please use the following formatting:
 
 Capitalize first word only, except in cases where the selection is an actual program name or proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient; Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes, Salt Lake City, etc.).
+
+&nbsp;
+
+##### Form Field Labels
+
+Use a colon at the end of form field labels (e.g. Email address:). A colon implies a direct connection between the label text and a particular control or set of controls. The only situation where a colon should not be used is when the label and control work together to form a single sentence.

--- a/projects/cashmere/src/lib/input/input.md
+++ b/projects/cashmere/src/lib/input/input.md
@@ -6,6 +6,12 @@ Capitalize first word only, except in cases where the selection is an actual pro
 
 &nbsp;
 
+##### Input Labels
+
+Use a colon at the end of input labels (e.g. Email address:). A colon implies a direct connection between the label text and a particular control or set of controls. The only situation where a colon should not be used is when the label and control work together to form a single sentence.
+
+&nbsp;
+
 ##### Form Fields
 
 To use the input element you must include [hcInput] on an input element and nest the input element within a hc-form-field component. hc-form-field acts as a coordinator between multiple components and is essential to be able to use all of the features of hcInput
@@ -14,7 +20,7 @@ To add a label use an hc-label within a hc-form-field. If the input is required 
 
 ```html
 <hc-form-field>
-    <hc-label>Validate an email address</hc-label>
+    <hc-label>Validate an email address:</hc-label>
     <input hcInput [formControl]="formDemo" required />
     <hc-error>Email address is required</hc-error>
 </hc-form-field>

--- a/projects/cashmere/src/lib/radio-button/radio-button.md
+++ b/projects/cashmere/src/lib/radio-button/radio-button.md
@@ -6,6 +6,12 @@ Capitalize first word only, except in cases where the selection is an actual pro
 
 &nbsp;
 
+##### Radio Group Labels
+
+Use a colon at the end of radio group labels (e.g. Email address:). A colon implies a direct connection between the label text and a particular control or set of controls. The only situation where a colon should not be used is when the label and control work together to form a single sentence.
+
+&nbsp;
+
 ##### Form Fields
 
 RadioButtonComponents are contained in a RadioGroupDirective which may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.

--- a/projects/cashmere/src/lib/select/select.md
+++ b/projects/cashmere/src/lib/select/select.md
@@ -6,6 +6,12 @@ Capitalize first word only, except in cases where the selection is an actual pro
 
 &nbsp;
 
+##### Select Labels
+
+Use a colon at the end of select box labels (e.g. Email address:). A colon implies a direct connection between the label text and a particular control or set of controls. The only situation where a colon should not be used is when the label and control work together to form a single sentence.
+
+&nbsp;
+
 ##### Form Fields
 
 The hc-select component may be nested within a hc-form-field component. hc-form-field acts as a coordinator between multiple components including label and error elements.

--- a/src/app/styles/typography/typography-demo.component.html
+++ b/src/app/styles/typography/typography-demo.component.html
@@ -491,6 +491,34 @@
     </hc-tile>
 
     <hc-tile>
+        <h5>Form Fields</h5>
+            <h3>Text formatting</h3>
+            <p>
+                For both the label on select boxes and their contents, please use the following formatting:
+                Capitalize first word only, except in cases where the selection is an actual program name or
+                proper name (e.g. Patient non-adherence or challenges in care management; Duplicate patient;
+                Algorithm incorrect; Comprehensive HIV AIDS Management Program (CHAMP), Grace Program, LSU Diabetes,
+                Salt Lake City, etc.).
+            </p>
+            <h3>Labels</h3>
+            <p>
+                Use a colon at the end of form field labels (e.g. Email address:). A colon implies a direct connection
+                between the label text and a particular control or set of controls. The only situation where a colon
+                should not be used is when the label and control work together to form a single sentence.
+            </p>
+            <div style="max-width: 300px; margin-top: 35px;">
+                <hc-form-field>
+                    <hc-label>Hospital department:</hc-label>
+                    <hc-select placeholder="Select a department">
+                        <option>Emergency department</option>
+                        <option>Cardiology</option>
+                        <option>Intensive care unit</option>
+                    </hc-select>
+                </hc-form-field>
+            </div>
+    </hc-tile>
+
+    <hc-tile>
         <h5>Font Size</h5>
         <p>
             The default font of the body is


### PR DESCRIPTION
adds standards for the use of colons in form field labels

closes #1178