### PR TITLE
refactor(popover): use shared keydown event listener

### DIFF
--- a/projects/cashmere/src/lib/pop/popover-accessibility.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-accessibility.service.ts
@@ -1,0 +1,39 @@
+import {Injectable, OnDestroy} from '@angular/core';
+export enum KEY_CODE {
+    DOWN_ARROW = 40,
+    RIGHT_ARROW = 39,
+    UP_ARROW = 38,
+    LEFT_ARROW = 37,
+    TAB = 9
+}
+
+export interface HcPopKeyboardNotifier {
+    isOpen: boolean;
+    nativeElement: HTMLElement;
+    hasSubmenu: () => boolean;
+    onKeyDown: (event: KeyboardEvent) => void;
+}
+
+@Injectable()
+export class HcPopoverAccessibilityService implements OnDestroy {
+    private notifiers: HcPopKeyboardNotifier[] = [];
+
+    constructor() {
+        window.addEventListener('keydown', this.handleKeydown);
+    }
+
+    ngOnDestroy() {
+        window.removeEventListener('keydown', this.handleKeydown);
+    }
+
+    registerNotifier(notifier: HcPopKeyboardNotifier) {
+        this.notifiers.push(notifier);
+    }
+
+    private handleKeydown = (event: KeyboardEvent) => {
+        this.notifiers.filter(n => n.isOpen).forEach(n => n.onKeyDown(event));
+        if (event.keyCode === KEY_CODE.RIGHT_ARROW) {
+            this.notifiers.filter(n => document.activeElement === n.nativeElement && n.hasSubmenu()).forEach(n => n.onKeyDown(event));
+        }
+    };
+}

--- a/projects/cashmere/src/lib/pop/popover.component.ts
+++ b/projects/cashmere/src/lib/pop/popover.component.ts
@@ -13,7 +13,6 @@ import {
     Output,
     ContentChildren,
     QueryList
-
 } from '@angular/core';
 import {AnimationEvent} from '@angular/animations';
 import {DOCUMENT} from '@angular/common';
@@ -226,12 +225,12 @@ export class HcPopComponent implements OnInit, OnDestroy {
         return this._parentMenu;
     }
     set parent(val: HcPopComponent) {
-        if ( this._parentMenu ) {
+        if (this._parentMenu) {
             this._parentClose.unsubscribe();
         }
         this._parentMenu = val;
-        this._parentClose = this._parentMenu.closed.subscribe((value) => {
-            if ( this.isOpen() ) {
+        this._parentClose = this._parentMenu.closed.subscribe(value => {
+            if (this.isOpen()) {
                 this.close();
             }
         });
@@ -349,7 +348,7 @@ export class HcPopComponent implements OnInit, OnDestroy {
 
     /** Toggle this popover open or closed. */
     toggle(): void {
-        if ( this.parent ) {
+        if (this.parent) {
             this.parent._subMenuOpen = !this.isOpen();
         }
         const notification = new PopoverNotification(NotificationAction.TOGGLE);
@@ -408,7 +407,8 @@ export class HcPopComponent implements OnInit, OnDestroy {
     _setAlignmentClassesForArrow(xAlign = this.horizontalAlign, yAlign = this.verticalAlign) {
         this._classList['hc-pop-show-arrow'] =
             (this.showArrow &&
-                (xAlign === 'start' || xAlign === 'center' || xAlign === 'end') && (yAlign === 'above' || yAlign === 'below')) ||
+                (xAlign === 'start' || xAlign === 'center' || xAlign === 'end') &&
+                (yAlign === 'above' || yAlign === 'below')) ||
             ((yAlign === 'start' || yAlign === 'center' || yAlign === 'end') && (xAlign === 'before' || xAlign === 'after'));
 
         this._yAlignClass = this._classList['hc-pop-show-arrow'] ? `hc-pop-arrow-y-${yAlign}` : '';

--- a/projects/cashmere/src/lib/pop/popover.module.ts
+++ b/projects/cashmere/src/lib/pop/popover.module.ts
@@ -13,6 +13,7 @@ import {MenuIconDirective} from './directives/menu-icon.directive';
 import {MenuTextDirective} from './directives/menu-text.directive';
 import {MenuSubTextDirective} from './directives/menu-sub-text.directive';
 import {DividerDirective} from './directives/divider.directive';
+import {HcPopoverAccessibilityService} from './popover-accessibility.service';
 
 @NgModule({
     imports: [CommonModule, OverlayModule, A11yModule, BidiModule],
@@ -36,6 +37,7 @@ import {DividerDirective} from './directives/divider.directive';
         MenuTextDirective,
         MenuSubTextDirective,
         DividerDirective
-    ]
+    ],
+    providers: [HcPopoverAccessibilityService]
 })
 export class PopModule {}


### PR DESCRIPTION
This isn't quite the solution we talked about @joeskeen -- I was struggling to get PopoverAnchor or PopoverComponent to hear keyboard events at anything smaller than the scope of the entire window. So this PR streamlines that, using one global keydown event listener with self-updating objects to quickly weed out as many elements as possible from the list of those that need to be notified of the event. For most keys there should be no lag. For the right arrow key, there may be slightly more lag if there are many, many elements...but there also may not be very much. See HcPopoverAccessibilityService.

I'm definitely open to other solutions, but this one is simple and hopefully will work.

Fixes #1213 