### PR TITLE
Merge master: Fix unwanted horizontal scrolling in IE due to larger drawer container width

### DIFF
--- a/projects/cashmere/src/lib/drawer/drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.ts
@@ -36,6 +36,8 @@ export function validateAlignInput(inputStr: string) {
     }
 }
 
+const openStateAnimation = '400ms cubic-bezier(0.25, 0.8, 0.25, 1)';
+
 /** Drawer that can be opened or closed on the drawer container */
 @Component({
     selector: 'hc-drawer',
@@ -45,9 +47,8 @@ export function validateAlignInput(inputStr: string) {
     animations: [
         trigger('openState', [
             state(
-                'open, open-instant',
+                'open-left, open-right, open-instant',
                 style({
-                    transform: 'translate3d(0, 0, 0)',
                     visibility: 'visible'
                 })
             ),
@@ -59,7 +60,21 @@ export function validateAlignInput(inputStr: string) {
                 })
             ),
             transition('void => open-instant', animate('0ms')),
-            transition('void <=> open, open-instant => void', animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)'))
+            transition('open-instant => void', animate(openStateAnimation)),
+            transition('void => open-left', [
+                animate('0ms', style({ transform: 'translate3d(-100%, 0, 0)' })),
+                animate(openStateAnimation)
+            ]),
+            transition('open-left => void', [
+                animate(openStateAnimation, style({ transform: 'translate3d(-100%, 0, 0)' }))
+            ]),
+            transition('void => open-right', [
+                animate('0ms', style({ transform: 'translate3d(100%, 0, 0)'})),
+                animate(openStateAnimation)
+            ]),
+            transition('open-right => void', [
+                animate(openStateAnimation, style({ transform: 'translate3d(100%, 0, 0)' }))
+            ])
         ])
     ],
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -180,9 +195,13 @@ export class Drawer implements AfterContentInit {
     }
 
     @HostBinding('@openState')
-    get _openState(): 'void' | 'open-instant' | 'open' {
+    get _openState(): 'void' | 'open-instant' | 'open-left' | 'open-right' {
         if (this._drawerOpened) {
-            return this._animationDisabled ? 'open-instant' : 'open';
+            if (this._animationDisabled) {
+                return 'open-instant';
+            }
+
+            return this._align === 'right' ? 'open-right' : 'open-left';
         }
         return 'void';
     }

--- a/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.ts
@@ -22,6 +22,8 @@ export function validateMenuDrawerTheme(menuTheme) {
     }
 }
 
+const openStateAnimation = '400ms cubic-bezier(0.25, 0.8, 0.25, 1)';
+
 /** Menu drawer that provides default themes */
 @Component({
     selector: 'hc-menu-drawer',
@@ -31,7 +33,7 @@ export function validateMenuDrawerTheme(menuTheme) {
     animations: [
         trigger('openState', [
             state(
-                'open, open-instant',
+                'open-left, open-right, open-instant',
                 style({
                     transform: 'translate3d(0, 0, 0)',
                     visibility: 'visible'
@@ -45,7 +47,21 @@ export function validateMenuDrawerTheme(menuTheme) {
                 })
             ),
             transition('void => open-instant', animate('0ms')),
-            transition('void <=> open, open-instant => void', animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)'))
+            transition('open-instant => void', animate(openStateAnimation)),
+            transition('void => open-left', [
+                animate('0ms', style({ transform: 'translate3d(-100%, 0, 0)' })),
+                animate(openStateAnimation)
+            ]),
+            transition('open-left => void', [
+                animate(openStateAnimation, style({ transform: 'translate3d(-100%, 0, 0)' }))
+            ]),
+            transition('void => open-right', [
+                animate('0ms', style({ transform: 'translate3d(100%, 0, 0)'})),
+                animate(openStateAnimation)
+            ]),
+            transition('open-right => void', [
+                animate(openStateAnimation, style({ transform: 'translate3d(100%, 0, 0)' }))
+            ])
         ])
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/cashmere/src/lib/sass/drawer.scss
+++ b/projects/cashmere/src/lib/sass/drawer.scss
@@ -18,13 +18,11 @@ $drawer-container-padding: 10px 20px;
     overflow-y: auto;
     position: absolute;
     top: 0;
-    transform: translate3d(-100%, 0, 0);
     z-index: 3;
 }
 
 @mixin hc-drawer-right() {
     right: 0;
-    transform: translate3d(100%, 0, 0);
 }
 
 @mixin hc-drawer-open() {


### PR DESCRIPTION
I made modifications to the Cashmere drawers so that in the "closed" state the drawers are actually inside the drawer containers, just hidden so that the user can't see them. The open animation sets the drawer outside the container just before the animation starts. The close animation puts the drawer back inside the container after it has finished closing. This allows the drawer containers to have the same width as they would have normally if there was no drawer being used. The only time the width of the container is modified is when the drawer is being animated in or out.

The reason for this change is that we encountered a bug in internet explorer that causes unwanted horizontal scrolling if a Cashmere Scroll Nav is used inside a Cashmere Drawer. The Element.scrollIntoView() method in internet explorer seems to think that the extra width created by the drawer is fair game for scrolling horizontally.

Link to the bug: #1270
Link to thread in slack where issue was reported: https://healthcatalyst.slack.com/archives/C75LHAV9S/p1591366716123200
Link to thread in slack where a demo of the fix is shown:
https://healthcatalyst.slack.com/archives/C6VV5GV3J/p1591652864332100

I have made the same modifications to the menu-drawer.