### PR TITLE
fix(navbar): hide mobile menu button

### DIFF
--- a/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
@@ -35,6 +35,11 @@
     </hc-navbar-mobile-menu>
 </hc-navbar>
 
+<br>
+
+<p><em><strong>Note:</strong> the code for this example demonstrates how to setup a mobile menu in the navbar, however
+    its display has been disabled here to prevent it from colliding with the Cashmere site navigation.</em></p>
+
 <hc-pop #appSwitcher [showArrow]="false" horizontalAlign="end">
     <hc-app-switcher [serviceName]="currentAppName" [serviceVersion]="currentAppVersion"></hc-app-switcher>
 </hc-pop>

--- a/projects/cashmere/src/lib/navbar/navbar.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar.component.html
@@ -25,7 +25,7 @@
     <div #rightcontainer class="hc-navbar-right-container">
         <ng-content></ng-content>
     </div>
-    <div class="hc-navbar-mobile-menu" (click)="_toggleMobileMenu()">
+    <div class="hc-navbar-mobile-menu" *ngIf="_mobileMenu.first" (click)="_toggleMobileMenu()">
         <hc-icon fontSet="fa" [fontIcon]="_mobileMenuIcon" hcIconMd></hc-icon>
     </div>
 </nav>

--- a/projects/cashmere/src/lib/navbar/navbar.component.ts
+++ b/projects/cashmere/src/lib/navbar/navbar.component.ts
@@ -140,14 +140,12 @@ export class NavbarComponent implements AfterViewInit, OnDestroy {
     }
 
     _toggleMobileMenu() {
-        if (this._mobileMenu.first) {
-            if (this._menuOpen) {
-                this._mobileMenu.first.hide();
-                this._menuOpen = false;
-            } else {
-                this._mobileMenu.first.show();
-                this._menuOpen = true;
-            }
+        if (this._menuOpen) {
+            this._mobileMenu.first.hide();
+            this._menuOpen = false;
+        } else {
+            this._mobileMenu.first.show();
+            this._menuOpen = true;
         }
     }
 


### PR DESCRIPTION
Added an additional note to the second example explaining why the mobile menu doesn't display.

But more importantly, I've hidden the mobile menu button on the navbar if a menu doesn't exist.  @isaaclyman calling that out on the first example made me realize that was an oversight.

closes #1140