### PR TITLE
fix(navbar): .active style correction

### DIFF
--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -111,7 +111,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         background-color: darken($navbar-color, 5%);
     }
     &:active:not(.inactive),
-    &.active {
+    &.active:not(.inactive) {
         color: $navbar-text;
         font-weight: 600;
         border-bottom: 5px solid $navbar-brand;


### PR DESCRIPTION
navbarlinks only display .active style when .inactive isn't present

ugh - I wasn't able to test this in context until I pushed the new build.  Didn't realize that navbarlinks can have both `.active` and `.inactive` classes attached at the same time.  So I'm rolling back one line I changed in my navbar PR yesterday and will update the build.