### PR TITLE
build: add recommended vscode extensions configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+        "ms-vscode.vscode-typescript-tslint-plugin",
+        "esbenp.prettier-vscode",
+        "Angular.ng-template"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}


### PR DESCRIPTION
This will recommend to anyone opening the Cashmere project in VSCode that they install the following extensions:

* Angular language service (`angular.ng-template`)
* TsLint (`ms-vscode.vscode-typescript-tslint-plugin`)
* Prettier (`esbenp.prettier-vscode`)

Doing so will help them have better tooling and keep them on the straight and narrow while contributing to Cashmere.