### PR TITLE
docs(guides): add angular version support guide

### DIFF
--- a/guides/supported-angular-versions.md
+++ b/guides/supported-angular-versions.md
@@ -1,0 +1,35 @@
+# Supported Angular Versions
+
+###### Last updated May 13, 2020
+
+:::
+
+##### Angular support
+
+As maintainers of Cashmere, we are dedicated to ensuring that Cashmere is a benefit, never a hinderance, to your application.  We aim to provide flexibility to application developers to use all the latest Angular features; at the same time, we don't want to leave applications behind by only targeting bleeding-edge versions.  Therefore, we take the following balanced approach for Angular versioning in Cashmere:
+
+### Target: latest LTS version
+
+We plan to keep Cashmere up-to-date with the latest LTS version of Angular.  This means that when an Angular version ends active support and enters LTS support (see [Angular's Support Policy and Schedule](https://angular.io/guide/releases#support-policy-and-schedule)), Cashmere will update its minimum supported version to that version.
+
+#### Hypothetical Example
+
+If the current support table on angular.io looks like this:
+
+| VERSION  | STATUS | RELEASED     | ACTIVE ENDS  | LTS ENDS     |
+| :------- | :----- | :----------- | :----------- | :----------- |
+| ^79.0.0  | Active | Feb 06, 2120 | Aug 06, 2120 | Aug 06, 2121 |
+| ^78.0.0  | LTS    | May 28, 2119 | Nov 28, 2119 | Nov 28, 2120 |
+
+Cashmere would be updated to target Angular versions on this schedule:
+
+* **Angular 78**: November 28, 2119
+* **Angular 79**: August 6, 2120
+
+### Latest Angular is always supported
+
+Even though Cashmere currently _targets_ Angular version `n`, we aim to make it compatible with all released versions `>n` as well.  In the example above, you don't have to wait until August 6, 2120 to upgrade from Angular 78 to 79.  We encourage all teams to keep up to date with the latest Angular version as much as possible.
+
+If you find any incompatibilites with the latest Angular version, please log an issue.
+
+:::

--- a/guides/supported-browsers.md
+++ b/guides/supported-browsers.md
@@ -6,7 +6,7 @@
 
 ##### Browser support table
 
-To support a more unifed and better user experience, Health Catalyst should aim to align the target browser compatibility. Along with a better experience, consistent compatibility helps push Health Catalyst products into the future vision of working in a tool switcher.
+To support a more unified and better user experience, Health Catalyst should aim to align the target browser compatibility. Along with a better experience, consistent compatibility helps push Health Catalyst products into the future vision of working in a tool switcher.
 
 |                                                                                          |                             | <img src="./assets/windows.png" alt="Windows" style="width: 50px;"/> **Windows** | <img src="./assets/mac.png" alt="Mac" style="width: 50px;"/> **Mac** |
 | ---------------------------------------------------------------------------------------: | :-------------------------- | :------------------------------------------------------------------------------: | :------------------------------------------------------------------: |

--- a/projects/cashmere/package.json
+++ b/projects/cashmere/package.json
@@ -16,14 +16,14 @@
     "jsnext": "./esm2015/cashmere.js",
     "typings": "./cashmere.d.ts",
     "peerDependencies": {
-        "@angular/cdk": "^8.2.0",
-        "@angular/common": "^8.2.0",
-        "@angular/core": "^8.2.0",
-        "@angular/forms": "^8.2.0",
+        "@angular/cdk": ">= 8.2.0",
+        "@angular/common": ">= 8.2.0",
+        "@angular/core": ">= 8.2.0",
+        "@angular/forms": ">= 8.2.0",
         "core-js": ">= 2.4.0 < 3",
         "font-awesome": "~4.7.0",
         "npm-font-open-sans": "^1.1.0",
-        "rxjs": "^6.5.0",
-        "zone.js": "~0.9.1"
+        "rxjs": ">= 6.5.0",
+        "zone.js": ">= 0.9.1"
     }
 }

--- a/src/app/guides/guides.service.ts
+++ b/src/app/guides/guides.service.ts
@@ -42,6 +42,12 @@ export class GuidesService {
             document: require('raw-loader!../../../guides/supported-browsers.md')
         },
         {
+            title: 'Supported Angular Versions',
+            route: 'supported-angular-versions',
+            category: 'using',
+            document: require('raw-loader!../../../guides/supported-angular-versions.md')
+        },
+        {
             title: 'Customizing Components',
             route: 'using-customizing-components',
             category: 'dev',


### PR DESCRIPTION
Add a guide to the Cashmere docs site regarding our plan for upgrading Angular versions in the future.

![image](https://user-images.githubusercontent.com/12286274/81870690-a443d100-9533-11ea-9a99-f27b696b0295.png)
