### PR TITLE
Set checkboxInput to static=true

### DIFF
--- a/projects/cashmere/src/lib/checkbox/checkbox.component.ts
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.ts
@@ -80,7 +80,7 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
     @Output()
     change = new EventEmitter<CheckboxChangeEvent>();
 
-    @ViewChild('checkboxInput', {static: false})
+    @ViewChild('checkboxInput', {static: true})
     _checkboxInput: ElementRef;
 
     @HostBinding('attr.id')


### PR DESCRIPTION
The checkboxInput should be set to static: true and that seems to do the trick. I'm not sure how we missed that one. I only see it in Ops Console.
![image](https://user-images.githubusercontent.com/12176013/82364752-51579700-99d5-11ea-8856-797bdc231f8e.png)
