### PR TITLE
fix(formfield): more flexible label content

### DIFF
--- a/projects/cashmere-examples/src/lib/form-field-labels/form-field-labels-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-labels/form-field-labels-example.component.html
@@ -1,0 +1,28 @@
+<form>
+    <div class="example-field">
+        <hc-form-field>
+            <hc-label>Primary form field label:</hc-label>
+            <hc-label-ext>
+                Additional descriptive or help content may be included with a label extension.
+            </hc-label-ext>
+            <input hcInput required>
+            <hc-error>An example of an error</hc-error>
+        </hc-form-field>
+    </div>
+
+    <div class="example-field">
+        <hc-form-field>
+            <hc-label>Additional label extension uses:</hc-label>
+            <hc-label-ext>
+                <span>Label extensions may include supporting content like images</span>
+                <img src="./assets/FabricCashmere.svg" alt="Fabric.Cashmere Title"/>
+            </hc-label-ext>
+            <hc-select placeholder="Select a version:" required>
+                <option value="daily">Latest</option>
+                <option value="weekly">Development</option>
+                <option value="monthly">Production</option>
+            </hc-select>
+            <hc-error>Another example error</hc-error>
+        </hc-form-field>
+    </div>
+</form>

--- a/projects/cashmere-examples/src/lib/form-field-labels/form-field-labels-example.component.scss
+++ b/projects/cashmere-examples/src/lib/form-field-labels/form-field-labels-example.component.scss
@@ -1,0 +1,4 @@
+.example-field {
+    max-width: 450px;
+    width: 100%;
+}

--- a/projects/cashmere-examples/src/lib/form-field-labels/form-field-labels-example.component.ts
+++ b/projects/cashmere-examples/src/lib/form-field-labels/form-field-labels-example.component.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+import {FormControl} from '@angular/forms';
+
+/**
+ * @title Form Field Label Extensions
+ */
+@Component({
+    selector: 'hc-form-field-labels-example',
+    templateUrl: 'form-field-labels-example.component.html',
+    styleUrls: ['form-field-labels-example.component.scss']
+})
+export class FormFieldLabelsExampleComponent {}

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.html
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.html
@@ -11,7 +11,7 @@
     </span>
     <div class="hc-form-field-content-wrapper">
 
-        <ng-content></ng-content>
+        <ng-content select="hc-label-ext"></ng-content>
 
         <div
             *ngIf="hasInput"
@@ -37,9 +37,7 @@
             [class.hc-form-field-non-input-inline-tight]="inline && tight"
             [class.hc-form-field-invalid]="_shouldShowErrorMessages()"
         >
-            <ng-content select="hc-select"></ng-content>
-            <ng-content select="hc-checkbox"></ng-content>
-            <ng-content select="hc-radio-group"></ng-content>
+            <ng-content></ng-content>
         </div>
         <div class="hc-form-field-error-wrapper" *ngIf="_shouldShowErrorMessages()">
             <hc-error *ngIf="_control._errorMessage && _control._errorMessage.length">{{ _control._errorMessage }}</hc-error>

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.html
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.html
@@ -10,6 +10,9 @@
         </label>
     </span>
     <div class="hc-form-field-content-wrapper">
+
+        <ng-content></ng-content>
+
         <div
             *ngIf="hasInput"
             [class.hc-form-field-flex]="!inline"
@@ -34,7 +37,9 @@
             [class.hc-form-field-non-input-inline-tight]="inline && tight"
             [class.hc-form-field-invalid]="_shouldShowErrorMessages()"
         >
-            <ng-content></ng-content>
+            <ng-content select="hc-select"></ng-content>
+            <ng-content select="hc-checkbox"></ng-content>
+            <ng-content select="hc-radio-group"></ng-content>
         </div>
         <div class="hc-form-field-error-wrapper" *ngIf="_shouldShowErrorMessages()">
             <hc-error *ngIf="_control._errorMessage && _control._errorMessage.length">{{ _control._errorMessage }}</hc-error>

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -118,6 +118,10 @@
     @include hc-form-field-label();
 }
 
+.hc-form-field-label-extension {
+    @include hc-form-field-label-extension();
+}
+
 .hc-form-field-label-inline {
     @include hc-form-field-label-inline();
 }

--- a/projects/cashmere/src/lib/form-field/hc-form-field.module.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.module.ts
@@ -5,11 +5,28 @@ import {HcErrorComponent} from './hc-error.component';
 import {HcSuffixDirective} from './hc-suffix.directive';
 import {HcPrefixDirective} from './hc-prefix.directive';
 import {HcLabelComponent} from './hc-label.component';
+import {HcLabelExtensionComponent} from './hc-label-ext.component';
 import {HcFormDirective} from './hc-form.directive';
 
 @NgModule({
     imports: [CommonModule],
-    declarations: [HcFormFieldComponent, HcErrorComponent, HcPrefixDirective, HcSuffixDirective, HcLabelComponent, HcFormDirective],
-    exports: [HcFormFieldComponent, HcErrorComponent, HcPrefixDirective, HcSuffixDirective, HcLabelComponent, HcFormDirective]
+    declarations: [
+        HcFormFieldComponent,
+        HcErrorComponent,
+        HcPrefixDirective,
+        HcSuffixDirective,
+        HcLabelComponent,
+        HcLabelExtensionComponent,
+        HcFormDirective
+    ],
+    exports: [
+        HcFormFieldComponent,
+        HcErrorComponent,
+        HcPrefixDirective,
+        HcSuffixDirective,
+        HcLabelComponent,
+        HcLabelExtensionComponent,
+        HcFormDirective
+    ]
 })
 export class FormFieldModule {}

--- a/projects/cashmere/src/lib/form-field/hc-label-ext.component.ts
+++ b/projects/cashmere/src/lib/form-field/hc-label-ext.component.ts
@@ -1,0 +1,12 @@
+import {Component, HostBinding, ViewEncapsulation} from '@angular/core';
+
+/** Container for additional label content for HcFormFieldComponent */
+@Component({
+    selector: 'hc-label-ext',
+    template: '<ng-content></ng-content>',
+    encapsulation: ViewEncapsulation.None
+})
+export class HcLabelExtensionComponent {
+    @HostBinding('class.hc-form-field-label-extension')
+    _hostHcLabelClass = true;
+}

--- a/projects/cashmere/src/lib/form-field/hc-label.component.ts
+++ b/projects/cashmere/src/lib/form-field/hc-label.component.ts
@@ -6,7 +6,4 @@ import {Component, HostBinding, ViewEncapsulation} from '@angular/core';
     template: '<ng-content></ng-content>',
     encapsulation: ViewEncapsulation.None
 })
-export class HcLabelComponent {
-    @HostBinding('class.hc-label')
-    _hostHcLabelClass = true;
-}
+export class HcLabelComponent {}

--- a/projects/cashmere/src/lib/form-field/index.ts
+++ b/projects/cashmere/src/lib/form-field/index.ts
@@ -6,5 +6,6 @@ export {HcErrorComponent} from './hc-error.component';
 export {HcPrefixDirective} from './hc-prefix.directive';
 export {HcSuffixDirective} from './hc-suffix.directive';
 export {HcLabelComponent} from './hc-label.component';
+export {HcLabelExtensionComponent} from './hc-label-ext.component';
 export {HcFormDirective} from './hc-form.directive';
 export {FormFieldModule} from './hc-form-field.module';

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -186,7 +186,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
     font: inherit;
     font-size: calculateRem(14px);
-    color: $gray-500;
+    color: $text;
     pointer-events: none; // We shouldn't catch mouse events (let them through).
 
     width: 100%;
@@ -198,6 +198,12 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     transform: translateY(-$infix-margin-top - $infix-padding) scale($label-font-scale);
     display: block;
     transform-origin: 0 0;
+}
+
+@mixin hc-form-field-label-extension() {
+    color: $gray-500;
+    font-size: calculateRem(12px);
+    margin-bottom: 10px;
 }
 
 @mixin hc-form-field-label-inline() {

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -54,7 +54,13 @@ const docs: DocItem[] = [
         examples: ['drawer-basic', 'drawer-overlay', 'drawer-side', 'drawer-menu']
     },
     {id: 'ellipsis-pipe', name: 'Ellipsis', category: 'pipes', usageDoc: true, hideApi: true, examples: ['ellipsis-overview']},
-    {id: 'form-field', name: 'Form Field', category: 'forms', usageDoc: true, examples: ['form-field-overview', 'form-field-tight']},
+    {
+        id: 'form-field',
+        name: 'Form Field',
+        category: 'forms',
+        usageDoc: true,
+        examples: ['form-field-overview', 'form-field-tight', 'form-field-labels']
+    },
     {id: 'icon', name: 'Icon', category: 'buttons', examples: ['icon-overview']},
     {
         id: 'input',


### PR DESCRIPTION
Allow additional custom markup inside hc-form-fields.

I think this change makes form-field more dynamic.  Beyond adding the help subtext, a user could add an image, omit hc-label and make their own custom label, etc.

So Jayson - your markup will look something like this for any form-field (with a class on the span to style the help text accordingly):
```
<hc-form-field>
            <hc-label>Run frequency:</hc-label>
            <span>Additional instructions may be included on this line</span>
            <hc-select placeholder="Select frequency:" [formControl]="selectControl">
                <option value="daily">Daily</option>
                <option value="weekly">Weekly</option>
                <option value="monthly">Monthly</option>
            </hc-select>
            <hc-error>Please select the run frequency for this item</hc-error>
</hc-form-field>
```
Let me know if you have any concerns.

closes #1225