### PR TITLE
feat(pagination): displayWidth parameter

### DIFF
--- a/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.html
+++ b/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.html
@@ -1,5 +1,18 @@
 <hc-form-field> <hc-label>Total number of items:</hc-label> <input hcInput type="number" [(ngModel)]="totalItems" /> </hc-form-field>
 <hc-form-field> <hc-label>Page number:</hc-label> <input hcInput type="number" [(ngModel)]="pageNumber" /> </hc-form-field>
 <hc-form-field> <hc-label>Page size:</hc-label> <input hcInput type="number" [(ngModel)]="pageSize" /> </hc-form-field>
+<hc-form-field>
+    <hc-label>Display width:</hc-label>
+    <hc-select [formControl]="widthControl">
+        <option value="lg">Large</option>
+        <option value="md">Medium</option>
+        <option value="sm">Small</option>
+    </hc-select>
+</hc-form-field>
 
-<hc-pagination [(pageNumber)]="pageNumber" [(pageSize)]="pageSize" [length]="totalItems"></hc-pagination>
+<hc-pagination
+    [(pageNumber)]="pageNumber"
+    [(pageSize)]="pageSize"
+    [length]="totalItems"
+    [displayWidth]="widthControl.value">
+</hc-pagination>

--- a/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.ts
+++ b/projects/cashmere-examples/src/lib/pagination-simple/pagination-simple-example.component.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 /**
  * @title Simple pagination
@@ -11,6 +12,7 @@ export class PaginationSimpleExampleComponent {
     _pageNumber: number = 8;
     pageSize: number = 100;
     totalItems: number = 1000;
+    widthControl = new FormControl('lg');
 
     get pageNumber() {
         return this._pageNumber;

--- a/projects/cashmere/src/lib/pagination/pagination.component.html
+++ b/projects/cashmere/src/lib/pagination/pagination.component.html
@@ -21,32 +21,36 @@
             <span class="hc-page-button-chevron hc-page-button-chevron-left"></span>
             <span>PREV</span>
         </button>
-        <!-- page navigation buttons to appear normally -->
-        <button
-            hc-button
-            color="secondary"
-            class="hc-page-button hc-page-inner-button expanded-page-button"
-            *ngFor="let page of _visiblePages"
-            [disabled]="!page"
-            [class.hc-page-button-current]="page === pageNumber"
-            (click)="_goToPage(page)"
-        >
-            <span *ngIf="!!page">{{ page }}</span>
-            <span *ngIf="!page" class="hc-page-button-ellipsis"></span>
-        </button>
-        <!-- page navigation buttons to appear when space is limited -->
-        <button
-            hc-button
-            color="secondary"
-            class="hc-page-button hc-page-inner-button collapsed-page-button"
-            *ngFor="let page of _collapsedVisiblePages"
-            [disabled]="!page"
-            [class.hc-page-button-current]="page === pageNumber"
-            (click)="_goToPage(page)"
-        >
-            <span *ngIf="!!page">{{ page }}</span>
-            <span *ngIf="!page" class="hc-page-button-ellipsis"></span>
-        </button>
+        <!-- large width page navigation buttons -->
+        <ng-container *ngIf="displayWidth === 'lg'">
+            <button
+                hc-button
+                color="secondary"
+                class="hc-page-button hc-page-inner-button"
+                *ngFor="let page of _visiblePages"
+                [disabled]="!page"
+                [class.hc-page-button-current]="page === pageNumber"
+                (click)="_goToPage(page)"
+            >
+                <span *ngIf="!!page">{{ page }}</span>
+                <span *ngIf="!page" class="hc-page-button-ellipsis"></span>
+            </button>
+        </ng-container>
+        <!-- medium width page navigation buttons -->
+        <ng-container *ngIf="displayWidth === 'md'">
+            <button
+                hc-button
+                color="secondary"
+                class="hc-page-button hc-page-inner-button"
+                *ngFor="let page of _collapsedVisiblePages"
+                [disabled]="!page"
+                [class.hc-page-button-current]="page === pageNumber"
+                (click)="_goToPage(page)"
+            >
+                <span *ngIf="!!page">{{ page }}</span>
+                <span *ngIf="!page" class="hc-page-button-ellipsis"></span>
+            </button>
+        </ng-container>
         <button
             hc-button
             color="secondary"

--- a/projects/cashmere/src/lib/pagination/pagination.component.scss
+++ b/projects/cashmere/src/lib/pagination/pagination.component.scss
@@ -42,32 +42,24 @@
     .hc-page-left-button {
         @include hc-page-left-button();
     }
-    
+
     .hc-page-right-button {
         @include hc-page-right-button();
     }
-    
+
     .hc-page-inner-button {
         @include hc-page-inner-button();
     }
-    
+
     .hc-page-button-chevron {
         @include hc-page-button-chevron();
     }
-    
+
     .hc-page-button-chevron-left {
         @include hc-page-button-chevron-left();
     }
-    
+
     .hc-page-button-ellipsis {
         @include hc-page-button-ellipsis();
-    }
-    
-    .expanded-page-button {
-        @include hc-page-button-expanded();
-    }
-    
-    .collapsed-page-button {
-        @include hc-page-button-collapsed();
     }
 }

--- a/projects/cashmere/src/lib/pagination/pagination.component.ts
+++ b/projects/cashmere/src/lib/pagination/pagination.component.ts
@@ -29,6 +29,11 @@ export class PaginationComponent extends BasePaginationComponent implements OnIn
     /** Displayed set of page size options. Will be sorted and include current page size. */
     _displayedPageSizeOptions: number[] = [];
 
+    /** Sets the controller to a specific width type - `lg`, `md`, or `sm`. Typically adjusted in a window
+     * resize listener for responsive layouts. *Defaults to lg.* */
+    @Input()
+    displayWidth: 'lg' | 'md' | 'sm' = 'lg';
+
     /** Whether to hide the page size selection UI from the user. *Defaults to false.* */
     @Input()
     get hidePageSize(): boolean {

--- a/projects/cashmere/src/lib/sass/pagination.scss
+++ b/projects/cashmere/src/lib/sass/pagination.scss
@@ -124,22 +124,6 @@
     width: 11px;
 }
 
-@mixin hc-page-button-expanded() {
-    display: block;
-
-    @include media-breakpoint-down(md) {
-        display: none;
-    }
-}
-
-@mixin hc-page-button-collapsed() {
-    display: none;
-
-    @include media-breakpoint-down(md) {
-        display: block;
-    }
-}
-
 @mixin hc-page-load-more-button() {
     display: block;
     margin: 20px auto;


### PR DESCRIPTION
Allows the component to control how much space it's buttons take up.

@corykon I liked this approach better than trying to build logic into the component to decide its size.  Feels like its better to give that control to the developer.

So we've got three sizes to choose from - `lg` is the current display (it's huge), `md` is the compressed version the would switch on the 768px break point, and `sm` just shows the prev and next buttons.

@CameronAFaust - FYI this is probably going to cause a collision with your PR because I updated the pagination-simple example - but I did make sure add the new setting as a FormControl :-)

closes #1323