### PR TITLE
fix(checkbox): expanded hit area

### DIFF
--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -56,8 +56,9 @@
 }
 
 @mixin hc-checkbox-label-tight() {
-    padding: 2px 0 2px 30px;
+    padding: 2px 0 2px 26px;
     font-size: calculateRem(13px);
+    left: -18px;
 }
 
 @mixin hc-checkbox-overlay() {

--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -49,12 +49,14 @@
 }
 
 @mixin hc-checkbox-label() {
-    padding: 4px 0 4px 12px;
+    padding: 4px 0 4px 34px;
     line-height: 1.5;
+    position: relative;
+    left: -22px;
 }
 
 @mixin hc-checkbox-label-tight() {
-    padding: 2px 0 2px 8px;
+    padding: 2px 0 2px 30px;
     font-size: calculateRem(13px);
 }
 


### PR DESCRIPTION
A slightly hacky, but presumably harmless, way to fix the issue of multiline checkboxes not having their hitbox cover the area above/below the box.  Extends the padding on the label over the checkbox.

closes #1264