### PR TITLE
fix(navbar): active style on navbar-dropdown

### DIFF
--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -205,6 +205,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         margin-left: 5px;
         vertical-align: top;
         margin-top: 1px;
+        margin-right: -10px;
         font-size: 13px !important;
     }
 
@@ -213,6 +214,11 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         outline: none;
         color: $navbar-text;
         background-color: darken($navbar-color, 5%);
+    }
+    &.active:not(.inactive) {
+        color: $navbar-text;
+        font-weight: 600;
+        border-bottom: 5px solid $navbar-brand;
     }
 
     // This piece of code allows to use the bold styling from the style guide, while


### PR DESCRIPTION
Underline wasn't appearing when active property was set on navbar-dropdowns