### PR TITLE
fix(select): objects in ngValue

### DIFF
--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.html
@@ -1,15 +1,15 @@
 <form>
     <hc-select [formControl]="selectControl">
-        <option value="corn">Corn on the cob</option>
-        <option value="chicken">Deep fried chicken</option>
-        <option value="taters">Mashed taters</option>
+        <option hcOption *ngFor="let location of locations" [ngValue]="location">{{location.dbaName}}</option>
     </hc-select>
 </form>
 
-<button hc-button class="demo-button" (click)="setTaters()">
-    Yummy Taters
+<button hc-button class="demo-button" (click)="setInsurance()">
+    Select Insurance Department
 </button>
 
 <button hc-button class="demo-button" (click)="toggleActive()">
     Enable/Disable Select
 </button>
+
+<p class="example-results">Form control value: <code>{{selectControl.value | json}}</code></p>

--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.html
@@ -1,6 +1,6 @@
 <form>
     <hc-select [formControl]="selectControl">
-        <option hcOption *ngFor="let location of locations" [ngValue]="location">{{location.dbaName}}</option>
+        <option *ngFor="let location of locations" [ngValue]="location">{{location.dbaName}}</option>
     </hc-select>
 </form>
 

--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.scss
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.scss
@@ -1,3 +1,8 @@
 form {
     max-width: 350px;
 }
+
+.example-results {
+    margin-top: 20px;
+    font-size: 14px;
+}

--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.ts
@@ -10,10 +10,16 @@ import {FormControl} from '@angular/forms';
     styleUrls: ['select-forms-example.component.scss']
 })
 export class SelectFormsExampleComponent {
-    selectControl = new FormControl('chicken');
+    locations = [
+        {id: 1, dbaName: 'Tax Commission'},
+        {id: 2, dbaName: 'Insurance Department'},
+        {id: 3, dbaName: 'Environmental Quality'},
+    ];
 
-    setTaters() {
-        this.selectControl.setValue('taters');
+    selectControl = new FormControl(this.locations[0]);
+
+    setInsurance() {
+        this.selectControl.setValue(this.locations[1], {onlySelf: true});
     }
 
     toggleActive() {

--- a/projects/cashmere/src/lib/select/hc-option.directive.ts
+++ b/projects/cashmere/src/lib/select/hc-option.directive.ts
@@ -1,0 +1,13 @@
+/* tslint:disable:directive-selector */
+
+import {Directive, Input} from '@angular/core';
+
+/** Utility directive to hold objects used in ngValue */
+@Directive({
+    selector: 'option[ngValue]'
+})
+export class HcOptionDirective {
+    /** Stores the content of ngValue, including objects */
+    @Input()
+    ngValue: any;
+}

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -9,16 +9,21 @@ import {
     DoCheck,
     Self,
     Output,
-    EventEmitter
+    EventEmitter,
+    ContentChildren,
+    QueryList,
+    ViewChild,
+    AfterContentInit
 } from '@angular/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR, NgForm, FormGroupDirective, NgControl} from '@angular/forms';
+import {ControlValueAccessor, NgForm, FormGroupDirective, NgControl} from '@angular/forms';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
+import {HcOptionDirective} from './hc-option.directive';
 
 let uniqueId = 1;
 
 export class SelectChangeEvent {
-    constructor(public source: SelectComponent, public value: string) {}
+    constructor(public source: SelectComponent, public value: any) {}
 }
 
 /** Select one of many options from a dropdown */
@@ -29,12 +34,20 @@ export class SelectChangeEvent {
     encapsulation: ViewEncapsulation.None,
     providers: [{provide: HcFormControlComponent, useExisting: forwardRef(() => SelectComponent)}]
 })
-export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck {
+export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, AfterContentInit, DoCheck {
     private _uniqueInputId = `hc-select-${uniqueId++}`;
     private _form: NgForm | FormGroupDirective | null;
     private _tight: boolean = false;
+    private _value: any = '';
+    private _valueData: any;
 
     _componentId = this._uniqueInputId;
+
+    @ContentChildren(HcOptionDirective)
+    _options: QueryList<HcOptionDirective>;
+
+    @ViewChild('selectInput')
+    _nativeSelect: ElementRef;
 
     /** Optional string of text to appear before selection is made */
     @Input()
@@ -79,7 +92,7 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         return this._value;
     }
 
-    set value(val: string) {
+    set value(val: any) {
         if (val !== this._value) {
             this._value = val;
             this.onChange(val);
@@ -104,8 +117,6 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
     @Output()
     change = new EventEmitter<SelectChangeEvent>();
 
-    private _value: string = '';
-
     @HostBinding('class.hc-select')
     _hostClass = true;
 
@@ -118,7 +129,6 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
     }
 
     constructor(
-        private _elementRef: ElementRef,
         @Optional() _parentForm: NgForm,
         @Optional() _parentFormGroup: FormGroupDirective,
         @Optional()
@@ -130,6 +140,14 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         this._form = _parentForm || _parentFormGroup;
         if (this._ngControl != null) {
             this._ngControl.valueAccessor = this;
+        }
+    }
+
+    ngAfterContentInit() {
+        if (this._valueData) {
+            setTimeout(() => {
+                this.writeValue(this._valueData);
+            });
         }
     }
 
@@ -145,19 +163,40 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         this.onTouched = fn;
     }
 
-    writeValue(value: string) {
-        this._value = value;
+    writeValue(value: any) {
+        this._valueData = value;
+        let targetVal = value;
+        // If ngValue is being used, set the currently selected value based on that data
+        if (this._options && this._options.length !== 0) {
+            let selectedIndex: number = 0;
+            this._options.forEach((option, index) => {
+                if (option.ngValue === value) {
+                    selectedIndex = index;
+                }
+            });
+            if (this.placeholder) {
+                selectedIndex += 1;
+            }
+            targetVal = this._nativeSelect.nativeElement.options[selectedIndex].value;
+        }
+        this._value = targetVal;
     }
 
-    _change(event: Event, value: string) {
+    _change(event: Event, value: any) {
+        this._valueData = value;
+        // If ngValue is being used, pull that value from the directive to allow objects well as strings
+        if (this._options.length !== 0) {
+            const optionArray = this._options.toArray();
+            const index = this.placeholder ?
+                this._nativeSelect.nativeElement.selectedIndex - 1 :
+                this._nativeSelect.nativeElement.selectedIndex;
+            this._valueData = optionArray[index].ngValue;
+        }
+
         event.stopPropagation();
-        this.onChange(value);
-        this.value = value;
-        this._emitChangeEvent();
-    }
-
-    private _emitChangeEvent() {
-        this.change.emit(new SelectChangeEvent(this, this.value));
+        this._value = value;
+        this.onChange(this._valueData);
+        this.change.emit(new SelectChangeEvent(this, this._valueData));
     }
 
     ngDoCheck(): void {

--- a/projects/cashmere/src/lib/select/select.module.ts
+++ b/projects/cashmere/src/lib/select/select.module.ts
@@ -1,10 +1,11 @@
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {SelectComponent} from './select.component';
+import {HcOptionDirective} from './hc-option.directive';
 
 @NgModule({
     imports: [CommonModule],
-    exports: [SelectComponent],
-    declarations: [SelectComponent]
+    exports: [SelectComponent, HcOptionDirective],
+    declarations: [SelectComponent, HcOptionDirective]
 })
 export class SelectModule {}


### PR DESCRIPTION
WOOHOO! `hc-select` now supports form ngValues as objects as well as strings.  It emits objects and you can set a formControl or ngValue with an object.  No additional markup required.  The last example on the Select page has been updated to demonstrate the functionality.

What a mind-bender this one was, but thanks @joeskeen for the suggestion to try `option[ngValue]` as the selector for the directive.

closes #779