### PR TITLE
fix(button): prevent wrapping split button

### DIFF
--- a/projects/cashmere/src/lib/button/split-button/split-button.component.html
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.html
@@ -1,4 +1,4 @@
-<span [hcPop]="splitMenu" trigger="none">
+<span class="hc-split-button-wrap" [hcPop]="splitMenu" trigger="none">
     <button
         hc-button
         class="hc-split-button-main"

--- a/projects/cashmere/src/lib/button/split-button/split-button.component.scss
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.scss
@@ -6,9 +6,14 @@
 .hc-split-button {
     @include hc-split-button();
 
+    .hc-split-button-wrap {
+        @include hc-split-button-wrap();
+    }
+
     .hc-split-button-main {
         @include hc-split-button-main();
     }
+
     .hc-split-button-toggle {
         @include hc-split-button-toggle();
     }

--- a/projects/cashmere/src/lib/sass/button.scss
+++ b/projects/cashmere/src/lib/sass/button.scss
@@ -215,6 +215,10 @@ $btn-icon-sz: 18px;
     display: inline-flex;
 }
 
+@mixin hc-split-button-wrap() {
+    display: inline-flex;
+}
+
 @mixin hc-split-button-main() {
     margin-right: 0;
     border-bottom-right-radius: 0;


### PR DESCRIPTION
We've been seeing the following issue on smaller screens:

![image](https://user-images.githubusercontent.com/9139369/81226175-a643e800-8fa7-11ea-8e7c-3bebe678fc18.png)

Adding `inline-flex` to the wrapper span prevents this behavior.