### PR TITLE
fix(hc-form-field): allow labels to wrap

### DIFF
--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.html
@@ -19,13 +19,14 @@
 
     <div class="form-sample">
         <hc-form-field>
-            <hc-label>Run frequency:</hc-label>
-            <hc-select placeholder="Select frequency:" [formControl]="selectControl">
-                <option value="daily">Daily</option>
-                <option value="weekly">Weekly</option>
-                <option value="monthly">Monthly</option>
+            <hc-label>How long has it been since your last ER or Urgent Care visit at one of our facilities?</hc-label>
+            <hc-select placeholder="Select answer" [formControl]="selectControl">
+                <option value="daily">Within the last week</option>
+                <option value="weekly">Within the last month</option>
+                <option value="monthly">Within the last 6 months</option>
+                <option value="monthly">More than 6 months ago</option>
             </hc-select>
-            <hc-error>Please select the run frequency for this item</hc-error>
+            <hc-error>Please answer the screening question</hc-error>
         </hc-form-field>
     </div>
 

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -6,10 +6,6 @@
 
 .hc-form-field-wrapper {
     @include hc-form-field-wrapper();
-
-    &.hc-form-field-wrapper-tight {
-        @include hc-form-field-wrapper-tight-border();
-    }
 }
 
 .hc-form-field-wrapper-inline {
@@ -128,10 +124,6 @@
 
 .hc-form-field-label-tight {
     @include hc-form-field-label-tight();
-}
-
-.hc-form-field-no-label {
-    @include hc-form-field-no-label();
 }
 
 .hc-form-field-error-wrapper {

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -25,17 +25,12 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
 @mixin hc-form-field-wrapper() {
     position: relative;
-    border-top: $infix-margin-top solid transparent;
     padding-bottom: $wrapper-padding-bottom;
     flex-direction: inherit;
 }
 
 @mixin hc-form-field-wrapper-tight() {
     padding-bottom: 10px;
-}
-
-@mixin hc-form-field-wrapper-tight-border() {
-    border-top: $infix-margin-top-tight solid transparent;
 }
 
 @mixin hc-form-field-wrapper-inline() {
@@ -144,23 +139,13 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 @mixin hc-form-field-label-wrapper() {
-    position: absolute;
-    left: 0;
     box-sizing: content-box;
     width: 100%;
-    height: 100%;
-    overflow: hidden;
     pointer-events: none; // We shouldn't catch mouse events (let them through).
-    top: -$infix-margin-top;
-    padding-top: $infix-margin-top;
-}
-
-@mixin hc-form-field-label-wrapper-tight() {
-    top: -$infix-margin-top-tight;
-    padding-top: $infix-margin-top-tight;
 }
 
 @mixin hc-form-field-label-wrapper-inline() {
+    flex: 1 0 auto;
     padding: 7px 15px 0 0;
 }
 
@@ -176,28 +161,14 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     vertical-align: baseline;
 }
 
-@mixin hc-form-field-no-label() {
-    border-top: none;
-}
-
 @mixin hc-form-field-label() {
-    position: absolute;
-    left: 0;
-
+    display: block;
+    width: 100%;
+    margin-bottom: 3px;
     font: inherit;
     font-size: calculateRem(14px);
     color: $text;
     pointer-events: none; // We shouldn't catch mouse events (let them through).
-
-    width: 100%;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-
-    top: $infix-margin-top + $infix-padding;
-    transform: translateY(-$infix-margin-top - $infix-padding) scale($label-font-scale);
-    display: block;
-    transform-origin: 0 0;
 }
 
 @mixin hc-form-field-label-extension() {
@@ -207,15 +178,11 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 @mixin hc-form-field-label-inline() {
+    width: 100%;
     font: inherit;
     font-size: calculateRem(14px);
-    color: $gray-500;
+    color: $text;
     pointer-events: none; // We shouldn't catch mouse events (let them through).
-
-    width: 100%;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
 }
 
 @mixin hc-form-field-label-tight() {


### PR DESCRIPTION
fix #1239, allowing labels to wrap. I got rid of some of the complex positioning magic that was being used before. It totally possible I'm missing a reason we were being so tricky with it, let me know if I did.

Also noticed that the inline labels were colored differently than other labels, so I made them match.
