### PR TITLE
1258 popover menu highlight bug

### DIFF
--- a/projects/cashmere/src/lib/pop/directives/menu.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/menu.directive.ts
@@ -24,7 +24,9 @@ export class MenuDirective implements AfterContentInit, OnDestroy {
                 this._subMenus.forEach((sub: HcPopoverAnchorDirective) => {
                     if (sub !== anchor && sub.attachedPopover.isOpen()) {
                         sub.attachedPopover._parentCloseBlock = true;
+                        sub.attachedPopover._restoreFocusOverride = false;
                         sub.closePopover();
+                        sub.attachedPopover._restoreFocusOverride = true;
                         let closeSub: Subscription = sub.attachedPopover.afterClose.subscribe(() => {
                             sub.attachedPopover._parentCloseBlock = false;
                             closeSub.unsubscribe();

--- a/projects/cashmere/src/lib/pop/directives/menu.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/menu.directive.ts
@@ -25,7 +25,7 @@ export class MenuDirective implements AfterContentInit, OnDestroy {
                     if (sub !== anchor && sub.attachedPopover.isOpen()) {
                         sub.attachedPopover._parentCloseBlock = true;
                         sub.attachedPopover._restoreFocusOverride = false;
-                        sub.closePopover();
+                        sub.closePopover({}, true);
                         sub.attachedPopover._restoreFocusOverride = true;
                         let closeSub: Subscription = sub.attachedPopover.afterClose.subscribe(() => {
                             sub.attachedPopover._parentCloseBlock = false;

--- a/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
@@ -166,11 +166,11 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
     /** Handle keyboard navigation of a hcMenu using the arrow or tab keys */
     _keyEvent(event: KeyboardEvent): void {
         if (this.attachedPopover.isOpen() && this.attachedPopover._menuItems.length > 0 && !this.attachedPopover._subMenuOpen) {
-            if (event.keyCode === KEY_CODE.UP_ARROW) {
+            if (event.keyCode === KEY_CODE.UP_ARROW || (event.keyCode === KEY_CODE.TAB && event.shiftKey)) {
                 event.stopPropagation();
                 event.preventDefault();
                 this.attachedPopover._keyFocus(false);
-            } else if (event.keyCode === KEY_CODE.DOWN_ARROW || event.keyCode === KEY_CODE.TAB) {
+            } else if (event.keyCode === KEY_CODE.DOWN_ARROW || (event.keyCode === KEY_CODE.TAB && !event.shiftKey)) {
                 event.stopPropagation();
                 event.preventDefault();
                 this.attachedPopover._keyFocus(true);
@@ -184,6 +184,7 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
             event.stopPropagation();
             event.preventDefault();
             this.openPopover();
+            this.attachedPopover._keyFocus(true);
         }
     }
 
@@ -203,8 +204,8 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
     }
 
     /** Closes the popover. */
-    closePopover(value?: any): void {
-        this._anchoring.closePopover(value);
+    closePopover(value?: any, neighborSubMenusAreOpen: boolean = false): void {
+        this._anchoring.closePopover(value, neighborSubMenusAreOpen);
     }
 
     /** Realign the popover to the anchor. */

--- a/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
@@ -137,9 +137,9 @@ export class HcPopoverAnchoringService implements OnDestroy {
     }
 
     /** Closes the popover. */
-    closePopover(value?: any): void {
+    closePopover(value?: any, neighborSubMenusAreOpen: boolean = false): void {
         if (this._popover._componentOverlay) {
-            this._saveClosedState(value);
+            this._saveClosedState(value, neighborSubMenusAreOpen);
             this._popover._componentOverlay.detach();
             this._popover._restoreFocusAndDestroyTrap();
         }
@@ -326,11 +326,11 @@ export class HcPopoverAnchoringService implements OnDestroy {
     }
 
     /** Save the closed state of the popover and emit. */
-    private _saveClosedState(value?: any): void {
+    private _saveClosedState(value?: any, neighborSubMenusAreOpen: boolean = false): void {
         if (this._popoverOpen) {
             this._popover._open = this._popoverOpen = false;
             if ( this._popover.parent ) {
-                this._popover.parent._subMenuOpen = false;
+                this._popover.parent._subMenuOpen = neighborSubMenusAreOpen;
             }
             this.popoverClosed.next(value);
             this._popover.closed.emit(value);

--- a/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
@@ -132,6 +132,7 @@ export class HcPopoverAnchoringService implements OnDestroy {
             this._subscribeToEscape();
             this._subscribeToDetachments();
             this._saveOpenedState();
+            this._popover._savePreviouslyFocusedElement();
         }
     }
 
@@ -140,6 +141,7 @@ export class HcPopoverAnchoringService implements OnDestroy {
         if (this._popover._componentOverlay) {
             this._saveClosedState(value);
             this._popover._componentOverlay.detach();
+            this._popover._restoreFocusAndDestroyTrap();
         }
     }
 

--- a/projects/cashmere/src/lib/pop/popover.component.ts
+++ b/projects/cashmere/src/lib/pop/popover.component.ts
@@ -443,26 +443,8 @@ export class HcPopComponent implements OnInit, OnDestroy {
         }
     }
 
-    /** Move the focus inside the focus trap and remember where to return later. */
-    private _trapFocus(): void {
-        this._savePreviouslyFocusedElement();
-
-        // There won't be a focus trap element if the close animation starts before open finishes
-        if (!this._focusTrapElement) {
-            return;
-        }
-
-        if (!this._focusTrap && this._focusTrapElement) {
-            this._focusTrap = this._focusTrapFactory.create(this._focusTrapElement.nativeElement);
-        }
-
-        if (this.autoFocus && this._focusTrap) {
-            this._focusTrap.focusInitialElementWhenReady();
-        }
-    }
-
     /** Restore focus to the element focused before the popover opened. Also destroy trap. */
-    private _restoreFocusAndDestroyTrap(): void {
+    _restoreFocusAndDestroyTrap(): void {
         const toFocus = this._previouslyFocusedElement;
 
         // Must check active element is focusable for IE sake
@@ -479,9 +461,25 @@ export class HcPopComponent implements OnInit, OnDestroy {
     }
 
     /** Save a reference to the element focused before the popover was opened. */
-    private _savePreviouslyFocusedElement(): void {
+    _savePreviouslyFocusedElement(): void {
         if (this._document) {
             this._previouslyFocusedElement = this._document.activeElement as HTMLElement;
+        }
+    }
+
+    /** Move the focus inside the focus trap and remember where to return later. */
+    private _trapFocus(): void {
+        // There won't be a focus trap element if the close animation starts before open finishes
+        if (!this._focusTrapElement) {
+            return;
+        }
+
+        if (!this._focusTrap && this._focusTrapElement) {
+            this._focusTrap = this._focusTrapFactory.create(this._focusTrapElement.nativeElement);
+        }
+
+        if (this.autoFocus && this._focusTrap) {
+            this._focusTrap.focusInitialElementWhenReady();
         }
     }
 


### PR DESCRIPTION
closes #1258 

Also add some minor tweaks to enhance the keyboard navigation experience:

- shift + tab navigates you in reverse order as expected (forward tabbing was already working great)
- hitting the right arrow when on a menu item that has a submenu pops you over to the submenu. feels a little more natural and snappy to me, but let me know if it doesn't feel right to you