### PR TITLE
docs(datepicker): sugar.js docs

### DIFF
--- a/projects/cashmere-examples/src/lib/datepicker-sugar/datepicker-sugar-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker-sugar/datepicker-sugar-example.component.html
@@ -1,3 +1,11 @@
+<p class="example-date-description">
+    <a href="https://sugarjs.com/dates/#/Parsing">SugarJS</a> is a JavaScript
+    library used by many Health Catalyst applications to handle parsing user
+    input into <code>Date</code> objects.  It handles a wide variety of input formats and
+    supports multiple languages.  To use SugarJS with the Cashmere DatePicker,
+    you need to declare a Sugar Date Adapter.  See this example's Module code for
+    more information.
+</p>
 <div class="example-date-input">
     <hc-form-field>
         <hc-label>Date:</hc-label>

--- a/projects/cashmere-examples/src/lib/datepicker-sugar/datepicker-sugar-example.component.scss
+++ b/projects/cashmere-examples/src/lib/datepicker-sugar/datepicker-sugar-example.component.scss
@@ -1,3 +1,8 @@
 .example-date-input {
     width: 200px;
+    margin-top: 15px;
+}
+
+.example-date-description {
+    font-size: 14px;
 }


### PR DESCRIPTION
corrects several errors in the datepicker usage doc; adds sugar.js info

@isaaclyman - if you have a minute to look over the changes to this usage doc, I'd very much value your input on any other changes you might recommend.

closes #1192
closes #884 