### PR TITLE
fix(accordion): accordion multiline toolbar

### DIFF
--- a/projects/cashmere/src/lib/sass/accordion.scss
+++ b/projects/cashmere/src/lib/sass/accordion.scss
@@ -1,4 +1,3 @@
-$accordion-toolbar-padding: 0 10px;
 $accordion-caret-img: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNi45NzgiIGhlaWdodD0iMTcuMzE5IiB2aWV3Qm94PSIwIDAgMjYuOTc4IDE3LjMxOSI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogIzAwYWVmZjsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHBhdGggaWQ9IlBhdGhfNSIgZGF0YS1uYW1lPSJQYXRoIDUiIGNsYXNzPSJjbHMtMSIgZD0iTTI4LjE3NS0xMi4xODhhMS4wODEsMS4wODEsMCwwLDAsMC0xLjUyM0wyNS40LTE2LjQ3M2ExLjA2MSwxLjA2MSwwLDAsMC0xLjUwNywwTDE1LTcuNTg0bC04Ljg5LTguODlhMS4wNjEsMS4wNjEsMCwwLDAtMS41MDcsMEwxLjgyNS0xMy43MTFhMS4wODEsMS4wODEsMCwwLDAsMCwxLjUyM0wxNC4yNDcuMjE4YTEuMDYxLDEuMDYxLDAsMCwwLDEuNTA3LDBaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMS41MTEgMTYuNzg3KSIvPgo8L3N2Zz4K';
 
 @mixin hc-accordion() {
@@ -12,6 +11,7 @@ $accordion-caret-img: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy5
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
+    align-items: center;
 }
 
 @mixin hc-accordion-toolbar-wrapper-pointer {
@@ -67,9 +67,7 @@ $accordion-caret-img: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy5
     box-sizing: border-box;
     display: flex;
     flex-direction: row;
-    flex-wrap: nowrap;
-    padding: $accordion-toolbar-padding;
-    white-space: nowrap;
+    flex-wrap: wrap;
     width: 100%;
 }
 
@@ -79,5 +77,5 @@ $accordion-caret-img: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy5
 
 @mixin hc-accordion-content() {
     outline: 0;
-    padding: 12px;
+    padding: 12px 0;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -66,6 +66,7 @@ body {
     .hc-accordion-toolbar {
         color: $dark-blue;
         font-weight: 600;
+        padding: 0 10px;
     }
 }
 


### PR DESCRIPTION
Accordion can line-wrap multiple lines of text in the toolbar.  Also eliminated some unnecessary horizontal padding from the toolbar and content area.  I suspect most devs were overriding these values to clear them - but I left the vertical padding on the content area so this wouldn't be a visual break for those who weren't overriding.

closes #1322