### PR TITLE
1267 checkbox multiselect bug

### DIFF
--- a/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.html
+++ b/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.html
@@ -1,0 +1,31 @@
+<ng-select class="checkbox-dropdown"
+        [items]="transportOptions"
+        [multiple]="true"
+        groupBy="type"
+        [closeOnSelect]="false"
+        [searchable]="true"
+        [searchFn]="customSearchFn"
+        bindLabel="name"
+        placeholder="Select to add"
+        [(ngModel)]="selected">
+        
+        <!-- Group header template -->
+        <ng-template ng-optgroup-tmp let-item="item">
+            <div class="group-row">{{item.type}}</div>
+        </ng-template>
+        
+        <!-- Dropdown option template -->
+        <ng-template ng-option-tmp let-item="item" let-search="searchTerm">
+            <div class="opt-row" title="Travel by {{item.type}}: {{item.name}}">
+                <span class="icon-wrapper {{item.color}}"> <hc-icon fontSet="fa" fontIcon="fa-{{item.icon}}" hcIconSm></hc-icon></span>{{item.name}}
+            </div>
+        </ng-template>
+        
+        <!-- Selected option template -->
+        <ng-template ng-label-tmp let-item="item" let-clear="clear">
+            <span class="ng-value-icon left" (click)="clear(item)" aria-hidden="true">×</span>
+            <span class="ng-value-label"><hc-icon fontSet="fa" fontIcon="fa-{{item.icon}}" hcIconSm></hc-icon>{{item.name}}</span>
+        </ng-template>
+</ng-select>
+
+<p>Selected: <code>{{selected | json}}</code></p>

--- a/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.scss
+++ b/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.scss
@@ -1,0 +1,44 @@
+@import "~@healthcatalyst/cashmere/scss/colors";
+@import "~@healthcatalyst/cashmere/scss/mixins";
+
+p {
+    font-size: 14px;
+    margin-bottom: 230px;
+}
+
+.group-row {
+    background-color: $slate-gray-100;
+    color: $offblack;
+    @include fontSize(12px);
+    margin: -8px -10px;
+    padding: 5px 20px;
+    text-transform: capitalize;
+}
+
+.ng-value-label hc-icon {
+    margin-right: 3px;
+}
+
+.opt-row {
+    display: flex;
+    align-items: center;
+    color: $offblack;
+}
+
+.icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    height: 28px;
+    width: 28px;
+    margin-right: 7px;
+    color: $white;
+
+    &.blue { background-color: $blue; }
+    &.green { background-color: $green; }
+    &.teal { background-color: $teal; }
+    &.purple { background-color: $purple; }
+    &.orange { background-color: $orange; }
+    &.dark-blue { background-color: $dark-blue; }
+}

--- a/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.ts
+++ b/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.ts
@@ -1,0 +1,26 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title Multiselect with customized templates
+ */
+@Component({
+    selector: 'hc-multiselect-custom-templates-example',
+    templateUrl: 'multiselect-custom-templates-example.component.html',
+    styleUrls: ['multiselect-custom-templates-example.component.scss']
+})
+export class MultiselectCustomTemplatesExampleComponent {
+    selected = [];
+    transportOptions = [
+      {name: "Bus", icon: "bus", color: "blue", type: "land"},
+      {name: "Train", icon: "train", color: "green", type: "land"},
+      {name: "Ferry", icon: "ship", color: "teal", type: "sea"},
+      {name: "Plane", icon: "plane", color: "purple", type: "air"},
+      {name: "Rocket", icon: "rocket", color: "orange", type: "air"},
+      {name: "Space Shuttle", icon: "space-shuttle", color: "dark-blue", type: "air"},
+    ];
+
+    customSearchFn(term: string, item: any) {
+        term = term.toLowerCase();
+        return item.name.toLowerCase().indexOf(term) > -1 || item.type.toLowerCase().indexOf(term) > -1;
+    }
+}

--- a/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.module.ts
+++ b/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {MultiselectCustomTemplatesExampleComponent} from './multiselect-custom-templates-example.component';
+import {CashmereModule} from '../cashmere.module';
+import {CommonModule} from '@angular/common';
+import {NgSelectModule} from '@ng-select/ng-select';
+import {FormsModule} from '@angular/forms';
+
+@NgModule({
+    imports: [CommonModule, CashmereModule, FormsModule, NgSelectModule],
+    declarations: [MultiselectCustomTemplatesExampleComponent],
+    exports: [MultiselectCustomTemplatesExampleComponent],
+    entryComponents: [MultiselectCustomTemplatesExampleComponent]
+})
+export class MultiselectCustomTemplatesExampleModule {}

--- a/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.component.html
+++ b/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.component.html
@@ -1,0 +1,15 @@
+<ng-select class="checkbox-dropdown"
+        [items]="careTeamRoles"
+        [multiple]="true"
+        [closeOnSelect]="false"
+        [searchable]="true"
+        bindLabel="name"
+        placeholder="Select to add"
+        [(ngModel)]="selectedCareTeamRoles"
+        [ngModelOptions]="{ standalone: true }">
+        <ng-template ng-option-tmp let-item="item" let-item$="item$" let-index="index">
+            <hc-checkbox [ngModel]="item$.selected" [isStub]="true">{{ item.name }}</hc-checkbox>
+        </ng-template>
+</ng-select>
+
+<p>Selected: <code>{{selectedCareTeamRoles | json}}</code></p>

--- a/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.component.scss
+++ b/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.component.scss
@@ -1,0 +1,4 @@
+p {
+    font-size: 14px;
+    margin-bottom: 120px;
+}

--- a/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.component.ts
+++ b/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.component.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title Multiselect with embedded checkbox
+ */
+@Component({
+    selector: 'hc-multiselect-embed-checkbox-example',
+    templateUrl: 'multiselect-embed-checkbox-example.component.html',
+    styleUrls: ['multiselect-embed-checkbox-example.component.scss']
+})
+export class MultiselectEmbedCheckboxExampleComponent {
+    selectedCareTeamRoles = [];
+    careTeamRoles = [
+      {name: "Care Team A"},
+      {name: "Care Team B"},
+      {name: "Care Team C"},
+    ];
+}

--- a/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.module.ts
+++ b/projects/cashmere-examples/src/lib/multiselect-embed-checkbox/multiselect-embed-checkbox-example.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {MultiselectEmbedCheckboxExampleComponent} from './multiselect-embed-checkbox-example.component';
+import {CashmereModule} from '../cashmere.module';
+import {CommonModule} from '@angular/common';
+import {NgSelectModule} from '@ng-select/ng-select';
+import {FormsModule} from '@angular/forms';
+
+@NgModule({
+    imports: [CommonModule, CashmereModule, FormsModule, NgSelectModule],
+    declarations: [MultiselectEmbedCheckboxExampleComponent],
+    exports: [MultiselectEmbedCheckboxExampleComponent],
+    entryComponents: [MultiselectEmbedCheckboxExampleComponent]
+})
+export class MultiselectEmbedCheckboxExampleModule {}

--- a/projects/cashmere-examples/src/lib/multiselect-overview/multiselect-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/multiselect-overview/multiselect-overview-example.component.ts
@@ -11,4 +11,10 @@ import {Component} from '@angular/core';
 export class MultiselectOverviewExampleComponent {
     cities = ["Philadelphia", "Atlanta", "Salt Lake City", "Chicago", "Orlando"];
     selectedCities = [];
+    selectedCareTeamRoles = [];
+    careTeamRoles = [
+      {name: "group 1"},
+      {name: "group 2"},
+      {name: "group 3"},
+    ];
 }

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.html
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.html
@@ -1,4 +1,4 @@
-<div class="hc-checkbox-container">
+<div class="hc-checkbox-container" [class.hc-checkbox-stub]="isStub">
     <div class="hc-checkbox-content" [class.hc-checkbox-tight]="tight" [ngClass]="'hc-checkbox-align-'+align">
         <input #checkboxInput
                type="checkbox"

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.scss
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.scss
@@ -85,3 +85,9 @@
         @include hc-checkbox-invalid();
     }
 }
+
+.hc-checkbox-stub {
+    .hc-checkbox-label, .hc-checkbox-overlay {
+        @include hc-checkbox-stubbed();
+    }
+}

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.ts
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.ts
@@ -49,6 +49,11 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
     @Input()
     indeterminate: boolean;
 
+    /** If true, the checkbox is for display purposes (not user interaction). As such its checked/unchecked state
+     * can only be controlled programatically. Useful for embedding in an ng-select typeahead */
+    @Input()
+    isStub = false;
+
     /** Unique id for the checkbox element. If none is supplied, one will be auto-generated. */
     @Input()
     get id(): string {

--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -135,3 +135,7 @@
 @mixin hc-checkbox-invalid() {
     border-color: $error !important;
 }
+
+@mixin hc-checkbox-stubbed() {
+    pointer-events: none;
+}

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -80,7 +80,14 @@ const docs: DocItem[] = [
         examples: ['navbar-overview', 'navbar-app-switcher'],
         usageDoc: true
     },
-    { id: 'multiselect', name: 'Multiselect & Typeahead', category: 'forms', hideApi: true, usageDoc: true, examples: ['multiselect-overview'] },
+    {
+        id: 'multiselect',
+        name: 'Multiselect & Typeahead',
+        category: 'forms',
+        hideApi: true,
+        usageDoc: true,
+        examples: ['multiselect-overview', 'multiselect-custom-templates', 'multiselect-embed-checkbox']
+    },
     {
         id: 'pagination',
         name: 'Pagination',


### PR DESCRIPTION
This is the best way could find to get our checkboxes and ng-select to coexist. Ng-select wraps some sort of extra click handler under the covers that updates the model, and our checkbox implementation doesn't play nicely with it.

May possible to rewrite the component to avoid the need for this new property, but this is where I landed.