### PR TITLE
fix(scss): standardize scss imports

### DIFF
--- a/projects/cashmere/src/lib/sass/_breadcrumbs.scss
+++ b/projects/cashmere/src/lib/sass/_breadcrumbs.scss
@@ -1,6 +1,6 @@
-@import 'colors';
-@import 'variables';
-@import 'mixins';
+@import './colors';
+@import './variables';
+@import './mixins';
 
 .breadcrumb {
     padding: 0;

--- a/projects/cashmere/src/lib/sass/_cdk-overlay.scss
+++ b/projects/cashmere/src/lib/sass/_cdk-overlay.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import './variables';
 
 .cdk-overlay-container {
     z-index: $zindex-cdk-overlay; // override index for implementation inside a modal: https://github.com/HealthCatalyst/Fabric.Cashmere/issues/867

--- a/projects/cashmere/src/lib/sass/_functions.scss
+++ b/projects/cashmere/src/lib/sass/_functions.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import './variables';
 
 /// Slightly lighten a color
 /// @param {Color} $color - color to tint

--- a/projects/cashmere/src/lib/sass/_mixins.scss
+++ b/projects/cashmere/src/lib/sass/_mixins.scss
@@ -1,5 +1,5 @@
-@import 'variables';
-@import 'functions';
+@import './variables';
+@import './functions';
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
 // Makes the @content apply to the given breakpoint and wider.

--- a/projects/cashmere/src/lib/sass/_ng-select-theme.scss
+++ b/projects/cashmere/src/lib/sass/_ng-select-theme.scss
@@ -3,8 +3,8 @@
 
 @import './colors';
 @import './mixins';
-@import './select.scss';
-@import './chip.scss';
+@import './select';
+@import './chip';
 
 $ng-select-primary-text: $offblack !default;
 $ng-select-disabled-text: $gray-200 !default;

--- a/projects/cashmere/src/lib/sass/_reset.scss
+++ b/projects/cashmere/src/lib/sass/_reset.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import './variables';
 
 /* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126

--- a/projects/cashmere/src/lib/sass/about-modal.scss
+++ b/projects/cashmere/src/lib/sass/about-modal.scss
@@ -1,6 +1,6 @@
 @import './colors';
-@import 'variables';
-@import 'mixins';
+@import './variables';
+@import './mixins';
 
 .about-modal-content {
     padding: 15px 0;

--- a/projects/cashmere/src/lib/sass/app-switcher.scss
+++ b/projects/cashmere/src/lib/sass/app-switcher.scss
@@ -1,5 +1,5 @@
 @import './colors';
-@import './mixins.scss';
+@import './mixins';
 
 @mixin hc-app-switcher-outer() {
     height: 100%;

--- a/projects/cashmere/src/lib/sass/banner.scss
+++ b/projects/cashmere/src/lib/sass/banner.scss
@@ -1,6 +1,6 @@
 @import './colors';
-@import './functions.scss';
-@import './mixins.scss';
+@import './functions';
+@import './mixins';
 
 @mixin hc-banner() {
     align-items: center;

--- a/projects/cashmere/src/lib/sass/button.scss
+++ b/projects/cashmere/src/lib/sass/button.scss
@@ -1,5 +1,5 @@
 @import './colors';
-@import './functions.scss';
+@import './functions';
 @import './mixins';
 
 $btn-icon-sz: 18px;

--- a/projects/cashmere/src/lib/sass/chip.scss
+++ b/projects/cashmere/src/lib/sass/chip.scss
@@ -1,6 +1,6 @@
 @import './colors';
-@import './functions.scss';
-@import './mixins.scss';
+@import './functions';
+@import './mixins';
 
 @mixin hc-chip() {
     @include fontSize(14px);

--- a/projects/cashmere/src/lib/sass/error-pages.scss
+++ b/projects/cashmere/src/lib/sass/error-pages.scss
@@ -1,6 +1,6 @@
 @import './colors';
-@import 'variables';
-@import 'mixins';
+@import './variables';
+@import './mixins';
 
 .error-tile {
     width: 100%;

--- a/projects/cashmere/src/lib/sass/login-page.scss
+++ b/projects/cashmere/src/lib/sass/login-page.scss
@@ -1,6 +1,6 @@
-@import 'colors';
-@import 'mixins';
-@import 'variables';
+@import './colors';
+@import './mixins';
+@import './variables';
 
 .hc-login-container {
     // font

--- a/projects/cashmere/src/lib/sass/menu-drawer.scss
+++ b/projects/cashmere/src/lib/sass/menu-drawer.scss
@@ -1,4 +1,4 @@
-@import 'colors';
+@import './colors';
 
 $drawer-toolbar-height: 52px;
 

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -1,6 +1,6 @@
-@import 'colors';
-@import 'variables';
-@import 'mixins';
+@import './colors';
+@import './variables';
+@import './mixins';
 
 $navbar-color: $charcoal-blue !default;
 $navbar-brand: $primary-brand !default;

--- a/projects/cashmere/src/lib/sass/progress-dots.scss
+++ b/projects/cashmere/src/lib/sass/progress-dots.scss
@@ -1,4 +1,4 @@
-@import 'colors';
+@import './colors';
 $animation-speed: 1.4s !default;
 $animation-delay: -0.16s !default;
 $dots-diameter: 8px !default;

--- a/projects/cashmere/src/lib/sass/progress-spinner.scss
+++ b/projects/cashmere/src/lib/sass/progress-spinner.scss
@@ -1,6 +1,6 @@
 // Styles forked from http://polymer.github.io
 // This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-@import 'colors';
+@import './colors';
 $diameter: 50px;
 
 $spinner-animation-timing: 1568ms;

--- a/projects/cashmere/src/lib/sass/select.scss
+++ b/projects/cashmere/src/lib/sass/select.scss
@@ -1,6 +1,6 @@
 @import './colors';
-@import './functions.scss';
-@import './mixins.scss';
+@import './functions';
+@import './mixins';
 
 @mixin hc-select() {
     display: inline-block;

--- a/projects/cashmere/src/lib/sass/subnav.class.scss
+++ b/projects/cashmere/src/lib/sass/subnav.class.scss
@@ -1,4 +1,4 @@
-@import './subnav.scss';
+@import './subnav';
 
 .hc-subnav {
     @include hc-subnav();

--- a/projects/cashmere/src/lib/sass/subnav.scss
+++ b/projects/cashmere/src/lib/sass/subnav.scss
@@ -1,5 +1,5 @@
-@import 'colors';
-@import 'variables';
+@import './colors';
+@import './variables';
 
 @mixin hc-subnav() {
     align-items: center;

--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -1,4 +1,4 @@
-@import './table.scss';
+@import './table';
 
 .hc-table {
     @include hc-table();

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.scss
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.scss
@@ -1,6 +1,6 @@
 @import 'scss/colors';
 @import 'scss/functions';
-@import 'scss/mixins.scss';
+@import 'scss/mixins';
 @import '~highlight.js/styles/github.css';
 
 .hc-tile:first-child {

--- a/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
@@ -1,6 +1,6 @@
 @import 'scss/colors';
 @import 'scss/functions';
-@import 'scss/mixins.scss';
+@import 'scss/mixins';
 
 .hc-doc-viewer {
     display: block;


### PR DESCRIPTION
Remove trailing .scss on imports to fix StackBlitz examples.

I think I've tracked down the error we're getting on StackBlitz.  Not sure when or why this started cropping up, but I was able to narrow down the scss files it was choking on.  And all of them had .scss included in their imports.  So for whatever reason that seems to be causing an issue. I went back through all our sass directory files and standardized our import syntax.

Won't be able to know for certain that this fixed the StackBlitz problem until a new version is published, but I'm pretty confident this should do it.

closes #1243