### PR TITLE
fix(hc-radio): add focus styles

### DIFF
--- a/projects/cashmere/src/lib/radio-button/radio-button.component.scss
+++ b/projects/cashmere/src/lib/radio-button/radio-button.component.scss
@@ -56,4 +56,12 @@
     &.disabled {
         @include hc-radio-input-disabled();
     }
+
+    &:focus + .hc-radio-overlay {
+        @include hc-radio-input-focus();
+    }
+
+    &:active + .hc-radio-overlay {
+        @include hc-radio-input-active();
+    }
 }

--- a/projects/cashmere/src/lib/sass/radio-button.scss
+++ b/projects/cashmere/src/lib/sass/radio-button.scss
@@ -97,6 +97,15 @@
     position: absolute;
 }
 
+@mixin hc-radio-input-focus {
+    outline: 2px solid lighten($azure, 30);
+    outline-offset: -1px;
+}
+
+@mixin hc-radio-input-active {
+    outline: none;
+}
+
 @mixin hc-radio-input-disabled() {
     cursor: not-allowed;
 }


### PR DESCRIPTION
A couple items in the issue were already addressed, so this just enhances keyboard accessibility by adding simple focus. Basically just makes it work more like native radios.

![cashmere-radio](https://user-images.githubusercontent.com/12416432/80659645-c3783400-8a46-11ea-8e20-e596b036ba2c.gif)
![native-radio](https://user-images.githubusercontent.com/12416432/80659647-c3783400-8a46-11ea-95a9-a24091b25942.gif)

re #951