### PR TITLE
fix(date range): smoother ui

### DIFF
--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
@@ -56,6 +56,7 @@ export class CalendarWrapperComponent implements OnChanges {
     @Input()
     prefixLabel: string;
 
+    /** Flag to filter out weekends. */
     @Input()
     excludeWeekends: boolean;
 
@@ -63,12 +64,13 @@ export class CalendarWrapperComponent implements OnChanges {
     @Input()
     minDate: D | undefined;
 
-    @Input()
-    invalidDateLabel: string;
-
-    /** Flag to filter out weekends. */
+    /** The maximum selectable date. */
     @Input()
     maxDate: D | undefined;
+
+    /** Message displayed when a date is invalid. */
+    @Input()
+    invalidDateLabel: string;
 
     weekendFilter = () => true;
 

--- a/projects/cashmere/src/lib/date-range/date-range.module.ts
+++ b/projects/cashmere/src/lib/date-range/date-range.module.ts
@@ -11,10 +11,12 @@ import {FormFieldModule} from '../form-field/hc-form-field.module';
 import {InputModule} from '../input/input.module';
 import {ButtonModule} from '../button/button.module';
 import {RadioButtonModule} from '../radio-button/radio-button.module';
+import {ChipModule} from '../chip/chip.module';
 
 @NgModule({
     imports: [
         CommonModule,
+        ChipModule,
         FormFieldModule,
         DatepickerModule,
         HcNativeDateModule,

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
@@ -4,10 +4,10 @@
             [prefixLabel]="options.startDatePrefix"
             [selectedDate]="_fromDate"
             [minDate]="options.fromMinMax?.fromDate"
-            [maxDate]="_fromMaxDate | async"
             (selectedDateChange)="_updateFromDate($event)"
+            [maxDate]="options.fromMinMax?.toDate"
             [excludeWeekends]="options.excludeWeekends"
-            [dateFormat]="options.dateFormat"
+            [dateFormat]="options.format"
             [invalidDateLabel]="options.invalidDateLabel"
             [mode]="options.mode"
             [hourCycle]="options.hourCycle"
@@ -17,17 +17,17 @@
         <hc-calendar-wrapper
             [prefixLabel]="options.endDatePrefix"
             [selectedDate]="_toDate"
-            [minDate]="_ToMinDate | async"
+            [minDate]="options.toMinMax?.fromDate"
             [maxDate]="options.toMinMax?.toDate"
             (selectedDateChange)="_updateToDate($event)"
             [excludeWeekends]="options.excludeWeekends"
-            [dateFormat]="options.dateFormat"
+            [dateFormat]="options.format"
             [invalidDateLabel]="options.invalidDateLabel"
             [mode]="options.mode"
             [hourCycle]="options.hourCycle"
         ></hc-calendar-wrapper>
     </div>
-    <div class="hc-date-range-calendar-item">
+    <div class="hc-date-range-calendar-item hc-date-range">
         <div class="hc-date-range-menu">
             <hc-radio-group class="presets" [(ngModel)]="_selectedPreset">
                 <hc-radio-button *ngFor="let p of options.presets; let i = index" [value]="i" (change)="_updateRangeByPreset(i)">
@@ -49,6 +49,11 @@
                     {{ options.applyLabel }}
                 </button>
             </div>
+            <hc-chip *ngIf="_rangeIsInvalid" color="red">
+                <span class="hc-date-range-warning-icon"></span>The start date cannot be after the end date.
+            </hc-chip>
         </div>
     </div>
 </div>
+
+

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.scss
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.scss
@@ -35,3 +35,8 @@
 .presets {
     @include hc-date-range-presets();
 }
+
+
+.hc-date-range-warning-icon {
+    @include hc-date-range-warning-icon();
+}

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
@@ -57,147 +57,44 @@ describe('RangeComponent', () => {
         expect(component._selectedPreset).toBe(0);
     });
 
-    describe('fromMaxDate', () => {
-        it('should be undefined if toDate and fromMinMax.toDate are null', async(() => {
-            return component._fromMaxDate
-                .pipe(
-                    tap((fromDate: Date | undefined) => {
-                        expect(fromDate).toBeUndefined();
-                    })
-                )
-                .subscribe();
+    describe('_validateRange', () => {
+        it('will not mark range invalid if one or both dates are missing', async(() => {
+            component._updateFromDate(new Date(2010, 1, 1));
+            component._updateToDate(undefined);
+            component._validateRange();
+            expect(component._rangeIsInvalid).toBeFalsy();
+
+            component._updateFromDate(undefined);
+            component._updateToDate(new Date(2010, 1, 1));
+            component._validateRange();
+            expect(component._rangeIsInvalid).toBeFalsy();
+
+            component._updateFromDate(undefined);
+            component._updateToDate(undefined);
+            component._validateRange();
+            expect(component._rangeIsInvalid).toBeFalsy();
         }));
 
-        it('should be toDate if it is less than fromMinMax.toDate', async(() => {
-            component._toDate = new Date(2010, 1, 1);
-            const toDate = new Date(2010, 2, 1);
-            configStoreService.updateDateRangeOptions({
-                fromMinMax: {
-                    toDate
-                }
-            });
-            return component._fromMaxDate
-                .pipe(
-                    tap((fromDate: Date | undefined) => {
-                        expect(fromDate).toEqual(component._toDate);
-                    })
-                )
-                .subscribe();
+        it('will not mark range invalid if fromDate is before toDate', async(() => {
+            component._updateFromDate(new Date(2010, 1, 1));
+            component._updateToDate(new Date(2010, 1, 2));
+            component._validateRange();
+            expect(component._rangeIsInvalid).toBeFalsy();
         }));
 
-        it('should be fromMinMax.toDate if it is less than toDate', async(() => {
-            component._toDate = new Date(2010, 2, 1);
-            const toDate = new Date(2010, 1, 1);
-            configStoreService.updateDateRangeOptions({
-                fromMinMax: {
-                    toDate
-                }
-            });
-            return component._fromMaxDate
-                .pipe(
-                    tap((fromDate: Date | undefined) => {
-                        expect(fromDate).toEqual(toDate);
-                    })
-                )
-                .subscribe();
+        it('will not mark range invalid if fromDate is equal to toDate', async(() => {
+            component._updateFromDate(new Date(2010, 1, 1));
+            component._updateToDate(new Date(2010, 1, 1));
+            component._validateRange();
+            expect(component._rangeIsInvalid).toBeFalsy();
         }));
 
-        it('should default toDate when no fromMinMax.toDate is set', async(() => {
-            component._toDate = new Date(2010, 1, 1);
-            return component._fromMaxDate
-                .pipe(
-                    tap((fromDate: Date | undefined) => {
-                        expect(fromDate).toEqual(component._toDate);
-                    })
-                )
-                .subscribe();
-        }));
-
-        it('should be equal to fromMinMax.toDate', async(() => {
-            component._toDate = undefined;
-            const toDate = new Date(2011, 1, 1);
-            configStoreService.updateDateRangeOptions({
-                fromMinMax: {
-                    toDate
-                }
-            });
-            return component._fromMaxDate
-                .pipe(
-                    tap((fromDate: Date | undefined) => {
-                        expect(fromDate).toEqual(toDate);
-                    })
-                )
-                .subscribe();
+        it('will mark range invalid if fromDate is after toDate', async(() => {
+            component._updateFromDate(new Date(2010, 1, 2));
+            component._updateToDate(new Date(2010, 1, 1));
+            component._validateRange();
+            expect(component._rangeIsInvalid).toBeTruthy();
         }));
     });
 
-    describe('ToMinDate', () => {
-        it('should be undefined if fromDate and toMinMax.fromDate are null', async(() => {
-            return component._ToMinDate
-                .pipe(
-                    tap((toDate: Date | undefined) => {
-                        expect(toDate).toBeUndefined();
-                    })
-                )
-                .subscribe();
-        }));
-
-        it('should be fromDate if it is greater than toMinMax.fromDate', async(() => {
-            component._fromDate = new Date(2010, 2, 1);
-            const fromDate = new Date(2010, 1, 1);
-            configStoreService.updateDateRangeOptions({
-                toMinMax: {
-                    fromDate
-                }
-            });
-            return component._ToMinDate
-                .pipe(
-                    tap((toDate: Date | undefined) => {
-                        expect(toDate).toEqual(component._fromDate);
-                    })
-                )
-                .subscribe();
-        }));
-
-        it('should be toMinMax.fromDate if it is greater than fromDate', async(() => {
-            component._fromDate = new Date(2010, 2, 1);
-            const fromDate = new Date(2010, 1, 1);
-            configStoreService.updateDateRangeOptions({
-                toMinMax: {
-                    fromDate
-                }
-            });
-            return component._ToMinDate
-                .pipe(
-                    tap((toDate: Date | undefined) => {
-                        expect(toDate).toEqual(component._fromDate);
-                    })
-                )
-                .subscribe();
-        }));
-
-        it('should default fromDate when no toMinMax.fromDate is set', async(() => {
-            component._fromDate = new Date(2010, 1, 1);
-            return component._ToMinDate.pipe(
-                tap((toDate: Date | undefined) => {
-                    expect(toDate).toEqual(component._toDate);
-                })
-            );
-        }));
-
-        it('should be equal to toMinMax.fromDate', async(() => {
-            component._toDate = undefined;
-            const fromDate = new Date(2011, 1, 1);
-            configStoreService.updateDateRangeOptions({
-                toMinMax: {
-                    fromDate
-                }
-            });
-            return component._ToMinDate.pipe(
-                tap((toDate: Date | undefined) => {
-                    expect(toDate).toEqual(toDate);
-                })
-            );
-        }));
-    });
 });

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewEncapsulation, AfterViewInit, ViewChildren, QueryList} from '@angular/core';
+import {Component, OnInit, ViewEncapsulation, AfterViewInit, ViewChildren, QueryList, ChangeDetectionStrategy, ChangeDetectorRef} from '@angular/core';
 import {DateRangeOptions, PresetItem} from '../model/model';
 import {OverlayRef} from '@angular/cdk/overlay';
 import {ConfigStoreService} from '../services/config-store.service';
@@ -6,33 +6,44 @@ import {DateRange} from '../model/model';
 import {D} from '../../datepicker/datetime/date-formats';
 import {CalendarWrapperComponent} from '../calendar-wrapper/calendar-wrapper.component';
 import {Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
 
 // ** Date range wrapper component */
 @Component({
     selector: 'hc-date-range-picker-overlay',
     templateUrl: './picker-overlay.component.html',
     styleUrls: ['./picker-overlay.component.scss'],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PickerOverlayComponent implements OnInit, AfterViewInit {
     options$: Observable<DateRangeOptions>;
-    _fromDate: D | undefined;
-    _toDate: D | undefined;
-    _selectedPreset: number | null;
+    set _fromDate(fd: D | undefined) { this.__fromDate = fd; this.cd.markForCheck(); }
+    set _toDate(td: D | undefined) { this.__toDate = td; this.cd.markForCheck(); }
+    set _selectedPreset(s: number | null ){ this.__selectedPreset = s; this.cd.markForCheck(); }
+    set _rangeIsInvalid(isInvalid: boolean) { this.__rangeIsInvalid = isInvalid; this.cd.markForCheck(); }
+    get _fromDate(): D | undefined { return this.__fromDate; }
+    get _toDate(): D | undefined { return this.__toDate; }
+    get _selectedPreset(): number | null { return this.__selectedPreset; }
+    get _rangeIsInvalid(): boolean { return this.__rangeIsInvalid; }
     _presetValues: PresetItem[] | undefined;
     _skipRangeCheck: boolean = false;
+
+    __fromDate: D | undefined;
+    __toDate: D | undefined;
+    __selectedPreset: number | null;
+    __rangeIsInvalid: boolean = false; // if true, the fromDate is after the toDate and save will not be allowed
 
     @ViewChildren(CalendarWrapperComponent)
     calendarWrappers: QueryList<CalendarWrapperComponent>;
 
-    constructor(public configStoreService: ConfigStoreService, private overlayRef: OverlayRef) {
+    constructor(public configStoreService: ConfigStoreService, private overlayRef: OverlayRef, private cd: ChangeDetectorRef) {
         this.options$ = configStoreService.dateRangeOptions$;
     }
 
     ngOnInit() {
         this.options$.subscribe((options: DateRangeOptions) => {
             this._presetValues = options.presets;
+            this.cd.markForCheck();
         });
         this.configStoreService.rangeUpdate$.subscribe((dateRange: DateRange) => {
             if (dateRange) {
@@ -42,6 +53,7 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
                 this._fromDate = undefined;
                 this._toDate = undefined;
             }
+            this._validateRange();
         });
         this.configStoreService.presetUpdate$.subscribe((presetIndex: number | DateRange) => {
             if (typeof presetIndex === 'number') {
@@ -62,12 +74,20 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
             this._fromDate = date;
             this._isRangePreset();
         }
+
+        if (this._rangeIsInvalid) {
+            this._validateRange();
+        }
     }
 
     _updateToDate(date?: D) {
         if ( !this._skipRangeCheck ) {
             this._toDate = date;
             this._isRangePreset();
+        }
+
+        if (this._rangeIsInvalid) {
+            this._validateRange();
         }
     }
 
@@ -107,6 +127,8 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
 
     _applyNewDates() {
         if (!!this._toDate && !!this._fromDate) {
+            this._validateRange();
+            if (this._rangeIsInvalid) { return; }
             this.configStoreService.updateRange({fromDate: this._fromDate, toDate: this._toDate});
             if (this._selectedPreset !== null) {
                 this.configStoreService.updatePreset(this._selectedPreset);
@@ -117,37 +139,11 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
         this.overlayRef.dispose();
     }
 
+    _validateRange() {
+        this._rangeIsInvalid = (!!this._fromDate && !!this._toDate) && this._fromDate > this._toDate;
+    }
+
     _discardNewDates() {
         this.overlayRef.dispose();
-    }
-
-    get _fromMaxDate(): Observable<Date | undefined> {
-        return this.options$.pipe(
-            map(options => {
-                if (!options || !options.fromMinMax || !options.fromMinMax.toDate) {
-                    return this._toDate;
-                }
-                if (!this._toDate) {
-                    return options.fromMinMax.toDate;
-                }
-
-                return options.fromMinMax.toDate > this._toDate ? this._toDate : options.fromMinMax.toDate;
-            })
-        );
-    }
-
-    get _ToMinDate(): Observable<Date | undefined> {
-        return this.options$.pipe(
-            map(options => {
-                if (!options || !options.toMinMax || !options.toMinMax.fromDate) {
-                    return this._fromDate;
-                }
-                if (!this._fromDate) {
-                    return options.toMinMax.fromDate;
-                }
-
-                return options.toMinMax.fromDate < this._fromDate ? this._fromDate : options.toMinMax.fromDate;
-            })
-        );
     }
 }

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
@@ -19,7 +19,7 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
     options$: Observable<DateRangeOptions>;
     set _fromDate(fd: D | undefined) { this.__fromDate = fd; this.cd.markForCheck(); }
     set _toDate(td: D | undefined) { this.__toDate = td; this.cd.markForCheck(); }
-    set _selectedPreset(s: number | null ){ this.__selectedPreset = s; this.cd.markForCheck(); }
+    set _selectedPreset(s: number | null ) { this.__selectedPreset = s; this.cd.markForCheck(); }
     set _rangeIsInvalid(isInvalid: boolean) { this.__rangeIsInvalid = isInvalid; this.cd.markForCheck(); }
     get _fromDate(): D | undefined { return this.__fromDate; }
     get _toDate(): D | undefined { return this.__toDate; }

--- a/projects/cashmere/src/lib/sass/date-range.scss
+++ b/projects/cashmere/src/lib/sass/date-range.scss
@@ -17,6 +17,7 @@
 
 @mixin hc-date-range-menu() {
     height: 100%;
+    width: 250px;
 }
 
 @mixin hc-date-range-controls() {
@@ -26,7 +27,7 @@
 }
 
 @mixin hc-date-range-control() {
-    min-width: 100px !important;
+    min-width: 120px !important;
 }
 
 @mixin hc-date-range-overlay() {
@@ -42,6 +43,15 @@
 
 @mixin hc-date-range-presets() {
     padding-left: 21px;
+}
+
+@mixin hc-date-range-warning-icon() {
+    flex: 1 0 auto;
+    width: 16px;
+    height: 16px;
+    margin-right: 10px;
+    background-repeat: no-repeat;
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4xLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA3OS41IDcwLjEiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDc5LjUgNzAuMTsiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4NCgkuc3Qwe2ZpbGw6Izk1MUMxRTt9DQo8L3N0eWxlPg0KPHRpdGxlPndhcm48L3RpdGxlPg0KPHBhdGggY2xhc3M9InN0MCIgZD0iTTc4LjgsNjIuOEw0NCwyLjRjLTEuMy0yLjMtNC4zLTMuMS02LjctMS44Yy0wLjcsMC40LTEuNCwxLTEuOCwxLjhMMC43LDYyLjhjLTEuMywyLjMtMC41LDUuMywxLjgsNi43DQoJYzAuNywwLjQsMS42LDAuNywyLjQsMC43aDY5LjdjMi43LDAsNC45LTIuMiw0LjktNC45Qzc5LjUsNjQuNCw3OS4yLDYzLjUsNzguOCw2Mi44eiBNMzUuMiwyMC43aDkuMnYyNS43aC05LjJWMjAuN3ogTTM5LjcsNjAuOA0KCWMtMy4xLDAtNS42LTIuNS01LjYtNS42czIuNS01LjYsNS42LTUuNnM1LjYsMi41LDUuNiw1LjZDNDUuNCw1OC4yLDQyLjgsNjAuOCwzOS43LDYwLjh6Ii8+DQo8L3N2Zz4NCg==');
 }
 
 @mixin hc-calendar-wrapper-form-field-wrapper() {


### PR DESCRIPTION
warn about date range being invalid on save, instead of locking the ui while selecting dates

fix #1244 