### PR TITLE
build(new:example): add new example generation script

### DIFF
--- a/guides/working-with-examples.md
+++ b/guides/working-with-examples.md
@@ -12,6 +12,16 @@ Adding meaningful examples can greatly enrich the documentation of components in
 
 :::
 
+##### Creating a new example
+
+From the root of the Cashmere repository, run `npm run new:example`. This will start an interactive prompt to gather all the information needed to create your example.
+
+_Please don't mess with any of the generated names in the files, otherwise your example may not work on the documentation site and/or StackBlitz._
+
+:::
+
+:::
+
 ##### Example files
 
 The following files are used in the creation of examples for the Cashmere documentation website.
@@ -31,38 +41,5 @@ The following files are used in the creation of examples for the Cashmere docume
 -   `projects/cashmere-examples/src/lib/examples.generated.module.ts` - the generated module file containing all the examples, imported into the documentation site for rendering the examples
 -   `projects/cashmere-examples/src/project-template` - the directory containing Angular CLI project files used in the StackBlitz
 -   `scripts/build-examples.ts` - the script used to generate the support files needed for the docs site and StackBlitz
-
-:::
-
-:::
-
-##### Creating a new example
-
-_Please pay close attention to the naming conventions used here, otherwise your example may not work on the documentation site and/or StackBlitz._
-
-1. Name the example (the [hardest part](https://bit.ly/2VI8ZI5)). Figure out what you want the title of the example to be on the documentation site.
-2. Derive the example name from the example title by converting it to kebab case (for instance, if your example is titled "Format Hard Drive", the example name would be `format-hard-drive`)
-3. Create a directory under `projects/cashmere-examples/src/lib/` named your example name, i.e. `projects/cashmere-examples/src/lib/format-hard-drive`
-4. Create the component file `{EXAMPLE_NAME}-example.component.ts`, i.e. `projects/cashmere-examples/src/lib/format-hard-drive/format-hard-drive-example.component.ts`
-5. In the example component, export the example class `{EXAMPLE_NAME}ExampleComponent`, i.e. `FormatHardDriveExampleComponent`
-6. Add the corresponding HTML template file and (only if needed) the SCSS style file and register them with the component, i.e. `format-hard-drive-example.component.html`
-7. Register your example with the appropriate component(s) by adding the example name to the list of examples in `src/app/core/document-items.service.ts`. For example, you may add your example to the SubNav component examples by adding it thus:
-    ```
-    {id: 'subnav', name: 'Subnav', examples: ['subnav-overview', 'format-hard-drive']},
-    ```
-8. If you are creating an example to a new Cashmere component, make sure that the corresponding module is added to `src/app/shared/cashmere.module.ts`. The example build process will use this file to generate the `CashmereModule` for both the example modules as well as the StackBlitz project.
-9. Implement your example.
-
-:::
-
-:::
-
-##### Creating a more complex example
-
-Sometimes your example needs more than a single component, such as when you are demonstrating modals. In this case you can create an example module file named `{EXAMPLE_NAME}-example.module.ts` which will declare all components used in your example. When doing this it is important to do the following in your module file:
-
--   Make sure the exported class name is `{EXAMPLE_NAME}ExampleModule`
--   Import both `CommonModule` from `@angular/common` and `CashmereModule` from `../cashmere.module`
--   In addition to any normal `entryComponents` you wire up (such as modal components), also include the main example component in `entryComponents`. This way the component can be created dynamically by the docs site.
 
 :::

--- a/guides/working-with-examples.md
+++ b/guides/working-with-examples.md
@@ -30,7 +30,7 @@ The following files are used in the creation of examples for the Cashmere docume
 
 -   `projects/cashmere-examples/src/lib/{EXAMPLE_NAME}` - the directory containing all files for an example
 -   `src/app/shared/cashmere.module.ts` - the `CashmereModule` for the documentation site, which is also used in the examples
--   `src/app/core/document-items.service.ts` - the service that associates examples with components for display on the docs site
+-   `src/app/core/cashmere-components-document-items.json` or `src/app/core/cashmere-bits-document-items.json` - the documentation metadata files
 
 ### Files used in the build process (which you shouldn't need to modify)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,6 +1103,28 @@
                 "tslib": "^1.9.0"
             }
         },
+        "@apollo/react-common": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
+            "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+            "dev": true,
+            "requires": {
+                "ts-invariant": "^0.4.4",
+                "tslib": "^1.10.0"
+            }
+        },
+        "@apollo/react-hooks": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
+            "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
+            "dev": true,
+            "requires": {
+                "@apollo/react-common": "^3.1.4",
+                "@wry/equality": "^0.1.9",
+                "ts-invariant": "^0.4.4",
+                "tslib": "^1.10.0"
+            }
+        },
         "@babel/code-frame": {
             "version": "7.5.5",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -1284,6 +1306,116 @@
                 "@babel/types": "^7.10.1"
             }
         },
+        "@babel/helper-builder-react-jsx": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
+            "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+                    "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+                    "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-builder-react-jsx-experimental": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
+            "integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/types": "^7.10.5"
+            },
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+                    "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-module-imports": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+                    "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+                    "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
         "@babel/helper-compilation-targets": {
             "version": "7.10.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.2.tgz",
@@ -1325,6 +1457,214 @@
                     "version": "1.1.58",
                     "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
                     "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+            "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-member-expression-to-functions": "^7.10.5",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+                    "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+                    "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.4",
+                        "@babel/template": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+                    "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-member-expression-to-functions": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+                    "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0"
+                    }
+                },
+                "@babel/helper-optimise-call-expression": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+                    "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+                    "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.10.4",
+                        "@babel/helper-optimise-call-expression": "^7.10.4",
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+                    "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+                    "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+                    "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/parser": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+                    "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/generator": "^7.11.0",
+                        "@babel/helper-function-name": "^7.10.4",
+                        "@babel/helper-split-export-declaration": "^7.11.0",
+                        "@babel/parser": "^7.11.0",
+                        "@babel/types": "^7.11.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.19"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+                    "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
                     "dev": true
                 }
             }
@@ -1482,6 +1822,46 @@
                 "@babel/types": "^7.10.1"
             }
         },
+        "@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+            "integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.0"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+                    "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
         "@babel/helper-split-export-declaration": {
             "version": "7.10.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
@@ -1556,6 +1936,35 @@
                 "@babel/plugin-syntax-async-generators": "^7.8.0"
             }
         },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+            "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-proposal-decorators": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
+            "integrity": "sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-decorators": "^7.8.3"
+            }
+        },
         "@babel/plugin-proposal-dynamic-import": {
             "version": "7.10.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.1.tgz",
@@ -1564,6 +1973,24 @@
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.1",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-export-namespace-from": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
+            "integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-json-strings": {
@@ -1576,6 +2003,24 @@
                 "@babel/plugin-syntax-json-strings": "^7.8.0"
             }
         },
+        "@babel/plugin-proposal-logical-assignment-operators": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
+            "integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-proposal-nullish-coalescing-operator": {
             "version": "7.10.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.1.tgz",
@@ -1584,6 +2029,24 @@
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.1",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
@@ -1617,6 +2080,24 @@
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0"
             }
         },
+        "@babel/plugin-proposal-private-methods": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
+            "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-proposal-unicode-property-regex": {
             "version": "7.10.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.1.tgz",
@@ -1636,6 +2117,49 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
+        "@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+            "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-syntax-decorators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.10.4.tgz",
+            "integrity": "sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-syntax-dynamic-import": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
@@ -1643,6 +2167,49 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-export-namespace-from": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-flow": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.10.4.tgz",
+            "integrity": "sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-syntax-import-meta": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -1654,6 +2221,40 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
+        "@babel/plugin-syntax-jsx": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
+            "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-syntax-nullish-coalescing-operator": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
@@ -1661,6 +2262,23 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -1697,6 +2315,23 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.1"
+            }
+        },
+        "@babel/plugin-syntax-typescript": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz",
+            "integrity": "sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-arrow-functions": {
@@ -1807,6 +2442,16 @@
             "requires": {
                 "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.1",
                 "@babel/helper-plugin-utils": "^7.10.1"
+            }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.9.0.tgz",
+            "integrity": "sha512-7Qfg0lKQhEHs93FChxVLAvhBshOPQDtJUTVHr/ZwQNRccCm4O9D79r9tVSoV8iNwjP1YgfD+e/fgHcPkN1qEQg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-flow": "^7.8.3"
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -1938,6 +2583,171 @@
                 "@babel/helper-plugin-utils": "^7.10.1"
             }
         },
+        "@babel/plugin-transform-react-constant-elements": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.10.4.tgz",
+            "integrity": "sha512-cYmQBW1pXrqBte1raMkAulXmi7rjg3VI6ZLg9QIic8Hq7BtYXaWuZSxsr2siOMI6SWwpxjWfnwhTUrd7JlAV7g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-react-display-name": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
+            "integrity": "sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-react-jsx": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
+            "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-react-jsx": "^7.10.4",
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-react-jsx-development": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.10.4.tgz",
+            "integrity": "sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-react-jsx-self": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.4.tgz",
+            "integrity": "sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-react-jsx-source": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.5.tgz",
+            "integrity": "sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-react-pure-annotations": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.4.tgz",
+            "integrity": "sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+                    "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+                    "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-transform-regenerator": {
             "version": "7.10.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
@@ -1954,6 +2764,29 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.1"
+            }
+        },
+        "@babel/plugin-transform-runtime": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
+            "integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.1"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
@@ -2001,6 +2834,42 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.1"
+            }
+        },
+        "@babel/plugin-transform-typescript": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.11.0.tgz",
+            "integrity": "sha512-edJsNzTtvb3MaXQwj8403B7mZoGu9ElDJQZOKjGUnvilquxBA3IQoEIOvkX/1O8xfAsnHS/oQhe2w/IXrr+w0w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.5",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-typescript": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-unicode-escapes": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
+            "integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -2078,6 +2947,52 @@
                 "semver": "^5.5.0"
             }
         },
+        "@babel/preset-modules": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+            "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            }
+        },
+        "@babel/preset-react": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.10.4.tgz",
+            "integrity": "sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-transform-react-display-name": "^7.10.4",
+                "@babel/plugin-transform-react-jsx": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-development": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-self": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-source": "^7.10.4",
+                "@babel/plugin-transform-react-pure-annotations": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/preset-typescript": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz",
+            "integrity": "sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-transform-typescript": "^7.9.0"
+            }
+        },
         "@babel/runtime": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
@@ -2091,6 +3006,24 @@
                     "version": "0.13.3",
                     "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
                     "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/runtime-corejs3": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.0.tgz",
+            "integrity": "sha512-K0ioacsw8JgzDSPpUiGWokMvLzGvnZPXLrTsJfyHPrFsnp4yoKn+Ap/8NNZgWKZG9o5+qotH8tAa8AXn8gTN5A==",
+            "dev": true,
+            "requires": {
+                "core-js-pure": "^3.0.0",
+                "regenerator-runtime": "^0.13.4"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
                     "dev": true
                 }
             }
@@ -2215,6 +3148,30 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
                     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true
+        },
+        "@cnakazawa/watch": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+            "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+            "dev": true,
+            "requires": {
+                "exec-sh": "^0.3.2",
+                "minimist": "^1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 }
             }
@@ -2998,11 +3955,1344 @@
             "integrity": "sha512-wo2rHprtDzTHf4tiSxavktJ52ntiwmg7eHNGFLH38G1of8OfGVwOc1sVbpM4jN/HK/rCMhYOi6xzoPqsv0537A==",
             "dev": true
         },
+        "@dabh/diagnostics": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+            "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+            "dev": true,
+            "requires": {
+                "colorspace": "1.1.x",
+                "enabled": "2.0.x",
+                "kuler": "^2.0.0"
+            }
+        },
+        "@graphql-modules/core": {
+            "version": "0.7.17",
+            "resolved": "https://registry.npmjs.org/@graphql-modules/core/-/core-0.7.17.tgz",
+            "integrity": "sha512-hGJa1VIsIHTKJ0Hc5gJfFrdhHAF1Vm+LWYeMNC5mPbVd/IZA1wVSpdLDjjliylLI6GnVRu1YreS2gXvFNXPJFA==",
+            "dev": true,
+            "requires": {
+                "@graphql-modules/di": "0.7.17",
+                "@graphql-toolkit/common": "0.10.6",
+                "@graphql-toolkit/schema-merging": "0.10.6",
+                "apollo-server-caching": "0.5.1",
+                "deepmerge": "4.2.2",
+                "graphql-tools": "5.0.0",
+                "tslib": "2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+                    "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-modules/di": {
+            "version": "0.7.17",
+            "resolved": "https://registry.npmjs.org/@graphql-modules/di/-/di-0.7.17.tgz",
+            "integrity": "sha512-Lq5sd/3RO+bNb8wVnAg43LWbwrqD57D0AVEqZlqiTwUj1f0mITtQdGMRN7g2sG79U7ngoaQx8VK/IiKh8E1OFQ==",
+            "dev": true,
+            "requires": {
+                "events": "3.1.0",
+                "tslib": "2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+                    "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-toolkit/common": {
+            "version": "0.10.6",
+            "resolved": "https://registry.npmjs.org/@graphql-toolkit/common/-/common-0.10.6.tgz",
+            "integrity": "sha512-rrH/KPheh/wCZzqUmNayBHd+aNWl/751C4iTL/327TzONdAVrV7ZQOyEkpGLW6YEFWPIlWxNkaBoEALIjCxTGg==",
+            "dev": true,
+            "requires": {
+                "aggregate-error": "3.0.1",
+                "camel-case": "4.1.1",
+                "graphql-tools": "5.0.0",
+                "lodash": "4.17.15"
+            },
+            "dependencies": {
+                "aggregate-error": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+                    "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+                    "dev": true,
+                    "requires": {
+                        "clean-stack": "^2.0.0",
+                        "indent-string": "^4.0.0"
+                    }
+                },
+                "camel-case": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+                    "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+                    "dev": true,
+                    "requires": {
+                        "pascal-case": "^3.1.1",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "clean-stack": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+                    "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+                    "dev": true
+                },
+                "indent-string": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+                    "dev": true
+                },
+                "lower-case": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+                    "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "no-case": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+                    "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^2.0.1",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "pascal-case": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+                    "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+                    "dev": true,
+                    "requires": {
+                        "no-case": "^3.0.3",
+                        "tslib": "^1.10.0"
+                    }
+                }
+            }
+        },
+        "@graphql-toolkit/schema-merging": {
+            "version": "0.10.6",
+            "resolved": "https://registry.npmjs.org/@graphql-toolkit/schema-merging/-/schema-merging-0.10.6.tgz",
+            "integrity": "sha512-BNABgYaNCw4Li3EiH/x7oDpkN+ml3M0SWqjnsW1Pf2NcyfGlv033Bda+O/q4XYtseZ0OOOh52GLXtUgwyPFb8A==",
+            "dev": true,
+            "requires": {
+                "@graphql-toolkit/common": "0.10.6",
+                "deepmerge": "4.2.2",
+                "graphql-tools": "5.0.0",
+                "tslib": "1.11.1"
+            }
+        },
+        "@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                }
+            }
+        },
         "@istanbuljs/schema": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
             "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
             "dev": true
+        },
+        "@jest/console": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.2.0.tgz",
+            "integrity": "sha512-mXQfx3nSLwiHm1i7jbu+uvi+vvpVjNGzIQYLCfsat9rapC+MJkS4zBseNrgJE0vU921b3P67bQzhduphjY3Tig==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^26.2.0",
+                "jest-util": "^26.2.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/core": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.2.2.tgz",
+            "integrity": "sha512-UwA8gNI8aeV4FHGfGAUfO/DHjrFVvlBravF1Tm9Kt6qFE+6YHR47kFhgdepOFpADEKstyO+MVdPvkV6/dyt9sA==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.2.0",
+                "@jest/reporters": "^26.2.2",
+                "@jest/test-result": "^26.2.0",
+                "@jest/transform": "^26.2.2",
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-changed-files": "^26.2.0",
+                "jest-config": "^26.2.2",
+                "jest-haste-map": "^26.2.2",
+                "jest-message-util": "^26.2.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.2.2",
+                "jest-resolve-dependencies": "^26.2.2",
+                "jest-runner": "^26.2.2",
+                "jest-runtime": "^26.2.2",
+                "jest-snapshot": "^26.2.2",
+                "jest-util": "^26.2.0",
+                "jest-validate": "^26.2.0",
+                "jest-watcher": "^26.2.0",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^2.1.0",
+                "rimraf": "^3.0.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "camelcase": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "jest-validate": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.2.0.tgz",
+                    "integrity": "sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "camelcase": "^6.0.0",
+                        "chalk": "^4.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "leven": "^3.1.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "leven": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+                    "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/environment": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.2.0.tgz",
+            "integrity": "sha512-oCgp9NmEiJ5rbq9VI/v/yYLDpladAAVvFxZgNsnJxOETuzPZ0ZcKKHYjKYwCtPOP1WCrM5nmyuOhMStXFGHn+g==",
+            "dev": true,
+            "requires": {
+                "@jest/fake-timers": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "jest-mock": "^26.2.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/fake-timers": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.2.0.tgz",
+            "integrity": "sha512-45Gfe7YzYTKqTayBrEdAF0qYyAsNRBzfkV0IyVUm3cx7AsCWlnjilBM4T40w7IXT5VspOgMPikQlV0M6gHwy/g==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "@sinonjs/fake-timers": "^6.0.1",
+                "@types/node": "*",
+                "jest-message-util": "^26.2.0",
+                "jest-mock": "^26.2.0",
+                "jest-util": "^26.2.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/globals": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.2.0.tgz",
+            "integrity": "sha512-Hoc6ScEIPaym7RNytIL2ILSUWIGKlwEv+JNFof9dGYOdvPjb2evEURSslvCMkNuNg1ECEClTE8PH7ULlMJntYA==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "expect": "^26.2.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/reporters": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.2.2.tgz",
+            "integrity": "sha512-7854GPbdFTAorWVh+RNHyPO9waRIN6TcvCezKVxI1khvFq9YjINTW7J3WU+tbR038Ynn6WjYred6vtT0YmIWVQ==",
+            "dev": true,
+            "requires": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^26.2.0",
+                "@jest/test-result": "^26.2.0",
+                "@jest/transform": "^26.2.2",
+                "@jest/types": "^26.2.0",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.2.4",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.3",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "jest-haste-map": "^26.2.2",
+                "jest-resolve": "^26.2.2",
+                "jest-util": "^26.2.0",
+                "jest-worker": "^26.2.1",
+                "node-notifier": "^7.0.0",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^4.0.1",
+                "terminal-link": "^2.0.0",
+                "v8-to-istanbul": "^4.1.3"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "istanbul-lib-coverage": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+                    "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+                    "dev": true
+                },
+                "istanbul-lib-instrument": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+                    "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.7.5",
+                        "@istanbuljs/schema": "^0.1.2",
+                        "istanbul-lib-coverage": "^3.0.0",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "istanbul-lib-report": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+                    "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+                    "dev": true,
+                    "requires": {
+                        "istanbul-lib-coverage": "^3.0.0",
+                        "make-dir": "^3.0.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+                    "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.1.1",
+                        "istanbul-lib-coverage": "^3.0.0",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "istanbul-reports": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+                    "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+                    "dev": true,
+                    "requires": {
+                        "html-escaper": "^2.0.0",
+                        "istanbul-lib-report": "^3.0.0"
+                    }
+                },
+                "jest-worker": {
+                    "version": "26.2.1",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.2.1.tgz",
+                    "integrity": "sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "make-dir": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^6.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "string-length": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+                    "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+                    "dev": true,
+                    "requires": {
+                        "char-regex": "^1.0.2",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/source-map": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.1.0.tgz",
+            "integrity": "sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.4",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "callsites": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/test-result": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.2.0.tgz",
+            "integrity": "sha512-kgPlmcVafpmfyQEu36HClK+CWI6wIaAWDHNxfQtGuKsgoa2uQAYdlxjMDBEa3CvI40+2U3v36gQF6oZBkoKatw==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/test-sequencer": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.2.2.tgz",
+            "integrity": "sha512-SliZWon5LNqV/lVXkeowSU6L8++FGOu3f43T01L1Gv6wnFDP00ER0utV9jyK9dVNdXqfMNCN66sfcyar/o7BNw==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^26.2.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.2.2",
+                "jest-runner": "^26.2.2",
+                "jest-runtime": "^26.2.2"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/transform": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.2.2.tgz",
+            "integrity": "sha512-c1snhvi5wRVre1XyoO3Eef5SEWpuBCH/cEbntBUd9tI5sNYiBDmO0My/lc5IuuGYKp/HFIHV1eZpSx5yjdkhKw==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^26.2.0",
+                "babel-plugin-istanbul": "^6.0.0",
+                "chalk": "^4.0.0",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.2.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-util": "^26.2.0",
+                "micromatch": "^4.0.2",
+                "pirates": "^4.0.1",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "^3.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "write-file-atomic": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+                    "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+                    "dev": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4",
+                        "is-typedarray": "^1.0.0",
+                        "signal-exit": "^3.0.2",
+                        "typedarray-to-buffer": "^3.1.5"
+                    }
+                }
+            }
+        },
+        "@jest/types": {
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+            "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^1.1.1",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "@microsoft/applicationinsights-analytics-js": {
             "version": "2.3.1",
@@ -4494,10 +6784,1181 @@
             "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
             "dev": true
         },
+        "@sinonjs/commons": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+            "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+            "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
         "@stackblitz/sdk": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@stackblitz/sdk/-/sdk-1.3.0.tgz",
             "integrity": "sha512-dTqbGKHLowJokC+mbjHMH/9mEd0AJCxOXmsfuKGEWOjnVTnxHjJKXL+bL/vxBSjMwBaUFPUNGmHojPPd2OxADQ=="
+        },
+        "@svgr/babel-plugin-add-jsx-attribute": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
+            "integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-remove-jsx-attribute": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
+            "integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-remove-jsx-empty-expression": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
+            "integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-replace-jsx-attribute-value": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
+            "integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-svg-dynamic-title": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
+            "integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-svg-em-dimensions": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
+            "integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-transform-react-native-svg": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
+            "integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-transform-svg-component": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.4.0.tgz",
+            "integrity": "sha512-zLl4Fl3NvKxxjWNkqEcpdSOpQ3LGVH2BNFQ6vjaK6sFo2IrSznrhURIPI0HAphKiiIwNYjAfE0TNoQDSZv0U9A==",
+            "dev": true
+        },
+        "@svgr/babel-preset": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.4.0.tgz",
+            "integrity": "sha512-Gyx7cCxua04DBtyILTYdQxeO/pwfTBev6+eXTbVbxe4HTGhOUW6yo7PSbG2p6eJMl44j6XSequ0ZDP7bl0nu9A==",
+            "dev": true,
+            "requires": {
+                "@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+                "@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
+                "@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+                "@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+                "@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+                "@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+                "@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+                "@svgr/babel-plugin-transform-svg-component": "^5.4.0"
+            }
+        },
+        "@svgr/core": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.4.0.tgz",
+            "integrity": "sha512-hWGm1DCCvd4IEn7VgDUHYiC597lUYhFau2lwJBYpQWDirYLkX4OsXu9IslPgJ9UpP7wsw3n2Ffv9sW7SXJVfqQ==",
+            "dev": true,
+            "requires": {
+                "@svgr/plugin-jsx": "^5.4.0",
+                "camelcase": "^6.0.0",
+                "cosmiconfig": "^6.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+                    "dev": true
+                },
+                "cosmiconfig": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+                    "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/parse-json": "^4.0.0",
+                        "import-fresh": "^3.1.0",
+                        "parse-json": "^5.0.0",
+                        "path-type": "^4.0.0",
+                        "yaml": "^1.7.2"
+                    }
+                },
+                "import-fresh": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+                    "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+                    "dev": true,
+                    "requires": {
+                        "parent-module": "^1.0.0",
+                        "resolve-from": "^4.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+                    "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
+        "@svgr/hast-util-to-babel-ast": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.4.0.tgz",
+            "integrity": "sha512-+U0TZZpPsP2V1WvVhqAOSTk+N+CjYHdZx+x9UBa1eeeZDXwH8pt0CrQf2+SvRl/h2CAPRFkm+Ey96+jKP8Bsgg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.9.5"
+            }
+        },
+        "@svgr/plugin-jsx": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.4.0.tgz",
+            "integrity": "sha512-SGzO4JZQ2HvGRKDzRga9YFSqOqaNrgLlQVaGvpZ2Iht2gwRp/tq+18Pvv9kS9ZqOMYgyix2LLxZMY1LOe9NPqw==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.7.5",
+                "@svgr/babel-preset": "^5.4.0",
+                "@svgr/hast-util-to-babel-ast": "^5.4.0",
+                "svg-parser": "^2.0.2"
+            }
+        },
+        "@svgr/plugin-svgo": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.4.0.tgz",
+            "integrity": "sha512-3Cgv3aYi1l6SHyzArV9C36yo4kgwVdF3zPQUC6/aCDUeXAofDYwE5kk3e3oT5ZO2a0N3lB+lLGvipBG6lnG8EA==",
+            "dev": true,
+            "requires": {
+                "cosmiconfig": "^6.0.0",
+                "merge-deep": "^3.0.2",
+                "svgo": "^1.2.2"
+            },
+            "dependencies": {
+                "cosmiconfig": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+                    "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/parse-json": "^4.0.0",
+                        "import-fresh": "^3.1.0",
+                        "parse-json": "^5.0.0",
+                        "path-type": "^4.0.0",
+                        "yaml": "^1.7.2"
+                    }
+                },
+                "import-fresh": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+                    "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+                    "dev": true,
+                    "requires": {
+                        "parent-module": "^1.0.0",
+                        "resolve-from": "^4.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+                    "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
+        "@svgr/webpack": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.4.0.tgz",
+            "integrity": "sha512-LjepnS/BSAvelnOnnzr6Gg0GcpLmnZ9ThGFK5WJtm1xOqdBE/1IACZU7MMdVzjyUkfFqGz87eRE4hFaSLiUwYg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.9.0",
+                "@babel/plugin-transform-react-constant-elements": "^7.9.0",
+                "@babel/preset-env": "^7.9.5",
+                "@babel/preset-react": "^7.9.4",
+                "@svgr/core": "^5.4.0",
+                "@svgr/plugin-jsx": "^5.4.0",
+                "@svgr/plugin-svgo": "^5.4.0",
+                "loader-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/compat-data": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
+                    "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
+                    "dev": true,
+                    "requires": {
+                        "browserslist": "^4.12.0",
+                        "invariant": "^2.2.4",
+                        "semver": "^5.5.0"
+                    }
+                },
+                "@babel/core": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.0.tgz",
+                    "integrity": "sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/generator": "^7.11.0",
+                        "@babel/helper-module-transforms": "^7.11.0",
+                        "@babel/helpers": "^7.10.4",
+                        "@babel/parser": "^7.11.0",
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.11.0",
+                        "@babel/types": "^7.11.0",
+                        "convert-source-map": "^1.7.0",
+                        "debug": "^4.1.0",
+                        "gensync": "^1.0.0-beta.1",
+                        "json5": "^2.1.2",
+                        "lodash": "^4.17.19",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+                    "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-annotate-as-pure": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+                    "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-builder-binary-assignment-operator-visitor": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+                    "integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-explode-assignable-expression": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-compilation-targets": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
+                    "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/compat-data": "^7.10.4",
+                        "browserslist": "^4.12.0",
+                        "invariant": "^2.2.4",
+                        "levenary": "^1.1.1",
+                        "semver": "^5.5.0"
+                    }
+                },
+                "@babel/helper-create-regexp-features-plugin": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
+                    "integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.10.4",
+                        "@babel/helper-regex": "^7.10.4",
+                        "regexpu-core": "^4.7.0"
+                    }
+                },
+                "@babel/helper-define-map": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+                    "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "^7.10.4",
+                        "@babel/types": "^7.10.5",
+                        "lodash": "^4.17.19"
+                    }
+                },
+                "@babel/helper-explode-assignable-expression": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
+                    "integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+                    "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.4",
+                        "@babel/template": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+                    "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-hoist-variables": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+                    "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-member-expression-to-functions": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+                    "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0"
+                    }
+                },
+                "@babel/helper-module-imports": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+                    "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-module-transforms": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+                    "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.10.4",
+                        "@babel/helper-replace-supers": "^7.10.4",
+                        "@babel/helper-simple-access": "^7.10.4",
+                        "@babel/helper-split-export-declaration": "^7.11.0",
+                        "@babel/template": "^7.10.4",
+                        "@babel/types": "^7.11.0",
+                        "lodash": "^4.17.19"
+                    }
+                },
+                "@babel/helper-optimise-call-expression": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+                    "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+                    "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+                    "dev": true
+                },
+                "@babel/helper-regex": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+                    "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.19"
+                    }
+                },
+                "@babel/helper-remap-async-to-generator": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
+                    "integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.10.4",
+                        "@babel/helper-wrap-function": "^7.10.4",
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+                    "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.10.4",
+                        "@babel/helper-optimise-call-expression": "^7.10.4",
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-simple-access": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+                    "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+                    "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/helper-wrap-function": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+                    "integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "^7.10.4",
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helpers": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+                    "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+                    "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+                    "dev": true
+                },
+                "@babel/plugin-proposal-async-generator-functions": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+                    "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-remap-async-to-generator": "^7.10.4",
+                        "@babel/plugin-syntax-async-generators": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-proposal-dynamic-import": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+                    "integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-proposal-json-strings": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+                    "integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/plugin-syntax-json-strings": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-proposal-nullish-coalescing-operator": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
+                    "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-proposal-object-rest-spread": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+                    "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                        "@babel/plugin-transform-parameters": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-proposal-optional-catch-binding": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+                    "integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-proposal-optional-chaining": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
+                    "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
+                        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-proposal-unicode-property-regex": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+                    "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-syntax-top-level-await": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+                    "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-arrow-functions": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+                    "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-async-to-generator": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+                    "integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-remap-async-to-generator": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-block-scoped-functions": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+                    "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-block-scoping": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
+                    "integrity": "sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-classes": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+                    "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.10.4",
+                        "@babel/helper-define-map": "^7.10.4",
+                        "@babel/helper-function-name": "^7.10.4",
+                        "@babel/helper-optimise-call-expression": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-replace-supers": "^7.10.4",
+                        "@babel/helper-split-export-declaration": "^7.10.4",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/plugin-transform-computed-properties": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+                    "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-destructuring": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+                    "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-dotall-regex": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+                    "integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-duplicate-keys": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+                    "integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-exponentiation-operator": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+                    "integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-for-of": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+                    "integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-function-name": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+                    "integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-literals": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+                    "integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-member-expression-literals": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+                    "integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-modules-amd": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+                    "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.10.5",
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "babel-plugin-dynamic-import-node": "^2.3.3"
+                    }
+                },
+                "@babel/plugin-transform-modules-commonjs": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+                    "integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-simple-access": "^7.10.4",
+                        "babel-plugin-dynamic-import-node": "^2.3.3"
+                    }
+                },
+                "@babel/plugin-transform-modules-systemjs": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+                    "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-hoist-variables": "^7.10.4",
+                        "@babel/helper-module-transforms": "^7.10.5",
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "babel-plugin-dynamic-import-node": "^2.3.3"
+                    }
+                },
+                "@babel/plugin-transform-modules-umd": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+                    "integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-named-capturing-groups-regex": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+                    "integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-new-target": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+                    "integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-object-super": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+                    "integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-replace-supers": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-parameters": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+                    "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-property-literals": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+                    "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-regenerator": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+                    "integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-transform": "^0.14.2"
+                    }
+                },
+                "@babel/plugin-transform-reserved-words": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+                    "integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-shorthand-properties": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+                    "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-spread": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
+                    "integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+                    }
+                },
+                "@babel/plugin-transform-sticky-regex": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+                    "integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/helper-regex": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-template-literals": {
+                    "version": "7.10.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+                    "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-typeof-symbol": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+                    "integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-transform-unicode-regex": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+                    "integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "@babel/preset-env": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
+                    "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/compat-data": "^7.11.0",
+                        "@babel/helper-compilation-targets": "^7.10.4",
+                        "@babel/helper-module-imports": "^7.10.4",
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
+                        "@babel/plugin-proposal-class-properties": "^7.10.4",
+                        "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+                        "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
+                        "@babel/plugin-proposal-json-strings": "^7.10.4",
+                        "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
+                        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+                        "@babel/plugin-proposal-numeric-separator": "^7.10.4",
+                        "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+                        "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
+                        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+                        "@babel/plugin-proposal-private-methods": "^7.10.4",
+                        "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+                        "@babel/plugin-syntax-async-generators": "^7.8.0",
+                        "@babel/plugin-syntax-class-properties": "^7.10.4",
+                        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+                        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+                        "@babel/plugin-syntax-json-strings": "^7.8.0",
+                        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+                        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+                        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+                        "@babel/plugin-syntax-top-level-await": "^7.10.4",
+                        "@babel/plugin-transform-arrow-functions": "^7.10.4",
+                        "@babel/plugin-transform-async-to-generator": "^7.10.4",
+                        "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
+                        "@babel/plugin-transform-block-scoping": "^7.10.4",
+                        "@babel/plugin-transform-classes": "^7.10.4",
+                        "@babel/plugin-transform-computed-properties": "^7.10.4",
+                        "@babel/plugin-transform-destructuring": "^7.10.4",
+                        "@babel/plugin-transform-dotall-regex": "^7.10.4",
+                        "@babel/plugin-transform-duplicate-keys": "^7.10.4",
+                        "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
+                        "@babel/plugin-transform-for-of": "^7.10.4",
+                        "@babel/plugin-transform-function-name": "^7.10.4",
+                        "@babel/plugin-transform-literals": "^7.10.4",
+                        "@babel/plugin-transform-member-expression-literals": "^7.10.4",
+                        "@babel/plugin-transform-modules-amd": "^7.10.4",
+                        "@babel/plugin-transform-modules-commonjs": "^7.10.4",
+                        "@babel/plugin-transform-modules-systemjs": "^7.10.4",
+                        "@babel/plugin-transform-modules-umd": "^7.10.4",
+                        "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
+                        "@babel/plugin-transform-new-target": "^7.10.4",
+                        "@babel/plugin-transform-object-super": "^7.10.4",
+                        "@babel/plugin-transform-parameters": "^7.10.4",
+                        "@babel/plugin-transform-property-literals": "^7.10.4",
+                        "@babel/plugin-transform-regenerator": "^7.10.4",
+                        "@babel/plugin-transform-reserved-words": "^7.10.4",
+                        "@babel/plugin-transform-shorthand-properties": "^7.10.4",
+                        "@babel/plugin-transform-spread": "^7.11.0",
+                        "@babel/plugin-transform-sticky-regex": "^7.10.4",
+                        "@babel/plugin-transform-template-literals": "^7.10.4",
+                        "@babel/plugin-transform-typeof-symbol": "^7.10.4",
+                        "@babel/plugin-transform-unicode-escapes": "^7.10.4",
+                        "@babel/plugin-transform-unicode-regex": "^7.10.4",
+                        "@babel/preset-modules": "^0.1.3",
+                        "@babel/types": "^7.11.0",
+                        "browserslist": "^4.12.0",
+                        "core-js-compat": "^3.6.2",
+                        "invariant": "^2.2.2",
+                        "levenary": "^1.1.1",
+                        "semver": "^5.5.0"
+                    }
+                },
+                "@babel/template": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+                    "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/parser": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+                    "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/generator": "^7.11.0",
+                        "@babel/helper-function-name": "^7.10.4",
+                        "@babel/helper-split-export-declaration": "^7.11.0",
+                        "@babel/parser": "^7.11.0",
+                        "@babel/types": "^7.11.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.19"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+                    "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "browserslist": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
+                    "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001093",
+                        "electron-to-chromium": "^1.3.488",
+                        "escalade": "^3.0.1",
+                        "node-releases": "^1.1.58"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001109",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz",
+                    "integrity": "sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.517",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.517.tgz",
+                    "integrity": "sha512-8wucrMsmXxeBxaM3TPg+YiwIJwPd1IZMudOj1XytmkP3UPXRagMhO9vo4nzzbSWeq91N1zhfUhJW2u9/MVhPxw==",
+                    "dev": true
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "1.1.60",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+                    "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
         },
         "@szmarczak/http-timer": {
             "version": "1.1.2",
@@ -4506,6 +7967,281 @@
             "dev": true,
             "requires": {
                 "defer-to-connect": "^1.0.1"
+            }
+        },
+        "@teambit/any-fs": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@teambit/any-fs/-/any-fs-0.0.5.tgz",
+            "integrity": "sha512-12QEoFIDEnjbAtnINSb84zQ+LiJYYGAE2cUyYqteAtNKp+MtIYAPvoztBkIfikS05yEZqLA/Myyr84cl4g2UYg==",
+            "dev": true,
+            "requires": {
+                "memfs": "3.0.3"
+            },
+            "dependencies": {
+                "memfs": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.0.3.tgz",
+                    "integrity": "sha512-uElu3oR/dM4GeKu86Fqi73eKdafJmmAaxEHx3iSayN+/zvCA0PTcsa6r1QhpN75SqxqdC7rfHqKZzzq3pgKQ5g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-extend": "1.0.2",
+                        "fs-monkey": "0.3.3"
+                    }
+                }
+            }
+        },
+        "@teambit/capsule": {
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/@teambit/capsule/-/capsule-0.0.12.tgz",
+            "integrity": "sha512-ZmKZpBXm9Br6BgiP/KX6u60O+/2kYVuzBWtuh4r05xkqGMtk1yo994aSQIQO0p3XwEe2+NH6FQOWor5DLfLOzw==",
+            "dev": true,
+            "requires": {
+                "@teambit/any-fs": "0.0.5",
+                "lodash": "^4.17.15",
+                "p-limit": "^2.2.1"
+            },
+            "dependencies": {
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@teambit/gitconfig": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@teambit/gitconfig/-/gitconfig-2.0.6.tgz",
+            "integrity": "sha512-Trlh4UXeX9eKSCtVH7g8TQWs++eWjVya98G44q7HzmkFbIIb1QPTfjh8PptKIGc//GRiKC74E5mevOKb05a+OQ==",
+            "dev": true,
+            "requires": {
+                "argx": "^3.0.0",
+                "arrayreduce": "^2.1.0",
+                "askconfig": "^3.0.5",
+                "co": "^4.6.0",
+                "execcli": "^4.0.8",
+                "lodash.get": "^4.4.2",
+                "objnest": "^3.0.6"
+            }
+        },
+        "@teambit/harmony": {
+            "version": "0.0.21",
+            "resolved": "https://registry.npmjs.org/@teambit/harmony/-/harmony-0.0.21.tgz",
+            "integrity": "sha512-6RQDilwsccvNsYA0Z8HVt2d92uiG2b8t5bW/kazIT7oKBNMe7R/L+zXYDddA7F1uxahWvVnPpFz+7LDv/HH73A==",
+            "dev": true,
+            "requires": {
+                "cleargraph": "^5.6.0",
+                "loud-rejection": "^1.6.0",
+                "reflect-metadata": "^0.1.13"
+            }
+        },
+        "@testing-library/jest-dom": {
+            "version": "5.11.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.2.tgz",
+            "integrity": "sha512-s+rWJx+lanEGKqvOl4qJR0rGjCrxsEjj9qjxFlg4NV4/FRD7fnUUAWPHqwpyafNHfLYArs58FADgdn4UKmjFmw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.9.2",
+                "@types/testing-library__jest-dom": "^5.9.1",
+                "aria-query": "^4.2.2",
+                "chalk": "^3.0.0",
+                "css": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "jest-diff": "^25.1.0",
+                "jest-matcher-utils": "^25.1.0",
+                "lodash": "^4.17.15",
+                "redent": "^3.0.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
+                    "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "aria-query": {
+                    "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+                    "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.10.2",
+                        "@babel/runtime-corejs3": "^7.10.2"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "css": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+                    "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.4",
+                        "source-map": "^0.6.1",
+                        "source-map-resolve": "^0.6.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "indent-string": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+                    "dev": true
+                },
+                "redent": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+                    "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+                    "dev": true,
+                    "requires": {
+                        "indent-string": "^4.0.0",
+                        "strip-indent": "^3.0.0"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-resolve": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+                    "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+                    "dev": true,
+                    "requires": {
+                        "atob": "^2.1.2",
+                        "decode-uri-component": "^0.2.0"
+                    }
+                },
+                "strip-indent": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+                    "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+                    "dev": true,
+                    "requires": {
+                        "min-indent": "^1.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@types/abstract-leveldown": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
+            "integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==",
+            "dev": true
+        },
+        "@types/anymatch": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+            "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+            "dev": true
+        },
+        "@types/babel__core": {
+            "version": "7.1.9",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
+            "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "@types/babel__generator": {
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+            "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__template": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+            "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__traverse": {
+            "version": "7.0.13",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
+            "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.0"
             }
         },
         "@types/color-name": {
@@ -4774,6 +8510,12 @@
                 "@types/d3-selection": "*"
             }
         },
+        "@types/eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+            "dev": true
+        },
         "@types/estree": {
             "version": "0.0.43",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.43.tgz",
@@ -4812,6 +8554,21 @@
                 "@types/node": "*"
             }
         },
+        "@types/graceful-fs": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+            "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/html-minifier-terser": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz",
+            "integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA==",
+            "dev": true
+        },
         "@types/inquirer": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.0.tgz",
@@ -4820,6 +8577,31 @@
             "requires": {
                 "@types/through": "*",
                 "rxjs": "^6.4.0"
+            }
+        },
+        "@types/istanbul-lib-coverage": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+            "dev": true
+        },
+        "@types/istanbul-lib-report": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+            "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "@types/istanbul-reports": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+            "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "*",
+                "@types/istanbul-lib-report": "*"
             }
         },
         "@types/jasmine": {
@@ -4837,11 +8619,76 @@
                 "@types/jasmine": "*"
             }
         },
+        "@types/jest": {
+            "version": "26.0.8",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.8.tgz",
+            "integrity": "sha512-eo3VX9jGASSuv680D4VQ89UmuLZneNxv2MCZjfwlInav05zXVJTzfc//lavdV0GPwSxsXJTy2jALscB7Acqg0g==",
+            "dev": true,
+            "requires": {
+                "jest-diff": "^25.2.1",
+                "pretty-format": "^25.2.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                }
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
             "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
             "dev": true
+        },
+        "@types/levelup": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.0.tgz",
+            "integrity": "sha512-h82BoajhjU/zwLoM4BUBX/SCodCFi1ae/ZlFOYh5Z4GbHeaXj9H709fF1LYl/StrK8KSwnJOeMRPo9lnC6sz4w==",
+            "dev": true,
+            "requires": {
+                "@types/abstract-leveldown": "*",
+                "@types/node": "*"
+            }
         },
         "@types/minimatch": {
             "version": "3.0.3",
@@ -4879,6 +8726,37 @@
             "integrity": "sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A==",
             "dev": true
         },
+        "@types/prop-types": {
+            "version": "15.7.3",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+            "dev": true
+        },
+        "@types/proper-lockfile": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
+            "integrity": "sha512-HAjVfDa73pFgivViHyDu8HHHcds+W4MgOuZZAdyFJrHS8ngtCXmhl4hc2YXqSOwO6Bsa+iF2Sgxb2+gv874VOQ==",
+            "dev": true,
+            "requires": {
+                "@types/retry": "*"
+            }
+        },
+        "@types/q": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
+            "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
+            "dev": true
+        },
+        "@types/react": {
+            "version": "16.9.44",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.44.tgz",
+            "integrity": "sha512-BtLoJrXdW8DVZauKP+bY4Kmiq7ubcJq+H/aCpRfvPF7RAT3RwR73Sg8szdc2YasbAlWBDrQ6Q+AFM0KwtQY+WQ==",
+            "dev": true,
+            "requires": {
+                "@types/prop-types": "*",
+                "csstype": "^3.0.2"
+            }
+        },
         "@types/resolve": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
@@ -4900,6 +8778,27 @@
             "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
             "dev": true
         },
+        "@types/stack-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+            "dev": true
+        },
+        "@types/tapable": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+            "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
+            "dev": true
+        },
+        "@types/testing-library__jest-dom": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.2.tgz",
+            "integrity": "sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==",
+            "dev": true,
+            "requires": {
+                "@types/jest": "*"
+            }
+        },
         "@types/through": {
             "version": "0.0.30",
             "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
@@ -4907,6 +8806,23 @@
             "dev": true,
             "requires": {
                 "@types/node": "*"
+            }
+        },
+        "@types/uglify-js": {
+            "version": "3.9.3",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+            "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "@types/unist": {
@@ -4933,6 +8849,28 @@
             "dev": true,
             "requires": {
                 "vfile-message": "*"
+            }
+        },
+        "@types/webpack": {
+            "version": "4.41.21",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
+            "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+            "dev": true,
+            "requires": {
+                "@types/anymatch": "*",
+                "@types/node": "*",
+                "@types/tapable": "*",
+                "@types/uglify-js": "*",
+                "@types/webpack-sources": "*",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "@types/webpack-sources": {
@@ -4968,6 +8906,147 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
             "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
             "dev": true
+        },
+        "@types/yoga-layout": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
+            "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
+            "dev": true
+        },
+        "@types/zen-observable": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+            "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==",
+            "dev": true
+        },
+        "@typescript-eslint/experimental-utils": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+            "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/typescript-estree": "1.13.0",
+                "eslint-scope": "^4.0.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+                    "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.unescape": "4.0.1",
+                        "semver": "5.5.0"
+                    }
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/parser": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+            "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+            "dev": true,
+            "requires": {
+                "@types/eslint-visitor-keys": "^1.0.0",
+                "@typescript-eslint/experimental-utils": "1.13.0",
+                "@typescript-eslint/typescript-estree": "1.13.0",
+                "eslint-visitor-keys": "^1.0.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+                    "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.unescape": "4.0.1",
+                        "semver": "5.5.0"
+                    }
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+            "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "eslint-visitor-keys": "^1.1.0",
+                "glob": "^7.1.6",
+                "is-glob": "^4.0.1",
+                "lodash": "^4.17.15",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                },
+                "tsutils": {
+                    "version": "3.17.1",
+                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+                    "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.8.1"
+                    }
+                }
+            }
+        },
+        "@vuedoc/parser": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@vuedoc/parser/-/parser-2.4.0.tgz",
+            "integrity": "sha512-u706LQhA2TZtEP+cJnS64EjkWUX12HxLLF+wbkozMWLbTZM4WFDWKlbSjtrbetrLqxjeUnNYR9vV8gwoPHmpvQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.3.1",
+                "acorn-bigint": "^1.0.0",
+                "acorn-export-ns-from": "^0.2.0",
+                "acorn-import-meta": "^1.1.0",
+                "acorn-private-class-elements": "^0.2.6",
+                "acorn-stage3": "^3.0.0",
+                "vue-template-compiler": "^2.6.11"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+                    "dev": true
+                }
+            }
         },
         "@webassemblyjs/ast": {
             "version": "1.8.5",
@@ -5145,6 +9224,25 @@
                 "@xtuc/long": "4.2.2"
             }
         },
+        "@wry/context": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+            "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+            "dev": true,
+            "requires": {
+                "@types/node": ">=6",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@wry/equality": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+            "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.3"
+            }
+        },
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5179,11 +9277,48 @@
             "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
             "dev": true
         },
+        "abab": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+            "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+            "dev": true
+        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "dev": true
+        },
+        "abind": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/abind/-/abind-1.0.5.tgz",
+            "integrity": "sha512-dbaEZphdPje0ihqSdWg36Sb8S20TuqQomiz2593oIx+enQ9Q4vDZRjIzhnkWltGRKVKqC28kTribkgRLBexWVQ==",
+            "dev": true
+        },
+        "abstract-leveldown": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+            "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.5.0",
+                "immediate": "^3.2.3",
+                "level-concat-iterator": "~2.0.0",
+                "level-supports": "~1.0.0",
+                "xtend": "~4.0.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                }
+            }
         },
         "accepts": {
             "version": "1.3.7",
@@ -5199,6 +9334,112 @@
             "version": "6.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
             "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+            "dev": true
+        },
+        "acorn-bigint": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-bigint/-/acorn-bigint-1.0.0.tgz",
+            "integrity": "sha512-AEbe7S7TA5Y89pbc+g5kjWcG/9CiW+fYBKQRd2+ihwCgp8cIol1J5ewHsQOCAIs+K3KEmpaLQixoAyy0sLkSJg==",
+            "dev": true
+        },
+        "acorn-class-fields": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.6.tgz",
+            "integrity": "sha512-nOzMl1byCFAJLgxNUG7QorpzRHWlkBKVSSOMKUu+bVbVZG5lU4NZkOp/uA7CnE+NAsWhmxTsMgQdHsQXUO8Ulg==",
+            "dev": true,
+            "requires": {
+                "acorn-private-class-elements": "^0.2.6"
+            }
+        },
+        "acorn-export-ns-from": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-export-ns-from/-/acorn-export-ns-from-0.2.0.tgz",
+            "integrity": "sha512-LG4/nZsdkOG59wmW2zC1stmwl4t0/4dS0K7aptQrTxFdmkyOo0DKqbG1eeuP9uLTCjlfJmiBmlJTzR/JIM03xw==",
+            "dev": true
+        },
+        "acorn-globals": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+            "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-import-meta": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-meta/-/acorn-import-meta-1.1.0.tgz",
+            "integrity": "sha512-pshgiVR5mhpjFVdizKTN+kAGRqjJFUOEB3TvpQ6kiAutb1lvHrIVVcGoe5xzMpJkVNifCeymMG7/tsDkWn8CdQ==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+            "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+            "dev": true
+        },
+        "acorn-logical-assignment": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/acorn-logical-assignment/-/acorn-logical-assignment-0.1.3.tgz",
+            "integrity": "sha512-tLFK3+HWerA2rAJaY02LRtDeO0/nwgw6Wn1EZwO8cNZRbZiwBxKo4V5rJEoVSfBvEqXo44JaiA2Q9ycYx+y7qQ==",
+            "dev": true
+        },
+        "acorn-numeric-separator": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.3.tgz",
+            "integrity": "sha512-xMbqqXR9EnxuGN1N6CbU+sm/sKS+VSttTnU6aRf9klvZF/P5E5BMtR3xZfSFWbVIkd4uXGKfgZJZwZ73zpExXQ==",
+            "dev": true
+        },
+        "acorn-private-class-elements": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.6.tgz",
+            "integrity": "sha512-PV+AhOU1/vCx5zIBgGYLB5+OoT8IPKZUcWEGdLBTQgFBMMzPM9S5SKSG4EdiuULqoq3pV3C07rGuSC1Y5gbi/g==",
+            "dev": true
+        },
+        "acorn-private-methods": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.2.tgz",
+            "integrity": "sha512-jTgRNDbEkbtxOIPUmDZ4u4oDGCO4tNPDNeW+jJrkbLl/Hzl9EVLva+kGQ289irSPhxi7FI9TjuXmIiqjnJcj9w==",
+            "dev": true,
+            "requires": {
+                "acorn-private-class-elements": "^0.2.6"
+            }
+        },
+        "acorn-stage3": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-stage3/-/acorn-stage3-3.0.0.tgz",
+            "integrity": "sha512-zS8peaLCVRDxj8kUpJTazea65Ob8wCNb+rSMTj7o0XohrA529YlUESvnTirz2iMX0157Mu2jPHaQB32+Sr79xQ==",
+            "dev": true,
+            "requires": {
+                "acorn-class-fields": "^0.3.6",
+                "acorn-logical-assignment": "^0.1.1",
+                "acorn-numeric-separator": "^0.3.2",
+                "acorn-private-methods": "^0.3.2",
+                "acorn-static-class-features": "^0.2.3"
+            }
+        },
+        "acorn-static-class-features": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.3.tgz",
+            "integrity": "sha512-N7yRI9NduTJRam3BQTXHLR63ykHQv2MnxWTRq0+4PfQosGUz/tM0/ToRqWUqGphP960mDTm/7zJFx3dB/AZtiw==",
+            "dev": true,
+            "requires": {
+                "acorn-private-class-elements": "^0.2.6"
+            }
+        },
+        "acorn-walk": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
             "dev": true
         },
         "after": {
@@ -5377,6 +9618,180 @@
                 "normalize-path": "^2.1.1"
             }
         },
+        "apollo-boost": {
+            "version": "0.4.9",
+            "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.9.tgz",
+            "integrity": "sha512-05y5BKcDaa8w47f8d81UVwKqrAjn8uKLv6QM9fNdldoNzQ+rnOHgFlnrySUZRz9QIT3vPftQkEz2UEASp1Mi5g==",
+            "dev": true,
+            "requires": {
+                "apollo-cache": "^1.3.5",
+                "apollo-cache-inmemory": "^1.6.6",
+                "apollo-client": "^2.6.10",
+                "apollo-link": "^1.0.6",
+                "apollo-link-error": "^1.0.3",
+                "apollo-link-http": "^1.3.1",
+                "graphql-tag": "^2.4.2",
+                "ts-invariant": "^0.4.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "apollo-cache": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
+            "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
+            "dev": true,
+            "requires": {
+                "apollo-utilities": "^1.3.4",
+                "tslib": "^1.10.0"
+            }
+        },
+        "apollo-cache-inmemory": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
+            "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
+            "dev": true,
+            "requires": {
+                "apollo-cache": "^1.3.5",
+                "apollo-utilities": "^1.3.4",
+                "optimism": "^0.10.0",
+                "ts-invariant": "^0.4.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "apollo-client": {
+            "version": "2.6.10",
+            "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
+            "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
+            "dev": true,
+            "requires": {
+                "@types/zen-observable": "^0.8.0",
+                "apollo-cache": "1.3.5",
+                "apollo-link": "^1.0.0",
+                "apollo-utilities": "1.3.4",
+                "symbol-observable": "^1.0.2",
+                "ts-invariant": "^0.4.0",
+                "tslib": "^1.10.0",
+                "zen-observable": "^0.8.0"
+            }
+        },
+        "apollo-link": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+            "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+            "dev": true,
+            "requires": {
+                "apollo-utilities": "^1.3.0",
+                "ts-invariant": "^0.4.0",
+                "tslib": "^1.9.3",
+                "zen-observable-ts": "^0.8.21"
+            }
+        },
+        "apollo-link-error": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
+            "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
+            "dev": true,
+            "requires": {
+                "apollo-link": "^1.2.14",
+                "apollo-link-http-common": "^0.2.16",
+                "tslib": "^1.9.3"
+            }
+        },
+        "apollo-link-http": {
+            "version": "1.5.17",
+            "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
+            "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
+            "dev": true,
+            "requires": {
+                "apollo-link": "^1.2.14",
+                "apollo-link-http-common": "^0.2.16",
+                "tslib": "^1.9.3"
+            }
+        },
+        "apollo-link-http-common": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+            "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
+            "dev": true,
+            "requires": {
+                "apollo-link": "^1.2.14",
+                "ts-invariant": "^0.4.0",
+                "tslib": "^1.9.3"
+            }
+        },
+        "apollo-server-caching": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
+            "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^5.0.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                    "dev": true
+                }
+            }
+        },
+        "apollo-upload-client": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
+            "integrity": "sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.9.2",
+                "apollo-link": "^1.2.12",
+                "apollo-link-http-common": "^0.2.14",
+                "extract-files": "^8.0.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
+                    "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                    "dev": true
+                }
+            }
+        },
+        "apollo-utilities": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+            "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+            "dev": true,
+            "requires": {
+                "@wry/equality": "^0.1.2",
+                "fast-json-stable-stringify": "^2.0.0",
+                "ts-invariant": "^0.4.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "app-module-path": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+            "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+            "dev": true
+        },
         "app-root-path": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
@@ -5422,6 +9837,15 @@
             "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
             "dev": true
         },
+        "argx": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/argx/-/argx-3.0.2.tgz",
+            "integrity": "sha1-G6qI0WCrb1Rrbs4OB1lswrs0JKk=",
+            "dev": true,
+            "requires": {
+                "iftype": "^3.0.0"
+            }
+        },
         "aria-query": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
@@ -5448,6 +9872,18 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-difference": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-difference/-/array-difference-0.0.1.tgz",
+            "integrity": "sha1-x8r9m1SzXrgvcue6MZ6Tij/TKwc=",
+            "dev": true
+        },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
         "array-find-index": {
@@ -5492,6 +9928,12 @@
             "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
             "dev": true
         },
+        "arrayreduce": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arrayreduce/-/arrayreduce-2.1.0.tgz",
+            "integrity": "sha1-6lg24whra1S3pWK0eez4BpyU0Qo=",
+            "dev": true
+        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -5503,6 +9945,18 @@
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
             "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
             "dev": true
+        },
+        "askconfig": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/askconfig/-/askconfig-3.0.5.tgz",
+            "integrity": "sha1-PwcA078U8w44yAH57QDC2Wgqne0=",
+            "dev": true,
+            "requires": {
+                "argx": "^3.0.0",
+                "cli-color": "^1.1.0",
+                "co": "^4.6.0",
+                "objnest": "^3.0.6"
+            }
         },
         "asn1": {
             "version": "0.2.4",
@@ -5571,10 +10025,28 @@
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
             "dev": true
         },
+        "ast-module-types": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.6.0.tgz",
+            "integrity": "sha512-zXSoVaMrf2R+r+ISid5/9a8SXm1LLdkhHzh6pSRhj9jklzruOOl1hva1YmFT33wAstg/f9ZndJAlq1BSrFLSGA==",
+            "dev": true
+        },
+        "ast-types": {
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
+            "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
+            "dev": true
+        },
         "ast-types-flow": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
             "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+            "dev": true
+        },
+        "astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
         "async": {
@@ -5590,6 +10062,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "dev": true
+        },
+        "async-exit-hook": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+            "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
             "dev": true
         },
         "async-foreach": {
@@ -5620,6 +10098,18 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
             "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+            "dev": true
+        },
+        "attempt-x": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.3.tgz",
+            "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A==",
+            "dev": true
+        },
+        "auto-bind": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+            "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
             "dev": true
         },
         "autoprefixer": {
@@ -5712,6 +10202,194 @@
                 "trim-right": "^1.0.1"
             }
         },
+        "babel-jest": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.2.2.tgz",
+            "integrity": "sha512-JmLuePHgA+DSOdOL8lPxCgD2LhPPm+rdw1vnxR73PpIrnmKCS2/aBhtkAcxQWuUcW2hBrH8MJ3LKXE7aWpNZyA==",
+            "dev": true,
+            "requires": {
+                "@jest/transform": "^26.2.2",
+                "@jest/types": "^26.2.0",
+                "@types/babel__core": "^7.1.7",
+                "babel-plugin-istanbul": "^6.0.0",
+                "babel-preset-jest": "^26.2.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "babel-loader": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
+            "integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
+            "dev": true,
+            "requires": {
+                "find-cache-dir": "^2.1.0",
+                "loader-utils": "^1.4.0",
+                "mkdirp": "^0.5.3",
+                "pify": "^4.0.1",
+                "schema-utils": "^2.6.5"
+            },
+            "dependencies": {
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "find-cache-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+                    "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^2.0.0",
+                        "pkg-dir": "^3.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                }
+            }
+        },
         "babel-messages": {
             "version": "6.23.0",
             "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -5728,6 +10406,472 @@
             "dev": true,
             "requires": {
                 "object.assign": "^4.1.0"
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+            "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-instrument": "^4.0.0",
+                "test-exclude": "^6.0.0"
+            },
+            "dependencies": {
+                "istanbul-lib-coverage": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+                    "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+                    "dev": true
+                },
+                "istanbul-lib-instrument": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+                    "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.7.5",
+                        "@istanbuljs/schema": "^0.1.2",
+                        "istanbul-lib-coverage": "^3.0.0",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+            "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.3.3",
+                "@babel/types": "^7.3.3",
+                "@types/babel__core": "^7.0.0",
+                "@types/babel__traverse": "^7.0.6"
+            }
+        },
+        "babel-plugin-macros": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+            "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.7.2",
+                "cosmiconfig": "^6.0.0",
+                "resolve": "^1.12.0"
+            },
+            "dependencies": {
+                "cosmiconfig": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+                    "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/parse-json": "^4.0.0",
+                        "import-fresh": "^3.1.0",
+                        "parse-json": "^5.0.0",
+                        "path-type": "^4.0.0",
+                        "yaml": "^1.7.2"
+                    }
+                },
+                "import-fresh": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+                    "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+                    "dev": true,
+                    "requires": {
+                        "parent-module": "^1.0.0",
+                        "resolve-from": "^4.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+                    "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
+        "babel-plugin-named-asset-import": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz",
+            "integrity": "sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA==",
+            "dev": true
+        },
+        "babel-plugin-transform-react-remove-prop-types": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+            "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
+            "dev": true
+        },
+        "babel-plugin-transform-typescript-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-typescript-metadata/-/babel-plugin-transform-typescript-metadata-0.2.2.tgz",
+            "integrity": "sha512-wWRw1p3IDNZN8l3UOLgeScq9Nhh4lvxT7ZOvUzYi5sMw8lUWW+KdRlnBeQKehHAsgDs5TR6PvMJmsQ6e6NmKCg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "babel-preset-current-node-syntax": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+            "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+            }
+        },
+        "babel-preset-jest": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.2.0.tgz",
+            "integrity": "sha512-R1k8kdP3R9phYQugXeNnK/nvCGlBzG4m3EoIIukC80GXb6wCv2XiwPhK6K9MAkQcMszWBYvl2Wm+yigyXFQqXg==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-jest-hoist": "^26.2.0",
+                "babel-preset-current-node-syntax": "^0.1.2"
+            }
+        },
+        "babel-preset-react-app": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.1.2.tgz",
+            "integrity": "sha512-k58RtQOKH21NyKtzptoAvtAODuAJJs3ZhqBMl456/GnXEQ/0La92pNmwgWoMn5pBTrsvk3YYXdY7zpY4e3UIxA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "7.9.0",
+                "@babel/plugin-proposal-class-properties": "7.8.3",
+                "@babel/plugin-proposal-decorators": "7.8.3",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "7.8.3",
+                "@babel/plugin-proposal-numeric-separator": "7.8.3",
+                "@babel/plugin-proposal-optional-chaining": "7.9.0",
+                "@babel/plugin-transform-flow-strip-types": "7.9.0",
+                "@babel/plugin-transform-react-display-name": "7.8.3",
+                "@babel/plugin-transform-runtime": "7.9.0",
+                "@babel/preset-env": "7.9.0",
+                "@babel/preset-react": "7.9.1",
+                "@babel/preset-typescript": "7.9.0",
+                "@babel/runtime": "7.9.0",
+                "babel-plugin-macros": "2.8.0",
+                "babel-plugin-transform-react-remove-prop-types": "0.4.24"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/core": {
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+                    "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.8.3",
+                        "@babel/generator": "^7.9.0",
+                        "@babel/helper-module-transforms": "^7.9.0",
+                        "@babel/helpers": "^7.9.0",
+                        "@babel/parser": "^7.9.0",
+                        "@babel/template": "^7.8.6",
+                        "@babel/traverse": "^7.9.0",
+                        "@babel/types": "^7.9.0",
+                        "convert-source-map": "^1.7.0",
+                        "debug": "^4.1.0",
+                        "gensync": "^1.0.0-beta.1",
+                        "json5": "^2.1.2",
+                        "lodash": "^4.17.13",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/plugin-proposal-class-properties": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+                    "integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-class-features-plugin": "^7.8.3",
+                        "@babel/helper-plugin-utils": "^7.8.3"
+                    }
+                },
+                "@babel/plugin-proposal-nullish-coalescing-operator": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+                    "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.8.3",
+                        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-proposal-numeric-separator": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+                    "integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.8.3",
+                        "@babel/plugin-syntax-numeric-separator": "^7.8.3"
+                    }
+                },
+                "@babel/plugin-proposal-optional-chaining": {
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+                    "integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.8.3",
+                        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+                    }
+                },
+                "@babel/plugin-transform-react-display-name": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.3.tgz",
+                    "integrity": "sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.8.3"
+                    }
+                },
+                "@babel/preset-env": {
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
+                    "integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/compat-data": "^7.9.0",
+                        "@babel/helper-compilation-targets": "^7.8.7",
+                        "@babel/helper-module-imports": "^7.8.3",
+                        "@babel/helper-plugin-utils": "^7.8.3",
+                        "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+                        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+                        "@babel/plugin-proposal-json-strings": "^7.8.3",
+                        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+                        "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+                        "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+                        "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+                        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+                        "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+                        "@babel/plugin-syntax-async-generators": "^7.8.0",
+                        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+                        "@babel/plugin-syntax-json-strings": "^7.8.0",
+                        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                        "@babel/plugin-syntax-numeric-separator": "^7.8.0",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+                        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+                        "@babel/plugin-syntax-top-level-await": "^7.8.3",
+                        "@babel/plugin-transform-arrow-functions": "^7.8.3",
+                        "@babel/plugin-transform-async-to-generator": "^7.8.3",
+                        "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+                        "@babel/plugin-transform-block-scoping": "^7.8.3",
+                        "@babel/plugin-transform-classes": "^7.9.0",
+                        "@babel/plugin-transform-computed-properties": "^7.8.3",
+                        "@babel/plugin-transform-destructuring": "^7.8.3",
+                        "@babel/plugin-transform-dotall-regex": "^7.8.3",
+                        "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+                        "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+                        "@babel/plugin-transform-for-of": "^7.9.0",
+                        "@babel/plugin-transform-function-name": "^7.8.3",
+                        "@babel/plugin-transform-literals": "^7.8.3",
+                        "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+                        "@babel/plugin-transform-modules-amd": "^7.9.0",
+                        "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+                        "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+                        "@babel/plugin-transform-modules-umd": "^7.9.0",
+                        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+                        "@babel/plugin-transform-new-target": "^7.8.3",
+                        "@babel/plugin-transform-object-super": "^7.8.3",
+                        "@babel/plugin-transform-parameters": "^7.8.7",
+                        "@babel/plugin-transform-property-literals": "^7.8.3",
+                        "@babel/plugin-transform-regenerator": "^7.8.7",
+                        "@babel/plugin-transform-reserved-words": "^7.8.3",
+                        "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+                        "@babel/plugin-transform-spread": "^7.8.3",
+                        "@babel/plugin-transform-sticky-regex": "^7.8.3",
+                        "@babel/plugin-transform-template-literals": "^7.8.3",
+                        "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+                        "@babel/plugin-transform-unicode-regex": "^7.8.3",
+                        "@babel/preset-modules": "^0.1.3",
+                        "@babel/types": "^7.9.0",
+                        "browserslist": "^4.9.1",
+                        "core-js-compat": "^3.6.2",
+                        "invariant": "^2.2.2",
+                        "levenary": "^1.1.1",
+                        "semver": "^5.5.0"
+                    }
+                },
+                "@babel/preset-react": {
+                    "version": "7.9.1",
+                    "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.9.1.tgz",
+                    "integrity": "sha512-aJBYF23MPj0RNdp/4bHnAP0NVqqZRr9kl0NAOP4nJCex6OYVio59+dnQzsAWFuogdLyeaKA1hmfUIVZkY5J+TQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.8.3",
+                        "@babel/plugin-transform-react-display-name": "^7.8.3",
+                        "@babel/plugin-transform-react-jsx": "^7.9.1",
+                        "@babel/plugin-transform-react-jsx-development": "^7.9.0",
+                        "@babel/plugin-transform-react-jsx-self": "^7.9.0",
+                        "@babel/plugin-transform-react-jsx-source": "^7.9.0"
+                    }
+                },
+                "@babel/runtime": {
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz",
+                    "integrity": "sha512-cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "browserslist": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
+                    "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001093",
+                        "electron-to-chromium": "^1.3.488",
+                        "escalade": "^3.0.1",
+                        "node-releases": "^1.1.58"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001109",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz",
+                    "integrity": "sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.517",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.517.tgz",
+                    "integrity": "sha512-8wucrMsmXxeBxaM3TPg+YiwIJwPd1IZMudOj1XytmkP3UPXRagMhO9vo4nzzbSWeq91N1zhfUhJW2u9/MVhPxw==",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "1.1.60",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+                    "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+                    "dev": true
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
             }
         },
         "babel-runtime": {
@@ -5921,6 +11065,1281 @@
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
         },
+        "bit-bin": {
+            "version": "14.8.8",
+            "resolved": "https://registry.npmjs.org/bit-bin/-/bit-bin-14.8.8.tgz",
+            "integrity": "sha512-t7PKK2o72FKW8LHEE7D11uFswljrTJIlwHD4ymG2eEvB6mzIv3POmce5pOTW4FiJEzY9WUA/bXarjHhtmDAzLQ==",
+            "dev": true,
+            "requires": {
+                "@apollo/react-hooks": "^3.1.5",
+                "@babel/core": "^7.9.6",
+                "@babel/preset-react": "^7.10.1",
+                "@babel/runtime": "^7.8.4",
+                "@graphql-modules/core": "^0.7.17",
+                "@svgr/webpack": "^5.4.0",
+                "@teambit/any-fs": "0.0.5",
+                "@teambit/capsule": "0.0.12",
+                "@teambit/gitconfig": "^2.0.6",
+                "@teambit/harmony": "0.0.21",
+                "@testing-library/jest-dom": "^5.9.0",
+                "@types/levelup": "^4.3.0",
+                "@types/proper-lockfile": "^4.1.1",
+                "@types/react": "^16.9.17",
+                "@typescript-eslint/typescript-estree": "^2.29.0",
+                "@vuedoc/parser": "^2.0.0-beta.5",
+                "acorn": "^6.4.1",
+                "ajv": "^6.11.0",
+                "apollo-boost": "^0.4.9",
+                "app-module-path": "^2.2.0",
+                "array-difference": "^0.0.1",
+                "async-exit-hook": "^2.0.1",
+                "babel-jest": "^26.0.1",
+                "babel-loader": "^8.1.0",
+                "babel-plugin-named-asset-import": "^0.3.6",
+                "babel-plugin-transform-typescript-metadata": "^0.2.2",
+                "babel-preset-react-app": "^9.1.2",
+                "babel-runtime": "^6.23.0",
+                "bluebird": "^3.7.2",
+                "chalk": "^2.4.1",
+                "chokidar": "^3.3.1",
+                "cleargraph": "^5.4.0",
+                "cli-spinners": "^1.0.0",
+                "commander": "^2.20.3",
+                "comment-json": "^3.0.2",
+                "cors": "^2.8.5",
+                "css-tree": "^1.0.0-alpha.39",
+                "debounce": "^1.2.0",
+                "debug": "^4.1.1",
+                "decamelize": "^1.2.0",
+                "detect-indent": "^5.0.0",
+                "detect-newline": "^3.1.0",
+                "detective-amd": "^3.0.0",
+                "detective-stylus": "^1.0.0",
+                "didyoumean": "^1.2.1",
+                "doctrine": "^2.0.2",
+                "enhanced-resolve": "^4.1.1",
+                "execa": "^2.1.0",
+                "express": "^4.17.1",
+                "express-graphql": "^0.9.0",
+                "filenamify": "^4.1.0",
+                "find-up": "^2.1.0",
+                "firstline": "^2.0.2",
+                "fs-extra": "^6.0.0",
+                "glob": "^7.1.6",
+                "graphlib": "^2.1.8",
+                "graphql": "^15.1.0",
+                "graphviz": "0.0.9",
+                "group-array": "^1.0.0",
+                "html-webpack-plugin": "^4.3.0",
+                "identity-obj-proxy": "^3.0.0",
+                "ignore": "^3.3.7",
+                "ini-builder": "^1.1.1",
+                "ink": "^2.6.0",
+                "inquirer": "^6.5.0",
+                "inquirer-fuzzy-path": "^2.2.0",
+                "is-array-buffer-x": "^1.0.13",
+                "is-glob": "^4.0.0",
+                "is-relative-path": "^2.0.0",
+                "is-url": "^1.2.4",
+                "isbinaryfile": "^4.0.4",
+                "jest": "^26.0.1",
+                "jest-environment-jsdom-fourteen": "^1.0.1",
+                "jest-watch-typeahead": "^0.6.0",
+                "jfs": "^0.3.0",
+                "level-mem": "^5.0.1",
+                "level-party": "^4.0.0",
+                "lodash": "^4.17.15",
+                "lodash.assignwith": "^4.2.0",
+                "lodash.groupby": "^4.6.0",
+                "lodash.merge": "^4.6.2",
+                "lodash.partition": "^4.6.0",
+                "lodash.set": "^4.3.2",
+                "lodash.toarray": "^4.4.0",
+                "lodash.unionby": "^4.8.0",
+                "lodash.uniqby": "^4.7.0",
+                "loud-rejection": "^1.6.0",
+                "make-fetch-happen": "^4.0.1",
+                "memfs": "2.15.5",
+                "minimatch": "^3.0.4",
+                "mockery": "^2.0.0",
+                "module-definition": "^3.3.0",
+                "module-lookup-amd": "^6.2.0",
+                "needle": "^2.3.2",
+                "node-source-walk": "^4.2.0",
+                "normalize-path": "^2.1.1",
+                "npm-run-all": "^4.1.5",
+                "object-diff": "^0.0.4",
+                "object-hash": "^1.3.0",
+                "open": "^7.0.3",
+                "ora": "^4.0.3",
+                "p-event": "^4.1.0",
+                "p-map-series": "^1.0.0",
+                "p-series": "^2.1.0",
+                "p-wait-for": "^3.1.0",
+                "package-json-validator": "^0.6.3",
+                "pad-right": "^0.2.2",
+                "parents": "^1.0.1",
+                "parse-gitignore": "^1.0.1",
+                "porter-stemmer": "^0.9.1",
+                "prettier-eslint": "^9.0.1",
+                "prettier-eslint-cli": "^5.0.0",
+                "prompt": "^1.0.0",
+                "proper-lockfile": "^4.1.1",
+                "ramda": "^0.24.1",
+                "ramda-adjunct": "^2.25.0",
+                "react": "^16.13.1",
+                "react-app-polyfill": "^1.0.6",
+                "react-docgen": "^5.3.0",
+                "react-dom": "^16.13.1",
+                "react-hot-loader": "^4.12.21",
+                "react-native-web": "^0.12.2",
+                "react-test-renderer": "^16.13.1",
+                "readable-stream": "^3.6.0",
+                "reflect-metadata": "^0.1.13",
+                "regenerator-runtime": "^0.11.0",
+                "requestify": "^0.2.5",
+                "resolve-dependency-path": "^2.0.0",
+                "rxjs": "^6.5.4",
+                "sass-lookup": "^3.0.0",
+                "semver": "^5.4.1",
+                "serialize-error": "^5.0.0",
+                "socket.io": "^2.3.0",
+                "socket.io-client": "^2.3.0",
+                "ssh2": "^0.5.4",
+                "string-format": "^0.5.0",
+                "string-to-color": "^2.1.3",
+                "stringify-package": "^1.0.1",
+                "stylable": "^5.2.2",
+                "stylus-lookup": "^3.0.2",
+                "subleveldown": "^4.1.4",
+                "symlink-or-copy": "^1.3.1",
+                "synchronous-promise": "^2.0.10",
+                "table": "^5.2.3",
+                "tar-stream": "^2.0.1",
+                "tsyringe": "^4.0.1",
+                "tty-table": "^2.8.12",
+                "uid-number": "0.0.6",
+                "unionfs": "^3.0.2",
+                "uniqid": "^5.2.0",
+                "user-home": "^2.0.0",
+                "uuid": "^3.4.0",
+                "v8-compile-cache": "^2.0.2",
+                "validate-npm-package-name": "^3.0.0",
+                "vinyl": "^2.2.0",
+                "vinyl-file": "^3.0.0",
+                "webpack": "^4.43.0",
+                "webpack-dev-server": "^3.11.0",
+                "winston": "^3.2.1",
+                "yn": "^2.0.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/core": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.0.tgz",
+                    "integrity": "sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/generator": "^7.11.0",
+                        "@babel/helper-module-transforms": "^7.11.0",
+                        "@babel/helpers": "^7.10.4",
+                        "@babel/parser": "^7.11.0",
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.11.0",
+                        "@babel/types": "^7.11.0",
+                        "convert-source-map": "^1.7.0",
+                        "debug": "^4.1.0",
+                        "gensync": "^1.0.0-beta.1",
+                        "json5": "^2.1.2",
+                        "lodash": "^4.17.19",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    },
+                    "dependencies": {
+                        "lodash": {
+                            "version": "4.17.19",
+                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+                    "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+                    "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.4",
+                        "@babel/template": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+                    "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-member-expression-to-functions": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+                    "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0"
+                    }
+                },
+                "@babel/helper-module-imports": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+                    "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-module-transforms": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+                    "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.10.4",
+                        "@babel/helper-replace-supers": "^7.10.4",
+                        "@babel/helper-simple-access": "^7.10.4",
+                        "@babel/helper-split-export-declaration": "^7.11.0",
+                        "@babel/template": "^7.10.4",
+                        "@babel/types": "^7.11.0",
+                        "lodash": "^4.17.19"
+                    },
+                    "dependencies": {
+                        "lodash": {
+                            "version": "4.17.19",
+                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@babel/helper-optimise-call-expression": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+                    "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+                    "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.10.4",
+                        "@babel/helper-optimise-call-expression": "^7.10.4",
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-simple-access": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+                    "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+                    "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.11.0"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/helpers": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+                    "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+                    "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+                    "dev": true
+                },
+                "@babel/runtime": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
+                    "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    },
+                    "dependencies": {
+                        "regenerator-runtime": {
+                            "version": "0.13.7",
+                            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                            "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@babel/template": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+                    "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/parser": "^7.10.4",
+                        "@babel/types": "^7.10.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+                    "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/generator": "^7.11.0",
+                        "@babel/helper-function-name": "^7.10.4",
+                        "@babel/helper-split-export-declaration": "^7.11.0",
+                        "@babel/parser": "^7.11.0",
+                        "@babel/types": "^7.11.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.19"
+                    },
+                    "dependencies": {
+                        "lodash": {
+                            "version": "4.17.19",
+                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+                    "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "lodash": {
+                            "version": "4.17.19",
+                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@webassemblyjs/ast": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+                    "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/helper-module-context": "1.9.0",
+                        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                        "@webassemblyjs/wast-parser": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/floating-point-hex-parser": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+                    "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
+                    "dev": true
+                },
+                "@webassemblyjs/helper-api-error": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+                    "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+                    "dev": true
+                },
+                "@webassemblyjs/helper-buffer": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+                    "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
+                    "dev": true
+                },
+                "@webassemblyjs/helper-code-frame": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+                    "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/wast-printer": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/helper-fsm": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+                    "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
+                    "dev": true
+                },
+                "@webassemblyjs/helper-module-context": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+                    "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/helper-wasm-bytecode": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+                    "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+                    "dev": true
+                },
+                "@webassemblyjs/helper-wasm-section": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+                    "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/helper-buffer": "1.9.0",
+                        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                        "@webassemblyjs/wasm-gen": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/ieee754": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+                    "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+                    "dev": true,
+                    "requires": {
+                        "@xtuc/ieee754": "^1.2.0"
+                    }
+                },
+                "@webassemblyjs/leb128": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+                    "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+                    "dev": true,
+                    "requires": {
+                        "@xtuc/long": "4.2.2"
+                    }
+                },
+                "@webassemblyjs/utf8": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+                    "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
+                    "dev": true
+                },
+                "@webassemblyjs/wasm-edit": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+                    "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/helper-buffer": "1.9.0",
+                        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                        "@webassemblyjs/helper-wasm-section": "1.9.0",
+                        "@webassemblyjs/wasm-gen": "1.9.0",
+                        "@webassemblyjs/wasm-opt": "1.9.0",
+                        "@webassemblyjs/wasm-parser": "1.9.0",
+                        "@webassemblyjs/wast-printer": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/wasm-gen": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+                    "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                        "@webassemblyjs/ieee754": "1.9.0",
+                        "@webassemblyjs/leb128": "1.9.0",
+                        "@webassemblyjs/utf8": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/wasm-opt": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+                    "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/helper-buffer": "1.9.0",
+                        "@webassemblyjs/wasm-gen": "1.9.0",
+                        "@webassemblyjs/wasm-parser": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/wasm-parser": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+                    "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/helper-api-error": "1.9.0",
+                        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                        "@webassemblyjs/ieee754": "1.9.0",
+                        "@webassemblyjs/leb128": "1.9.0",
+                        "@webassemblyjs/utf8": "1.9.0"
+                    }
+                },
+                "@webassemblyjs/wast-parser": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+                    "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+                        "@webassemblyjs/helper-api-error": "1.9.0",
+                        "@webassemblyjs/helper-code-frame": "1.9.0",
+                        "@webassemblyjs/helper-fsm": "1.9.0",
+                        "@xtuc/long": "4.2.2"
+                    }
+                },
+                "@webassemblyjs/wast-printer": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+                    "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/wast-parser": "1.9.0",
+                        "@xtuc/long": "4.2.2"
+                    }
+                },
+                "ajv": {
+                    "version": "6.12.3",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+                    "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "async": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+                    "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+                    "dev": true
+                },
+                "binary-extensions": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+                    "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "cacache": {
+                    "version": "11.3.3",
+                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+                    "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.5",
+                        "chownr": "^1.1.1",
+                        "figgy-pudding": "^3.5.1",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.1.15",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.3",
+                        "ssri": "^6.0.1",
+                        "unique-filename": "^1.1.1",
+                        "y18n": "^4.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "detect-indent": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+                    "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+                    "dev": true
+                },
+                "enhanced-resolve": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+                    "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.5.0",
+                        "tapable": "^1.0.0"
+                    }
+                },
+                "execa": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+                    "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^3.0.0",
+                        "onetime": "^5.1.0",
+                        "p-finally": "^2.0.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+                    "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "glob-parent": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+                    "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "ignore": {
+                    "version": "3.3.10",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+                    "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+                    "dev": true
+                },
+                "inquirer": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+                    "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.2.0",
+                        "chalk": "^2.4.2",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.17.12",
+                        "mute-stream": "0.0.7",
+                        "run-async": "^2.2.0",
+                        "rxjs": "^6.4.0",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^5.1.0",
+                        "through": "^2.3.6"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true,
+                    "optional": true
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "is-wsl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+                    "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+                    "dev": true,
+                    "requires": {
+                        "is-docker": "^2.0.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "make-fetch-happen": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.2.tgz",
+                    "integrity": "sha512-YMJrAjHSb/BordlsDEcVcPyTbiJKkzqMf48N8dAJZT9Zjctrkb6Yg4TY9Sq2AwSIQJFn5qBBKVTYt3vP5FMIHA==",
+                    "dev": true,
+                    "requires": {
+                        "agentkeepalive": "^3.4.1",
+                        "cacache": "^11.3.3",
+                        "http-cache-semantics": "^3.8.1",
+                        "http-proxy-agent": "^2.1.0",
+                        "https-proxy-agent": "^2.2.1",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "node-fetch-npm": "^2.0.2",
+                        "promise-retry": "^1.1.1",
+                        "socks-proxy-agent": "^4.0.0",
+                        "ssri": "^6.0.0"
+                    }
+                },
+                "memory-fs": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+                    "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+                    "dev": true,
+                    "requires": {
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.7",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        }
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+                    "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "onetime": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^2.1.0"
+                    }
+                },
+                "open": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/open/-/open-7.1.0.tgz",
+                    "integrity": "sha512-lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==",
+                    "dev": true,
+                    "requires": {
+                        "is-docker": "^2.0.0",
+                        "is-wsl": "^2.1.1"
+                    }
+                },
+                "p-finally": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+                    "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "readdirp": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+                    "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "picomatch": "^2.2.1"
+                    },
+                    "dependencies": {
+                        "picomatch": {
+                            "version": "2.2.2",
+                            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+                            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
+                },
+                "watchpack": {
+                    "version": "1.7.4",
+                    "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+                    "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+                    "dev": true,
+                    "requires": {
+                        "chokidar": "^3.4.1",
+                        "graceful-fs": "^4.1.2",
+                        "neo-async": "^2.5.0",
+                        "watchpack-chokidar2": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "chokidar": {
+                            "version": "3.4.1",
+                            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+                            "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "anymatch": "~3.1.1",
+                                "braces": "~3.0.2",
+                                "fsevents": "~2.1.2",
+                                "glob-parent": "~5.1.0",
+                                "is-binary-path": "~2.1.0",
+                                "is-glob": "~4.0.1",
+                                "normalize-path": "~3.0.0",
+                                "readdirp": "~3.4.0"
+                            }
+                        },
+                        "normalize-path": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "webpack": {
+                    "version": "4.44.1",
+                    "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
+                    "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.9.0",
+                        "@webassemblyjs/helper-module-context": "1.9.0",
+                        "@webassemblyjs/wasm-edit": "1.9.0",
+                        "@webassemblyjs/wasm-parser": "1.9.0",
+                        "acorn": "^6.4.1",
+                        "ajv": "^6.10.2",
+                        "ajv-keywords": "^3.4.1",
+                        "chrome-trace-event": "^1.0.2",
+                        "enhanced-resolve": "^4.3.0",
+                        "eslint-scope": "^4.0.3",
+                        "json-parse-better-errors": "^1.0.2",
+                        "loader-runner": "^2.4.0",
+                        "loader-utils": "^1.2.3",
+                        "memory-fs": "^0.4.1",
+                        "micromatch": "^3.1.10",
+                        "mkdirp": "^0.5.3",
+                        "neo-async": "^2.6.1",
+                        "node-libs-browser": "^2.2.1",
+                        "schema-utils": "^1.0.0",
+                        "tapable": "^1.1.3",
+                        "terser-webpack-plugin": "^1.4.3",
+                        "watchpack": "^1.7.4",
+                        "webpack-sources": "^1.4.1"
+                    },
+                    "dependencies": {
+                        "memory-fs": {
+                            "version": "0.4.1",
+                            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+                            "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+                            "dev": true,
+                            "requires": {
+                                "errno": "^0.1.3",
+                                "readable-stream": "^2.0.1"
+                            }
+                        },
+                        "readable-stream": {
+                            "version": "2.3.7",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        }
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "winston": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+                    "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+                    "dev": true,
+                    "requires": {
+                        "@dabh/diagnostics": "^2.0.2",
+                        "async": "^3.1.0",
+                        "is-stream": "^2.0.0",
+                        "logform": "^2.2.0",
+                        "one-time": "^1.0.0",
+                        "readable-stream": "^3.4.0",
+                        "stack-trace": "0.0.x",
+                        "triple-beam": "^1.3.0",
+                        "winston-transport": "^4.4.0"
+                    }
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                    "dev": true
+                }
+            }
+        },
+        "bl": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+            "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
         "blob": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -5993,6 +12412,18 @@
                 "multicast-dns": "^6.0.1",
                 "multicast-dns-service-types": "^1.1.0"
             }
+        },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
+        "boolify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
+            "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
+            "dev": true
         },
         "bottleneck": {
             "version": "2.19.5",
@@ -6107,10 +12538,25 @@
                 }
             }
         },
+        "breakword": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/breakword/-/breakword-1.0.5.tgz",
+            "integrity": "sha512-ex5W9DoOQ/LUEU3PMdLs9ua/CYZl1678NUkKOdUSi8Aw5F1idieaiRURCBFJCwVcrD1J8Iy3vfWSloaMwO2qFg==",
+            "dev": true,
+            "requires": {
+                "wcwidth": "^1.0.1"
+            }
+        },
         "brorand": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
             "dev": true
         },
         "browserify-aes": {
@@ -6222,6 +12668,15 @@
                 "caniuse-lite": "^1.0.30001023",
                 "electron-to-chromium": "^1.3.341",
                 "node-releases": "^1.1.47"
+            }
+        },
+        "bser": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+            "dev": true,
+            "requires": {
+                "node-int64": "^0.4.0"
             }
         },
         "btoa-lite": {
@@ -6378,6 +12833,12 @@
                 }
             }
         },
+        "cached-constructors-x": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.2.tgz",
+            "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw==",
+            "dev": true
+        },
         "cachedir": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.2.0.tgz",
@@ -6429,6 +12890,12 @@
             "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
             "dev": true
         },
+        "camelcase-css": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-1.0.1.tgz",
+            "integrity": "sha1-FXxCOCZfXPlKHf/ehkRlUsvz9wU=",
+            "dev": true
+        },
         "camelcase-keys": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
@@ -6450,6 +12917,15 @@
             "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz",
             "integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ=",
             "dev": true
+        },
+        "capture-exit": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+            "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+            "dev": true,
+            "requires": {
+                "rsvp": "^4.8.4"
+            }
         },
         "cardinal": {
             "version": "2.1.1",
@@ -6517,6 +12993,12 @@
                 "upper-case": "^1.1.1",
                 "upper-case-first": "^1.1.0"
             }
+        },
+        "char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true
         },
         "character-entities-html4": {
             "version": "1.1.4",
@@ -6734,11 +13216,35 @@
             "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
             "dev": true
         },
+        "cleargraph": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/cleargraph/-/cleargraph-5.7.0.tgz",
+            "integrity": "sha512-s7t6d9DgGReT1oGy+kAxrhcaqLtZ5ZBQ/IVw38yMayTQZFv4EM//Nfht/2ZMSlGaKVywJRqY1EZKYBgeiNZCWg==",
+            "dev": true,
+            "requires": {
+                "graphlib": "^2.1.8",
+                "lodash": "^4.17.15"
+            }
+        },
         "cli-boxes": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
             "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
             "dev": true
+        },
+        "cli-color": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+            "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.1.1",
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "memoizee": "^0.4.14",
+                "timers-ext": "^0.1.5"
+            }
         },
         "cli-cursor": {
             "version": "2.1.0",
@@ -6748,6 +13254,12 @@
             "requires": {
                 "restore-cursor": "^2.0.0"
             }
+        },
+        "cli-spinners": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
+            "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+            "dev": true
         },
         "cli-table": {
             "version": "0.3.1",
@@ -6861,6 +13373,12 @@
             "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
             "dev": true
         },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
+        },
         "clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -6879,6 +13397,40 @@
             "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
+            }
+        },
+        "clone-stats": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+            "dev": true
+        },
+        "cloneable-readable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+            "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "coa": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+            "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+            "dev": true,
+            "requires": {
+                "@types/q": "^1.5.1",
+                "chalk": "^2.4.1",
+                "q": "^1.1.2"
             }
         },
         "code-point-at": {
@@ -6912,6 +13464,12 @@
                 }
             }
         },
+        "collect-v8-coverage": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+            "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+            "dev": true
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -6920,6 +13478,16 @@
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
+            }
+        },
+        "color": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+            "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
             }
         },
         "color-convert": {
@@ -6937,11 +13505,37 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "color-string": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+            "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+            "dev": true,
+            "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
+        },
+        "colornames": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+            "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
+            "dev": true
+        },
         "colors": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
             "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
             "dev": true
+        },
+        "colorspace": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+            "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+            "dev": true,
+            "requires": {
+                "color": "3.0.x",
+                "text-hex": "1.0.x"
+            }
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -6968,6 +13562,26 @@
             "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
             "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
             "dev": true
+        },
+        "comment-json": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-3.0.2.tgz",
+            "integrity": "sha512-ysJasbJ671+8mPEmwLOfLFqxoGtSmjyoep+lKRVH4J1/hsGu79fwetMDQWk8de8mVgqDZ43D7JuJAlACqjI1pg==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "^1.0.2",
+                "esprima": "^4.0.1",
+                "has-own-prop": "^2.0.0",
+                "repeat-string": "^1.6.1"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                }
+            }
         },
         "commitizen": {
             "version": "4.1.2",
@@ -7145,6 +13759,12 @@
                     "dev": true
                 }
             }
+        },
+        "common-tags": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -8259,11 +14879,27 @@
                 }
             }
         },
+        "core-js-pure": {
+            "version": "3.6.5",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+            "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+            "dev": true
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
+        },
+        "cors": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4",
+                "vary": "^1"
+            }
         },
         "cosmiconfig": {
             "version": "5.2.1",
@@ -8400,6 +15036,40 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "create-react-class": {
+            "version": "15.6.3",
+            "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+            "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+            "dev": true,
+            "requires": {
+                "fbjs": "^0.8.9",
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+            },
+            "dependencies": {
+                "core-js": {
+                    "version": "1.2.7",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                    "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+                    "dev": true
+                },
+                "fbjs": {
+                    "version": "0.8.17",
+                    "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+                    "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+                    "dev": true,
+                    "requires": {
+                        "core-js": "^1.0.0",
+                        "isomorphic-fetch": "^2.1.1",
+                        "loose-envify": "^1.0.0",
+                        "object-assign": "^4.1.0",
+                        "promise": "^7.1.1",
+                        "setimmediate": "^1.0.5",
+                        "ua-parser-js": "^0.7.18"
+                    }
+                }
+            }
+        },
         "cross-spawn": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -8455,10 +15125,38 @@
                 }
             }
         },
+        "css-in-js-utils": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+            "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+            "dev": true,
+            "requires": {
+                "hyphenate-style-name": "^1.0.2",
+                "isobject": "^3.0.1"
+            }
+        },
         "css-parse": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
             "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
+            "dev": true
+        },
+        "css-select": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+            "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+            "dev": true,
+            "requires": {
+                "boolbase": "^1.0.0",
+                "css-what": "^3.2.1",
+                "domutils": "^1.7.0",
+                "nth-check": "^1.0.2"
+            }
+        },
+        "css-select-base-adapter": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+            "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
             "dev": true
         },
         "css-selector-tokenizer": {
@@ -8471,6 +15169,42 @@
                 "fastparse": "^1.1.2",
                 "regexpu-core": "^4.6.0"
             }
+        },
+        "css-tree": {
+            "version": "1.0.0-alpha.39",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
+            "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+            "dev": true,
+            "requires": {
+                "mdn-data": "2.0.6",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "mdn-data": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
+                    "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "css-what": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
+            "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==",
+            "dev": true
+        },
+        "css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+            "dev": true
         },
         "cssauron": {
             "version": "1.4.0",
@@ -8485,6 +15219,74 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true
+        },
+        "csso": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
+            "integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
+            "dev": true,
+            "requires": {
+                "css-tree": "1.0.0-alpha.39"
+            }
+        },
+        "cssom": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "dev": true,
+            "requires": {
+                "cssom": "~0.3.6"
+            },
+            "dependencies": {
+                "cssom": {
+                    "version": "0.3.8",
+                    "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                    "dev": true
+                }
+            }
+        },
+        "csstype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
+            "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
+            "dev": true
+        },
+        "csv": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/csv/-/csv-5.3.2.tgz",
+            "integrity": "sha512-odDyucr9OgJTdGM2wrMbJXbOkJx3nnUX3Pt8SFOwlAMOpsUQlz1dywvLMXJWX/4Ib0rjfOsaawuuwfI5ucqBGQ==",
+            "dev": true,
+            "requires": {
+                "csv-generate": "^3.2.4",
+                "csv-parse": "^4.8.8",
+                "csv-stringify": "^5.3.6",
+                "stream-transform": "^2.0.1"
+            }
+        },
+        "csv-generate": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.2.4.tgz",
+            "integrity": "sha512-qNM9eqlxd53TWJeGtY1IQPj90b563Zx49eZs8e0uMyEvPgvNVmX1uZDtdzAcflB3PniuH9creAzcFOdyJ9YGvA==",
+            "dev": true
+        },
+        "csv-parse": {
+            "version": "4.11.1",
+            "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.11.1.tgz",
+            "integrity": "sha512-cH2BG5Gd0u4G8qVI/jGXJSP2+El7Vy91/ZD3ehKALAWids1aIKOPhZ1ZVJzUrs2zTn6aGumVPBlbHsI91kI83A==",
+            "dev": true
+        },
+        "csv-stringify": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.0.tgz",
+            "integrity": "sha512-G05575DSO/9vFzQxZN+Srh30cNyHk0SM0ePyiTChMD5WVt7GMTVPBQf4rtgMF6mqhNCJUPw4pN8LDe8MF9EYOA==",
             "dev": true
         },
         "cuint": {
@@ -8531,6 +15333,16 @@
                 "longest": "^1.0.1",
                 "right-pad": "^1.0.1",
                 "word-wrap": "^1.0.3"
+            }
+        },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
             }
         },
         "d3": {
@@ -8809,6 +15621,17 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "data-urls": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.3",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0"
+            }
+        },
         "date-fns": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
@@ -8825,6 +15648,18 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
             "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true
+        },
+        "de-indent": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+            "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+            "dev": true
+        },
+        "debounce": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+            "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
             "dev": true
         },
         "debug": {
@@ -8858,6 +15693,12 @@
                 "map-obj": "^1.0.0"
             }
         },
+        "decimal.js": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+            "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+            "dev": true
+        },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -8879,6 +15720,15 @@
             "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
             "dev": true
         },
+        "deep-assign": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+            "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+            "dev": true,
+            "requires": {
+                "is-obj": "^1.0.0"
+            }
+        },
         "deep-equal": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -8897,6 +15747,18 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
         },
         "default-gateway": {
@@ -8957,11 +15819,63 @@
                 "strip-bom": "^2.0.0"
             }
         },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "requires": {
+                "clone": "^1.0.2"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                    "dev": true
+                }
+            }
+        },
         "defer-to-connect": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
             "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
             "dev": true
+        },
+        "deferred-leveldown": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+            "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
+            "dev": true,
+            "requires": {
+                "abstract-leveldown": "~6.2.1",
+                "inherits": "^2.0.3"
+            },
+            "dependencies": {
+                "abstract-leveldown": {
+                    "version": "6.2.3",
+                    "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+                    "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+                    "dev": true,
+                    "requires": {
+                        "buffer": "^5.5.0",
+                        "immediate": "^3.2.3",
+                        "level-concat-iterator": "~2.0.0",
+                        "level-supports": "~1.0.0",
+                        "xtend": "~4.0.0"
+                    }
+                },
+                "buffer": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                }
+            }
         },
         "define-properties": {
             "version": "1.1.3",
@@ -9012,6 +15926,18 @@
                     }
                 }
             }
+        },
+        "defined": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+            "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+            "dev": true
+        },
+        "deindent": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/deindent/-/deindent-0.1.0.tgz",
+            "integrity": "sha1-YuHc3R2Elwnlx0A8iQ5H486+OZ0=",
+            "dev": true
         },
         "del": {
             "version": "4.1.1",
@@ -9106,6 +16032,12 @@
             "integrity": "sha512-KqtH4/EZdtdfWX0p6MGP9jljvxSY6msy/pRUD4jgNwVpv3v1QmNLlsB3LDSSUg79BRVSn7jI1QPRtArGABovAQ==",
             "dev": true
         },
+        "deprecated-decorator": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+            "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
+            "dev": true
+        },
         "deprecation": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -9143,10 +16075,34 @@
                 "repeating": "^2.0.0"
             }
         },
+        "detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true
+        },
         "detect-node": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
             "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+            "dev": true
+        },
+        "detective-amd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-3.0.0.tgz",
+            "integrity": "sha512-kOpKHyabdSKF9kj7PqYHLeHPw+TJT8q2u48tZYMkIcas28el1CYeLEJ42Nm+563/Fq060T5WknfwDhdX9+kkBQ==",
+            "dev": true,
+            "requires": {
+                "ast-module-types": "^2.3.1",
+                "escodegen": "^1.8.0",
+                "get-amd-module-type": "^3.0.0",
+                "node-source-walk": "^4.0.0"
+            }
+        },
+        "detective-stylus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.0.tgz",
+            "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0=",
             "dev": true
         },
         "dezalgo": {
@@ -9260,10 +16216,22 @@
             "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
             "dev": true
         },
+        "didyoumean": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
+            "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
+            "dev": true
+        },
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "diff-sequences": {
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+            "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
             "dev": true
         },
         "diffie-hellman": {
@@ -9294,6 +16262,12 @@
                 "path-type": "^3.0.0"
             }
         },
+        "dlv": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+            "dev": true
+        },
         "dns-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -9317,6 +16291,24 @@
             "dev": true,
             "requires": {
                 "buffer-indexof": "^1.0.0"
+            }
+        },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
+        "dom-converter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+            "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+            "dev": true,
+            "requires": {
+                "utila": "~0.4"
             }
         },
         "dom-serialize": {
@@ -9355,6 +16347,12 @@
                 }
             }
         },
+        "dom-walk": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+            "dev": true
+        },
         "domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -9366,6 +16364,23 @@
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
             "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
             "dev": true
+        },
+        "domexception": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+            "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "^5.0.0"
+            },
+            "dependencies": {
+                "webidl-conversions": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                    "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+                    "dev": true
+                }
+            }
         },
         "domhandler": {
             "version": "2.4.2",
@@ -9498,6 +16513,12 @@
                 }
             }
         },
+        "emittery": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+            "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+            "dev": true
+        },
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9508,6 +16529,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
             "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+            "dev": true
+        },
+        "enabled": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
             "dev": true
         },
         "encodeurl": {
@@ -9523,6 +16550,18 @@
             "dev": true,
             "requires": {
                 "iconv-lite": "~0.4.13"
+            }
+        },
+        "encoding-down": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+            "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+            "dev": true,
+            "requires": {
+                "abstract-leveldown": "^6.2.1",
+                "inherits": "^2.0.3",
+                "level-codec": "^9.0.0",
+                "level-errors": "^2.0.0"
             }
         },
         "end-of-stream": {
@@ -9830,6 +16869,28 @@
                 "is-symbol": "^1.0.2"
             }
         },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "es6-promise": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -9845,6 +16906,34 @@
                 "es6-promise": "^4.0.3"
             }
         },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "escalade": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+            "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+            "dev": true
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -9857,6 +16946,231 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
+        "escodegen": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "eslint": {
+            "version": "5.16.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+            "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.9.1",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "eslint-scope": "^4.0.3",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^5.0.1",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^5.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.2.2",
+                "js-yaml": "^3.13.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.11",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.1",
+                "semver": "^5.5.1",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "doctrine": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+                    "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2"
+                    }
+                },
+                "espree": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+                    "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^6.0.7",
+                        "acorn-jsx": "^5.0.0",
+                        "eslint-visitor-keys": "^1.0.0"
+                    }
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                },
+                "import-fresh": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+                    "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+                    "dev": true,
+                    "requires": {
+                        "parent-module": "^1.0.0",
+                        "resolve-from": "^4.0.0"
+                    }
+                },
+                "inquirer": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+                    "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.2.0",
+                        "chalk": "^2.4.2",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.17.12",
+                        "mute-stream": "0.0.7",
+                        "run-async": "^2.2.0",
+                        "rxjs": "^6.4.0",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^5.1.0",
+                        "through": "^2.3.6"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
         "eslint-scope": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -9867,11 +17181,43 @@
                 "estraverse": "^4.1.1"
             }
         },
+        "eslint-utils": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+            "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+            "dev": true
+        },
         "espree": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
             "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
             "dev": true
+        },
+        "esquery": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+            "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.1.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+                    "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+                    "dev": true
+                }
+            }
         },
         "esrecurse": {
             "version": "4.2.1",
@@ -9906,6 +17252,16 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
         },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
         "eventemitter3": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
@@ -9937,6 +17293,12 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "exec-sh": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+            "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
+            "dev": true
+        },
         "execa": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
@@ -9966,6 +17328,26 @@
                     }
                 }
             }
+        },
+        "execcli": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/execcli/-/execcli-4.0.11.tgz",
+            "integrity": "sha1-PbmCCoP6EkK5v7UNEVUdBQWSfUM=",
+            "dev": true,
+            "requires": {
+                "argx": "^3.0.0",
+                "arrayreduce": "^2.1.0",
+                "babel-runtime": "^6.23.0",
+                "findout": "^2.0.1",
+                "hasbin": "^1.2.3",
+                "stringcase": "^3.2.1"
+            }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -10009,6 +17391,139 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "expect": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-26.2.0.tgz",
+            "integrity": "sha512-8AMBQ9UVcoUXt0B7v+5/U5H6yiUR87L6eKCfjE3spx7Ya5lF+ebUo37MCFBML2OiLfkX1sxmQOZhIDonyVTkcw==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "ansi-styles": "^4.0.0",
+                "jest-get-type": "^26.0.0",
+                "jest-matcher-utils": "^26.2.0",
+                "jest-message-util": "^26.2.0",
+                "jest-regex-util": "^26.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
+                    "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-diff": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.2.0.tgz",
+                    "integrity": "sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^26.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "jest-matcher-utils": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.2.0.tgz",
+                    "integrity": "sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "jest-diff": "^26.2.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "express": {
@@ -10059,6 +17574,95 @@
                     "version": "6.7.0",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
                     "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                }
+            }
+        },
+        "express-graphql": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
+            "integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
+            "dev": true,
+            "requires": {
+                "accepts": "^1.3.7",
+                "content-type": "^1.0.4",
+                "http-errors": "^1.7.3",
+                "raw-body": "^2.4.1"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+                    "dev": true
+                },
+                "http-errors": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+                    "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.4",
+                        "setprototypeof": "1.2.0",
+                        "statuses": ">= 1.5.0 < 2",
+                        "toidentifier": "1.0.0"
+                    }
+                },
+                "raw-body": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+                    "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.1.0",
+                        "http-errors": "1.7.3",
+                        "iconv-lite": "0.4.24",
+                        "unpipe": "1.0.0"
+                    },
+                    "dependencies": {
+                        "http-errors": {
+                            "version": "1.7.3",
+                            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+                            "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+                            "dev": true,
+                            "requires": {
+                                "depd": "~1.1.2",
+                                "inherits": "2.0.4",
+                                "setprototypeof": "1.1.1",
+                                "statuses": ">= 1.5.0 < 2",
+                                "toidentifier": "1.0.0"
+                            }
+                        },
+                        "setprototypeof": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+                            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+                    "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+                    "dev": true
+                }
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
                     "dev": true
                 }
             }
@@ -10166,6 +17770,12 @@
                 }
             }
         },
+        "extract-files": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-8.1.0.tgz",
+            "integrity": "sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==",
+            "dev": true
+        },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -10182,6 +17792,12 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
             "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
+        },
+        "fast-extend": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-1.0.2.tgz",
+            "integrity": "sha512-XXA9RmlPatkFKUzqVZAFth18R4Wo+Xug/S+C7YlYA3xrXwfPlW3dqNwOb4hvQo7wZJ2cNDYhrYuPzVOfHy5/uQ==",
             "dev": true
         },
         "fast-glob": {
@@ -10257,6 +17873,18 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+            "dev": true
+        },
         "fastparse": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -10281,6 +17909,43 @@
                 "websocket-driver": ">=0.5.1"
             }
         },
+        "fb-watchman": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+            "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+            "dev": true,
+            "requires": {
+                "bser": "2.1.1"
+            }
+        },
+        "fbjs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+            "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+            "dev": true,
+            "requires": {
+                "core-js": "^2.4.1",
+                "fbjs-css-vars": "^1.0.0",
+                "isomorphic-fetch": "^2.1.1",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.18"
+            }
+        },
+        "fbjs-css-vars": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+            "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+            "dev": true
+        },
+        "fecha": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+            "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
+            "dev": true
+        },
         "figgy-pudding": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -10296,6 +17961,21 @@
                 "escape-string-regexp": "^1.0.5"
             }
         },
+        "file-entry-cache": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^2.0.1"
+            }
+        },
+        "file-exists-dazinatorfork": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/file-exists-dazinatorfork/-/file-exists-dazinatorfork-1.0.2.tgz",
+            "integrity": "sha512-r70c72ln2YHzQINNfxDp02hAhbGkt1HffZ+Du8oetWDLjDtFja/Lm10lUaSh9e+wD+7VDvPee0b0C9SAy8pWZg==",
+            "dev": true
+        },
         "file-loader": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.2.0.tgz",
@@ -10304,6 +17984,23 @@
             "requires": {
                 "loader-utils": "^1.2.3",
                 "schema-utils": "^2.0.0"
+            }
+        },
+        "filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+            "dev": true
+        },
+        "filenamify": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
+            "integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
+            "dev": true,
+            "requires": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.1",
+                "trim-repeated": "^1.0.0"
             }
         },
         "fileset": {
@@ -10352,6 +18049,15 @@
                 "parseurl": "~1.3.3",
                 "statuses": "~1.5.0",
                 "unpipe": "~1.0.0"
+            }
+        },
+        "find": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/find/-/find-0.3.0.tgz",
+            "integrity": "sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw==",
+            "dev": true,
+            "requires": {
+                "traverse-chain": "~0.1.0"
             }
         },
         "find-cache-dir": {
@@ -10422,6 +18128,16 @@
                 "semver-regex": "^2.0.0"
             }
         },
+        "findout": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/findout/-/findout-2.1.2.tgz",
+            "integrity": "sha1-eEFc9z7Z4nwC4pqbxETn0ir2AQU=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.11.6",
+                "co": "^4.6.0"
+            }
+        },
         "findup-sync": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
@@ -10432,6 +18148,43 @@
                 "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
+            }
+        },
+        "first-chunk-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+            "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "firstline": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/firstline/-/firstline-2.0.2.tgz",
+            "integrity": "sha512-8KcmfI0jgSECnzdhucm0i7vrwef3BWwgjimW2YkRC5eSFwjb5DibVoA0YvgkYwwxuJi9c+7M7X3b3lX8o9B6wg==",
+            "dev": true
+        },
+        "flat-cache": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+            "dev": true,
+            "requires": {
+                "flatted": "^2.0.0",
+                "rimraf": "2.6.3",
+                "write": "1.0.3"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
             }
         },
         "flatted": {
@@ -10449,6 +18202,12 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^2.3.6"
             }
+        },
+        "fn.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+            "dev": true
         },
         "follow-redirects": {
             "version": "1.9.0",
@@ -10486,6 +18245,15 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -10544,6 +18312,12 @@
                 "null-check": "^1.0.0"
             }
         },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
+        },
         "fs-extra": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -10563,6 +18337,12 @@
             "requires": {
                 "minipass": "^2.6.0"
             }
+        },
+        "fs-monkey": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-0.3.3.tgz",
+            "integrity": "sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==",
+            "dev": true
         },
         "fs-write-stream-atomic": {
             "version": "1.0.10",
@@ -11148,6 +18928,18 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "fuzzy": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
+            "integrity": "sha1-THbsL/CsGjap3M+aAN+GIweNTtg=",
+            "dev": true
+        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -11185,6 +18977,16 @@
             "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
             "dev": true
         },
+        "get-amd-module-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-3.0.0.tgz",
+            "integrity": "sha512-99Q7COuACPfVt18zH9N4VAMyb81S6TUgJm2NgV6ERtkh9VIkAaByZkW530wl3lLN5KTtSrK9jVLxYsoP5hQKsw==",
+            "dev": true,
+            "requires": {
+                "ast-module-types": "^2.3.2",
+                "node-source-walk": "^4.0.0"
+            }
+        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -11195,6 +18997,12 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
             "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
+            "dev": true
+        },
+        "get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
         },
         "get-stdin": {
@@ -11521,6 +19329,16 @@
                 }
             }
         },
+        "global": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+            "dev": true,
+            "requires": {
+                "min-document": "^2.19.0",
+                "process": "^0.11.10"
+            }
+        },
         "global-dirs": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -11638,6 +19456,143 @@
             "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
             "dev": true
         },
+        "grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+            "dev": true
+        },
+        "graphlib": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+            "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.15"
+            }
+        },
+        "graphql": {
+            "version": "15.3.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+            "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
+            "dev": true
+        },
+        "graphql-tag": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+            "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==",
+            "dev": true
+        },
+        "graphql-tools": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-5.0.0.tgz",
+            "integrity": "sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==",
+            "dev": true,
+            "requires": {
+                "apollo-link": "^1.2.14",
+                "apollo-upload-client": "^13.0.0",
+                "deprecated-decorator": "^0.1.6",
+                "form-data": "^3.0.0",
+                "iterall": "^1.3.0",
+                "node-fetch": "^2.6.0",
+                "tslib": "^1.11.1",
+                "uuid": "^7.0.3"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+                    "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "uuid": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+                    "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+                    "dev": true
+                }
+            }
+        },
+        "graphviz": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
+            "integrity": "sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==",
+            "dev": true,
+            "requires": {
+                "temp": "~0.4.0"
+            }
+        },
+        "group-array": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/group-array/-/group-array-1.0.0.tgz",
+            "integrity": "sha512-PJresALe5TUzSIcdWKLdAKcdUDxv8du2EGueShgAL2xknbcTo5Bk1xbNaNhxpWxxAx/SV7N+5S0UyK7XV0+QhA==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.1.0",
+                "for-own": "^1.0.0",
+                "get-value": "^3.0.1",
+                "kind-of": "^6.0.2",
+                "split-string": "^6.1.0",
+                "union-value": "^2.0.1"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                },
+                "get-value": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+                    "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "set-value": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-3.0.2.tgz",
+                    "integrity": "sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                },
+                "split-string": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/split-string/-/split-string-6.1.0.tgz",
+                    "integrity": "sha512-9UBdnmnvx2NLLd4bMs7CEKK+wSzbujVv3ONyorkP1o8M3pVJQtXDO1cN19xD1JJs6ltOrtPrkUND0HzLSinUcA==",
+                    "dev": true
+                },
+                "union-value": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/union-value/-/union-value-2.0.1.tgz",
+                    "integrity": "sha512-NmcRHHhUy1qWmp6yYWsaURV2qwfS24TmTtO9S9x0L41wCNNVBQFD3toOzO0cd8SsNrFhbw/O0iYO5uffXGYocw==",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^3.0.1",
+                        "set-value": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true,
+            "optional": true
+        },
         "handle-thing": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -11734,6 +19689,12 @@
             "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
             "dev": true
         },
+        "harmony-reflect": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+            "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==",
+            "dev": true
+        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -11781,11 +19742,43 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
+        "has-own-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+            "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+            "dev": true
+        },
+        "has-own-property-x": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
+            "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "to-object-x": "^1.5.0",
+                "to-property-key-x": "^2.0.2"
+            }
+        },
+        "has-symbol-support-x": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+            "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+            "dev": true
+        },
         "has-symbols": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
             "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
             "dev": true
+        },
+        "has-to-string-tag-x": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+            "dev": true,
+            "requires": {
+                "has-symbol-support-x": "^1.4.1"
+            }
         },
         "has-unicode": {
             "version": "2.0.1",
@@ -11830,6 +19823,23 @@
             "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
             "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
             "dev": true
+        },
+        "hasbin": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
+            "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
+            "dev": true,
+            "requires": {
+                "async": "~1.5"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                }
+            }
         },
         "hash-base": {
             "version": "3.1.0",
@@ -11932,6 +19942,12 @@
                 "space-separated-tokens": "^1.0.0"
             }
         },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true
+        },
         "header-case": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
@@ -11940,6 +19956,12 @@
                 "no-case": "^2.2.0",
                 "upper-case": "^1.1.3"
             }
+        },
+        "hex-rgb": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
+            "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g==",
+            "dev": true
         },
         "highlight.js": {
             "version": "9.18.1",
@@ -11956,6 +19978,15 @@
                 "hash.js": "^1.0.3",
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "dev": true,
+            "requires": {
+                "react-is": "^16.7.0"
             }
         },
         "homedir-polyfill": {
@@ -11991,17 +20022,158 @@
                 "wbuf": "^1.1.0"
             }
         },
+        "html-encoding-sniffer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+            "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^1.0.5"
+            }
+        },
         "html-entities": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
             "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
             "dev": true
         },
+        "html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
+        },
+        "html-minifier-terser": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+            "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+            "dev": true,
+            "requires": {
+                "camel-case": "^4.1.1",
+                "clean-css": "^4.2.3",
+                "commander": "^4.1.1",
+                "he": "^1.2.0",
+                "param-case": "^3.0.3",
+                "relateurl": "^0.2.7",
+                "terser": "^4.6.3"
+            },
+            "dependencies": {
+                "camel-case": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+                    "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+                    "dev": true,
+                    "requires": {
+                        "pascal-case": "^3.1.1",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "clean-css": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+                    "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "~0.6.0"
+                    }
+                },
+                "commander": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+                    "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+                    "dev": true
+                },
+                "dot-case": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+                    "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+                    "dev": true,
+                    "requires": {
+                        "no-case": "^3.0.3",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "lower-case": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+                    "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "no-case": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+                    "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^2.0.1",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "param-case": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+                    "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+                    "dev": true,
+                    "requires": {
+                        "dot-case": "^3.0.3",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "pascal-case": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+                    "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+                    "dev": true,
+                    "requires": {
+                        "no-case": "^3.0.3",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "html-void-elements": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
             "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
             "dev": true
+        },
+        "html-webpack-plugin": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.3.0.tgz",
+            "integrity": "sha512-C0fzKN8yQoVLTelcJxZfJCE+aAvQiY2VUf3UuKrR4a9k5UMWYOtpDLsaXwATbcVCnI05hUS7L9ULQHWLZhyi3w==",
+            "dev": true,
+            "requires": {
+                "@types/html-minifier-terser": "^5.0.0",
+                "@types/tapable": "^1.0.5",
+                "@types/webpack": "^4.41.8",
+                "html-minifier-terser": "^5.0.1",
+                "loader-utils": "^1.2.3",
+                "lodash": "^4.17.15",
+                "pretty-error": "^2.1.1",
+                "tapable": "^1.1.3",
+                "util.promisify": "1.0.0"
+            },
+            "dependencies": {
+                "util.promisify": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+                    "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "^1.1.2",
+                        "object.getownpropertydescriptors": "^2.0.3"
+                    }
+                }
+            }
         },
         "htmlencode": {
             "version": "0.0.4",
@@ -12197,12 +20369,33 @@
                 }
             }
         },
+        "hyphenate-style-name": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==",
+            "dev": true
+        },
+        "i": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+            "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+            "dev": true
+        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "identity-obj-proxy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+            "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+            "dev": true,
+            "requires": {
+                "harmony-reflect": "^1.4.6"
             }
         },
         "ieee754": {
@@ -12216,6 +20409,15 @@
             "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
             "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
             "dev": true
+        },
+        "iftype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/iftype/-/iftype-3.0.2.tgz",
+            "integrity": "sha1-V3EmHmT7NaaA0yDTZox1Kfklq3Q=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.11.6"
+            }
         },
         "ignore": {
             "version": "5.1.8",
@@ -12238,6 +20440,12 @@
             "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
             "dev": true,
             "optional": true
+        },
+        "immediate": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+            "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+            "dev": true
         },
         "import-cwd": {
             "version": "2.1.0",
@@ -12358,6 +20566,12 @@
                 "repeating": "^2.0.0"
             }
         },
+        "indexes-of": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+            "dev": true
+        },
         "indexof": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -12368,6 +20582,12 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
             "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+            "dev": true
+        },
+        "infinity-x": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.2.tgz",
+            "integrity": "sha512-2Ioz+exrAwlHxFBaDHQIbvUyjKFt0YjIal34/agfzx738aT1zBQwSU5A8Zgb1IQ2r24BtXrkeZZusxE40MyZaQ==",
             "dev": true
         },
         "inflight": {
@@ -12392,11 +20612,367 @@
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
+        "ini-builder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ini-builder/-/ini-builder-1.1.1.tgz",
+            "integrity": "sha512-75kk/PhKAzS/O1HnNcVKby4tgLAi/TlMyOjY23pzIAGMr2YcmqTG7T/Oe1ltHwICGZAH8eEFX77PcSv2AzByrA==",
+            "dev": true
+        },
         "injection-js": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/injection-js/-/injection-js-2.3.0.tgz",
             "integrity": "sha512-rhS6E5jv603kbaO72ylOt0hGF1LT03oqQ4GU5KOO0qSaRbIWmdUCHjXq+VT79jL6/NmXtw9ccfK6dh/CzjoYjA==",
             "dev": true
+        },
+        "ink": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/ink/-/ink-2.7.1.tgz",
+            "integrity": "sha512-s7lJuQDJEdjqtaIWhp3KYHl6WV3J04U9zoQ6wVc+Xoa06XM27SXUY57qC5DO46xkF0CfgXMKkKNcgvSu/SAEpA==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "arrify": "^2.0.1",
+                "auto-bind": "^4.0.0",
+                "chalk": "^3.0.0",
+                "cli-cursor": "^3.1.0",
+                "cli-truncate": "^2.1.0",
+                "is-ci": "^2.0.0",
+                "lodash.throttle": "^4.1.1",
+                "log-update": "^3.0.0",
+                "prop-types": "^15.6.2",
+                "react-reconciler": "^0.24.0",
+                "scheduler": "^0.18.0",
+                "signal-exit": "^3.0.2",
+                "slice-ansi": "^3.0.0",
+                "string-length": "^3.1.0",
+                "widest-line": "^3.1.0",
+                "wrap-ansi": "^6.2.0",
+                "yoga-layout-prebuilt": "^1.9.3"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "arrify": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+                    "dev": true
+                },
+                "cli-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+                    "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^3.1.0"
+                    }
+                },
+                "cli-truncate": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+                    "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+                    "dev": true,
+                    "requires": {
+                        "slice-ansi": "^3.0.0",
+                        "string-width": "^4.2.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "log-update": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.4.0.tgz",
+                    "integrity": "sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.2.0",
+                        "cli-cursor": "^2.1.0",
+                        "wrap-ansi": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-escapes": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+                            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+                            "dev": true
+                        },
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                            "dev": true
+                        },
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                            "dev": true,
+                            "requires": {
+                                "color-convert": "^1.9.0"
+                            }
+                        },
+                        "cli-cursor": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+                            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                            "dev": true,
+                            "requires": {
+                                "restore-cursor": "^2.0.0"
+                            }
+                        },
+                        "color-convert": {
+                            "version": "1.9.3",
+                            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                            "dev": true,
+                            "requires": {
+                                "color-name": "1.1.3"
+                            }
+                        },
+                        "color-name": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                            "dev": true
+                        },
+                        "emoji-regex": {
+                            "version": "7.0.3",
+                            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                            "dev": true
+                        },
+                        "mimic-fn": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                            "dev": true
+                        },
+                        "onetime": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+                            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                            "dev": true,
+                            "requires": {
+                                "mimic-fn": "^1.0.0"
+                            }
+                        },
+                        "restore-cursor": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+                            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                            "dev": true,
+                            "requires": {
+                                "onetime": "^2.0.0",
+                                "signal-exit": "^3.0.2"
+                            }
+                        },
+                        "string-width": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                            "dev": true,
+                            "requires": {
+                                "emoji-regex": "^7.0.1",
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        },
+                        "wrap-ansi": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^3.2.0",
+                                "string-width": "^3.0.0",
+                                "strip-ansi": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "onetime": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^2.1.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+                    "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "slice-ansi": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+                    "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                },
+                "widest-line": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+                    "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "inline-style-prefixer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz",
+            "integrity": "sha512-PYUF+94gDfhy+LsQxM0g3d6Hge4l1pAqOSOiZuHWzMvQEGsbRQ/ck2WioLqrY2ZkHyPgVUXxn+hrkF7D6QUGbA==",
+            "dev": true,
+            "requires": {
+                "css-in-js-utils": "^2.0.0"
+            }
         },
         "inquirer": {
             "version": "7.3.3",
@@ -12582,6 +21158,108 @@
                 }
             }
         },
+        "inquirer-autocomplete-prompt": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.2.tgz",
+            "integrity": "sha512-vNmAhhrOQwPnUm4B9kz1UB7P98rVF1z8txnjp53r40N0PBCuqoRWqjg3Tl0yz0UkDg7rEUtZ2OZpNc7jnOU9Zw==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "figures": "^2.0.0",
+                "run-async": "^2.3.0"
+            }
+        },
+        "inquirer-fuzzy-path": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/inquirer-fuzzy-path/-/inquirer-fuzzy-path-2.3.0.tgz",
+            "integrity": "sha512-zfHC/97GSkxKKM7IctZM22x1sVi+FYBh9oaHTmI7Er/GKFpNykUgtviTmqqpiFQs5yJoSowxbT0PHy6N+H+QRg==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "fuzzy": "^0.1.3",
+                "inquirer": "^6.0.0",
+                "inquirer-autocomplete-prompt": "^1.0.2",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "inquirer": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+                    "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.2.0",
+                        "chalk": "^2.4.2",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.17.12",
+                        "mute-stream": "0.0.7",
+                        "run-async": "^2.2.0",
+                        "rxjs": "^6.4.0",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^5.1.0",
+                        "through": "^2.3.6"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
         "internal-ip": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -12685,6 +21363,19 @@
             "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
             "dev": true
         },
+        "is-array-buffer-x": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
+            "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
+            "dev": true,
+            "requires": {
+                "attempt-x": "^1.1.0",
+                "has-to-string-tag-x": "^1.4.1",
+                "is-object-like-x": "^1.5.1",
+                "object-get-own-property-descriptor-x": "^3.2.0",
+                "to-string-tag-x": "^1.4.1"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -12778,6 +21469,12 @@
             "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
             "dev": true
         },
+        "is-docker": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+            "dev": true
+        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -12790,6 +21487,15 @@
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
+        "is-falsey-x": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.3.tgz",
+            "integrity": "sha512-RWjusR6LXAhGa0Vus7aD1rwJuJwdJsvG3daAVMDvOAgvGuGm4eilNgoSuXhpv2/2qpLDvioAKTNb3t3XYidCNg==",
+            "dev": true,
+            "requires": {
+                "to-boolean-x": "^1.0.2"
+            }
+        },
         "is-finite": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -12797,6 +21503,16 @@
             "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
+            }
+        },
+        "is-finite-x": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.4.tgz",
+            "integrity": "sha512-wdSI5zk/Pl21HzGcLWFoFzuDa8gsgcqhwZGAZryL2eU7RKf7+g+q4jL2gGItrBs/YtspkjOrJ4JxXNZqquoAWA==",
+            "dev": true,
+            "requires": {
+                "infinity-x": "^1.0.1",
+                "is-nan-x": "^1.0.2"
             }
         },
         "is-fullwidth-code-point": {
@@ -12807,6 +21523,36 @@
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
+        },
+        "is-function-x": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
+            "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
+            "dev": true,
+            "requires": {
+                "attempt-x": "^1.1.1",
+                "has-to-string-tag-x": "^1.4.1",
+                "is-falsey-x": "^1.0.1",
+                "is-primitive": "^2.0.0",
+                "normalize-space-x": "^3.0.0",
+                "replace-comments-x": "^2.0.0",
+                "to-boolean-x": "^1.0.1",
+                "to-string-tag-x": "^1.4.2"
+            },
+            "dependencies": {
+                "is-primitive": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                    "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                    "dev": true
+                }
+            }
+        },
+        "is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+            "dev": true
         },
         "is-glob": {
             "version": "4.0.1",
@@ -12823,6 +21569,19 @@
             "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
             "dev": true
         },
+        "is-index-x": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
+            "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
+            "dev": true,
+            "requires": {
+                "math-clamp-x": "^1.2.0",
+                "max-safe-integer": "^1.0.1",
+                "to-integer-x": "^3.0.0",
+                "to-number-x": "^2.0.0",
+                "to-string-symbols-supported-x": "^1.0.0"
+            }
+        },
         "is-installed-globally": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -12832,6 +21591,12 @@
                 "global-dirs": "^0.1.0",
                 "is-path-inside": "^1.0.0"
             }
+        },
+        "is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "dev": true
         },
         "is-lower-case": {
             "version": "1.1.3",
@@ -12846,6 +21611,22 @@
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
             "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
             "dev": true
+        },
+        "is-nan-x": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.3.tgz",
+            "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA==",
+            "dev": true
+        },
+        "is-nil-x": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.2.tgz",
+            "integrity": "sha512-9aDY7ir7IGb5HlgqL+b38v2YMxf8S7MEHHxjHGzUhijg2crq47RKdxL37bS6dU0VN87wy2IBZP4akgQtIXmyvg==",
+            "dev": true,
+            "requires": {
+                "lodash.isnull": "^3.0.0",
+                "validate.io-undefined": "^1.0.3"
+            }
         },
         "is-npm": {
             "version": "3.0.0",
@@ -12878,6 +21659,16 @@
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
+        },
+        "is-object-like-x": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.7.1.tgz",
+            "integrity": "sha512-89nz+kESAW2Y7udq+PdRX/dZnRN2WP1b19Gdv4OYE1Xjoekn1xf31l0ZPzT40qdPD7I2nveNFm9rxxI0vmnGHA==",
+            "dev": true,
+            "requires": {
+                "is-function-x": "^3.3.0",
+                "is-primitive": "^3.0.0"
+            }
         },
         "is-observable": {
             "version": "1.1.0",
@@ -12938,6 +21729,18 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-potential-custom-element-name": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+            "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+            "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
+            "dev": true
+        },
         "is-promise": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -12976,10 +21779,22 @@
             "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
             "dev": true
         },
+        "is-relative-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-2.0.0.tgz",
+            "integrity": "sha1-vNCtPsI6STinfzQD0tv/NLmR+y8=",
+            "dev": true
+        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-string": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
             "dev": true
         },
         "is-symbol": {
@@ -13014,11 +21829,26 @@
                 "upper-case": "^1.1.0"
             }
         },
+        "is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "dev": true
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
+        },
+        "is-vendor-prefixed": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-vendor-prefixed/-/is-vendor-prefixed-1.0.0.tgz",
+            "integrity": "sha1-0QQwU/TRTNeAfr4ohiGmoOrRrfg=",
+            "dev": true,
+            "requires": {
+                "vendor-prefixes": "1.0.0"
+            }
         },
         "is-windows": {
             "version": "1.0.2",
@@ -13061,6 +21891,28 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "dev": true
+        },
+        "isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "dev": true,
+            "requires": {
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "1.7.3",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+                    "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+                    "dev": true,
+                    "requires": {
+                        "encoding": "^0.1.11",
+                        "is-stream": "^1.0.1"
+                    }
+                }
+            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -13209,6 +22061,12 @@
                 "handlebars": "^4.0.3"
             }
         },
+        "iterall": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+            "dev": true
+        },
         "jasmine-core": {
             "version": "2.6.4",
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.4.tgz",
@@ -13238,11 +22096,3048 @@
             "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
             "dev": true
         },
+        "jest": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-26.2.2.tgz",
+            "integrity": "sha512-EkJNyHiAG1+A8pqSz7cXttoVa34hOEzN/MrnJhYnfp5VHxflVcf2pu3oJSrhiy6LfIutLdWo+n6q63tjcoIeig==",
+            "dev": true,
+            "requires": {
+                "@jest/core": "^26.2.2",
+                "import-local": "^3.0.2",
+                "jest-cli": "^26.2.2"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "camelcase": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "import-local": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+                    "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+                    "dev": true,
+                    "requires": {
+                        "pkg-dir": "^4.2.0",
+                        "resolve-cwd": "^3.0.0"
+                    }
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
+                },
+                "jest-cli": {
+                    "version": "26.2.2",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.2.2.tgz",
+                    "integrity": "sha512-vVcly0n/ijZvdy6gPQiQt0YANwX2hLTPQZHtW7Vi3gcFdKTtif7YpI85F8R8JYy5DFSWz4x1OW0arnxlziu5Lw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/core": "^26.2.2",
+                        "@jest/test-result": "^26.2.0",
+                        "@jest/types": "^26.2.0",
+                        "chalk": "^4.0.0",
+                        "exit": "^0.1.2",
+                        "graceful-fs": "^4.2.4",
+                        "import-local": "^3.0.2",
+                        "is-ci": "^2.0.0",
+                        "jest-config": "^26.2.2",
+                        "jest-util": "^26.2.0",
+                        "jest-validate": "^26.2.0",
+                        "prompts": "^2.0.1",
+                        "yargs": "^15.3.1"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "jest-validate": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.2.0.tgz",
+                    "integrity": "sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "camelcase": "^6.0.0",
+                        "chalk": "^4.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "leven": "^3.1.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "leven": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+                    "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "resolve-cwd": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+                    "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+                    "dev": true,
+                    "requires": {
+                        "resolve-from": "^5.0.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-changed-files": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.2.0.tgz",
+            "integrity": "sha512-+RyJb+F1K/XBLIYiL449vo5D+CvlHv29QveJUWNPXuUicyZcq+tf1wNxmmFeRvAU1+TzhwqczSjxnCCFt7+8iA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "execa": "^4.0.0",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "execa": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+                    "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "onetime": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^2.1.0"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "jest-config": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.2.2.tgz",
+            "integrity": "sha512-2lhxH0y4YFOijMJ65usuf78m7+9/8+hAb1PZQtdRdgnQpAb4zP6KcVDDktpHEkspBKnc2lmFu+RQdHukUUbiTg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^26.2.2",
+                "@jest/types": "^26.2.0",
+                "babel-jest": "^26.2.2",
+                "chalk": "^4.0.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.2.4",
+                "jest-environment-jsdom": "^26.2.0",
+                "jest-environment-node": "^26.2.0",
+                "jest-get-type": "^26.0.0",
+                "jest-jasmine2": "^26.2.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.2.2",
+                "jest-util": "^26.2.0",
+                "jest-validate": "^26.2.0",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^26.2.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "camelcase": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "jest-validate": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.2.0.tgz",
+                    "integrity": "sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "camelcase": "^6.0.0",
+                        "chalk": "^4.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "leven": "^3.1.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "leven": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+                    "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "jest-diff": {
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+            "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+            "dev": true,
+            "requires": {
+                "chalk": "^3.0.0",
+                "diff-sequences": "^25.2.6",
+                "jest-get-type": "^25.2.6",
+                "pretty-format": "^25.5.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-docblock": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+            "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+            "dev": true,
+            "requires": {
+                "detect-newline": "^3.0.0"
+            }
+        },
+        "jest-each": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.2.0.tgz",
+            "integrity": "sha512-gHPCaho1twWHB5bpcfnozlc6mrMi+VAewVPNgmwf81x2Gzr6XO4dl+eOrwPWxbkYlgjgrYjWK2xgKnixbzH3Ew==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.0.0",
+                "jest-util": "^26.2.0",
+                "pretty-format": "^26.2.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-environment-jsdom": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.2.0.tgz",
+            "integrity": "sha512-sDG24+5M4NuIGzkI3rJW8XUlrpkvIdE9Zz4jhD8OBnVxAw+Y1jUk9X+lAOD48nlfUTlnt3lbAI3k2Ox+WF3S0g==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.2.0",
+                "@jest/fake-timers": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "jest-mock": "^26.2.0",
+                "jest-util": "^26.2.0",
+                "jsdom": "^16.2.2"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-environment-jsdom-fourteen": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-1.0.1.tgz",
+            "integrity": "sha512-DojMX1sY+at5Ep+O9yME34CdidZnO3/zfPh8UW+918C5fIZET5vCjfkegixmsi7AtdYfkr4bPlIzmWnlvQkP7Q==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^24.3.0",
+                "@jest/fake-timers": "^24.3.0",
+                "@jest/types": "^24.3.0",
+                "jest-mock": "^24.0.0",
+                "jest-util": "^24.0.0",
+                "jsdom": "^14.1.0"
+            },
+            "dependencies": {
+                "@jest/console": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+                    "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/source-map": "^24.9.0",
+                        "chalk": "^2.0.1",
+                        "slash": "^2.0.0"
+                    }
+                },
+                "@jest/environment": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+                    "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/fake-timers": "^24.9.0",
+                        "@jest/transform": "^24.9.0",
+                        "@jest/types": "^24.9.0",
+                        "jest-mock": "^24.9.0"
+                    }
+                },
+                "@jest/fake-timers": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+                    "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^24.9.0",
+                        "jest-message-util": "^24.9.0",
+                        "jest-mock": "^24.9.0"
+                    }
+                },
+                "@jest/source-map": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+                    "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+                    "dev": true,
+                    "requires": {
+                        "callsites": "^3.0.0",
+                        "graceful-fs": "^4.1.15",
+                        "source-map": "^0.6.0"
+                    }
+                },
+                "@jest/test-result": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+                    "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/console": "^24.9.0",
+                        "@jest/types": "^24.9.0",
+                        "@types/istanbul-lib-coverage": "^2.0.0"
+                    }
+                },
+                "@jest/transform": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+                    "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.1.0",
+                        "@jest/types": "^24.9.0",
+                        "babel-plugin-istanbul": "^5.1.0",
+                        "chalk": "^2.0.1",
+                        "convert-source-map": "^1.4.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "graceful-fs": "^4.1.15",
+                        "jest-haste-map": "^24.9.0",
+                        "jest-regex-util": "^24.9.0",
+                        "jest-util": "^24.9.0",
+                        "micromatch": "^3.1.10",
+                        "pirates": "^4.0.1",
+                        "realpath-native": "^1.1.0",
+                        "slash": "^2.0.0",
+                        "source-map": "^0.6.1",
+                        "write-file-atomic": "2.4.1"
+                    }
+                },
+                "@jest/types": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+                    "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^13.0.0"
+                    }
+                },
+                "@types/yargs": {
+                    "version": "13.0.9",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
+                    "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yargs-parser": "*"
+                    }
+                },
+                "acorn-globals": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+                    "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^6.0.1",
+                        "acorn-walk": "^6.0.1"
+                    }
+                },
+                "acorn-walk": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+                    "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+                    "dev": true
+                },
+                "babel-plugin-istanbul": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+                    "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "find-up": "^3.0.0",
+                        "istanbul-lib-instrument": "^3.3.0",
+                        "test-exclude": "^5.2.3"
+                    }
+                },
+                "callsites": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+                    "dev": true
+                },
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+                    "dev": true
+                },
+                "cssom": {
+                    "version": "0.3.8",
+                    "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                    "dev": true
+                },
+                "cssstyle": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+                    "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+                    "dev": true,
+                    "requires": {
+                        "cssom": "0.3.x"
+                    }
+                },
+                "data-urls": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+                    "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+                    "dev": true,
+                    "requires": {
+                        "abab": "^2.0.0",
+                        "whatwg-mimetype": "^2.2.0",
+                        "whatwg-url": "^7.0.0"
+                    }
+                },
+                "domexception": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+                    "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+                    "dev": true,
+                    "requires": {
+                        "webidl-conversions": "^4.0.2"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "html-encoding-sniffer": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+                    "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+                    "dev": true,
+                    "requires": {
+                        "whatwg-encoding": "^1.0.1"
+                    }
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
+                },
+                "istanbul-lib-coverage": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+                    "dev": true
+                },
+                "istanbul-lib-instrument": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+                    "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/generator": "^7.4.0",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/template": "^7.4.0",
+                        "@babel/traverse": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "istanbul-lib-coverage": "^2.0.5",
+                        "semver": "^6.0.0"
+                    }
+                },
+                "jest-haste-map": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+                    "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^24.9.0",
+                        "anymatch": "^2.0.0",
+                        "fb-watchman": "^2.0.0",
+                        "fsevents": "^1.2.7",
+                        "graceful-fs": "^4.1.15",
+                        "invariant": "^2.2.4",
+                        "jest-serializer": "^24.9.0",
+                        "jest-util": "^24.9.0",
+                        "jest-worker": "^24.9.0",
+                        "micromatch": "^3.1.10",
+                        "sane": "^4.0.3",
+                        "walker": "^1.0.7"
+                    }
+                },
+                "jest-message-util": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+                    "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@jest/test-result": "^24.9.0",
+                        "@jest/types": "^24.9.0",
+                        "@types/stack-utils": "^1.0.1",
+                        "chalk": "^2.0.1",
+                        "micromatch": "^3.1.10",
+                        "slash": "^2.0.0",
+                        "stack-utils": "^1.0.1"
+                    }
+                },
+                "jest-mock": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+                    "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^24.9.0"
+                    }
+                },
+                "jest-regex-util": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+                    "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+                    "dev": true
+                },
+                "jest-serializer": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+                    "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
+                    "dev": true
+                },
+                "jest-util": {
+                    "version": "24.9.0",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+                    "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/console": "^24.9.0",
+                        "@jest/fake-timers": "^24.9.0",
+                        "@jest/source-map": "^24.9.0",
+                        "@jest/test-result": "^24.9.0",
+                        "@jest/types": "^24.9.0",
+                        "callsites": "^3.0.0",
+                        "chalk": "^2.0.1",
+                        "graceful-fs": "^4.1.15",
+                        "is-ci": "^2.0.0",
+                        "mkdirp": "^0.5.1",
+                        "slash": "^2.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                },
+                "jsdom": {
+                    "version": "14.1.0",
+                    "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz",
+                    "integrity": "sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==",
+                    "dev": true,
+                    "requires": {
+                        "abab": "^2.0.0",
+                        "acorn": "^6.0.4",
+                        "acorn-globals": "^4.3.0",
+                        "array-equal": "^1.0.0",
+                        "cssom": "^0.3.4",
+                        "cssstyle": "^1.1.1",
+                        "data-urls": "^1.1.0",
+                        "domexception": "^1.0.1",
+                        "escodegen": "^1.11.0",
+                        "html-encoding-sniffer": "^1.0.2",
+                        "nwsapi": "^2.1.3",
+                        "parse5": "5.1.0",
+                        "pn": "^1.1.0",
+                        "request": "^2.88.0",
+                        "request-promise-native": "^1.0.5",
+                        "saxes": "^3.1.9",
+                        "symbol-tree": "^3.2.2",
+                        "tough-cookie": "^2.5.0",
+                        "w3c-hr-time": "^1.0.1",
+                        "w3c-xmlserializer": "^1.1.2",
+                        "webidl-conversions": "^4.0.2",
+                        "whatwg-encoding": "^1.0.5",
+                        "whatwg-mimetype": "^2.3.0",
+                        "whatwg-url": "^7.0.0",
+                        "ws": "^6.1.2",
+                        "xml-name-validator": "^3.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "parse5": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+                    "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+                    "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                },
+                "saxes": {
+                    "version": "3.1.11",
+                    "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+                    "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+                    "dev": true,
+                    "requires": {
+                        "xmlchars": "^2.1.1"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "stack-utils": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+                    "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                },
+                "test-exclude": {
+                    "version": "5.2.3",
+                    "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+                    "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3",
+                        "minimatch": "^3.0.4",
+                        "read-pkg-up": "^4.0.0",
+                        "require-main-filename": "^2.0.0"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+                    "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                },
+                "tr46": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+                    "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "^2.1.0"
+                    }
+                },
+                "w3c-xmlserializer": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+                    "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+                    "dev": true,
+                    "requires": {
+                        "domexception": "^1.0.1",
+                        "webidl-conversions": "^4.0.2",
+                        "xml-name-validator": "^3.0.0"
+                    }
+                },
+                "webidl-conversions": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+                    "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+                    "dev": true
+                },
+                "whatwg-url": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^1.0.1",
+                        "webidl-conversions": "^4.0.2"
+                    }
+                },
+                "write-file-atomic": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+                    "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                }
+            }
+        },
+        "jest-environment-node": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.2.0.tgz",
+            "integrity": "sha512-4M5ExTYkJ19efBzkiXtBi74JqKLDciEk4CEsp5tTjWGYMrlKFQFtwIVG3tW1OGE0AlXhZjuHPwubuRYY4j4uOw==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.2.0",
+                "@jest/fake-timers": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "jest-mock": "^26.2.0",
+                "jest-util": "^26.2.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "jest-get-type": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
             "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
             "dev": true
+        },
+        "jest-haste-map": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.2.2.tgz",
+            "integrity": "sha512-3sJlMSt+NHnzCB+0KhJ1Ut4zKJBiJOlbrqEYNdRQGlXTv8kqzZWjUKQRY3pkjmlf+7rYjAV++MQ4D6g4DhAyOg==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "@types/graceful-fs": "^4.1.2",
+                "@types/node": "*",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-regex-util": "^26.0.0",
+                "jest-serializer": "^26.2.0",
+                "jest-util": "^26.2.0",
+                "jest-worker": "^26.2.1",
+                "micromatch": "^4.0.2",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "dev": true,
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+                    "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "jest-worker": {
+                    "version": "26.2.1",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.2.1.tgz",
+                    "integrity": "sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "jest-jasmine2": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.2.2.tgz",
+            "integrity": "sha512-Q8AAHpbiZMVMy4Hz9j1j1bg2yUmPa1W9StBvcHqRaKa9PHaDUMwds8LwaDyzP/2fkybcTQE4+pTMDOG9826tEw==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^26.2.0",
+                "@jest/source-map": "^26.1.0",
+                "@jest/test-result": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "expect": "^26.2.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^26.2.0",
+                "jest-matcher-utils": "^26.2.0",
+                "jest-message-util": "^26.2.0",
+                "jest-runtime": "^26.2.2",
+                "jest-snapshot": "^26.2.2",
+                "jest-util": "^26.2.0",
+                "pretty-format": "^26.2.0",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
+                    "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-diff": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.2.0.tgz",
+                    "integrity": "sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^26.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "jest-matcher-utils": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.2.0.tgz",
+                    "integrity": "sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "jest-diff": "^26.2.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-leak-detector": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.2.0.tgz",
+            "integrity": "sha512-aQdzTX1YiufkXA1teXZu5xXOJgy7wZQw6OJ0iH5CtQlOETe6gTSocaYKUNui1SzQ91xmqEUZ/WRavg9FD82rtQ==",
+            "dev": true,
+            "requires": {
+                "jest-get-type": "^26.0.0",
+                "pretty-format": "^26.2.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-matcher-utils": {
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+            "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^3.0.0",
+                "jest-diff": "^25.5.0",
+                "jest-get-type": "^25.2.6",
+                "pretty-format": "^25.5.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-message-util": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.2.0.tgz",
+            "integrity": "sha512-g362RhZaJuqeqG108n1sthz5vNpzTNy926eNDszo4ncRbmmcMRIUAZibnd6s5v2XSBCChAxQtCoN25gnzp7JbQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@jest/types": "^26.2.0",
+                "@types/stack-utils": "^1.0.1",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "micromatch": "^4.0.2",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.2"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "jest-mock": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.2.0.tgz",
+            "integrity": "sha512-XeC7yWtWmWByoyVOHSsE7NYsbXJLtJNgmhD7z4MKumKm6ET0si81bsSLbQ64L5saK3TgsHo2B/UqG5KNZ1Sp/Q==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "@types/node": "*"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-pnp-resolver": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "dev": true
+        },
+        "jest-regex-util": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+            "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+            "dev": true
+        },
+        "jest-resolve": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.2.2.tgz",
+            "integrity": "sha512-ye9Tj/ILn/0OgFPE/3dGpQPUqt4dHwIocxt5qSBkyzxQD8PbL0bVxBogX2FHxsd3zJA7V2H/cHXnBnNyyT9YoQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^26.2.0",
+                "read-pkg-up": "^7.0.1",
+                "resolve": "^1.17.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+                    "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+                    "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.1.0",
+                        "read-pkg": "^5.2.0",
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-resolve-dependencies": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.2.2.tgz",
+            "integrity": "sha512-S5vufDmVbQXnpP7435gr710xeBGUFcKNpNswke7RmFvDQtmqPjPVU/rCeMlEU0p6vfpnjhwMYeaVjKZAy5QYJA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-snapshot": "^26.2.2"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-runner": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.2.2.tgz",
+            "integrity": "sha512-/qb6ptgX+KQ+aNMohJf1We695kaAfuu3u3ouh66TWfhTpLd9WbqcF6163d/tMoEY8GqPztXPLuyG0rHRVDLxCA==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.2.0",
+                "@jest/environment": "^26.2.0",
+                "@jest/test-result": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "emittery": "^0.7.1",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.2.2",
+                "jest-docblock": "^26.0.0",
+                "jest-haste-map": "^26.2.2",
+                "jest-leak-detector": "^26.2.0",
+                "jest-message-util": "^26.2.0",
+                "jest-resolve": "^26.2.2",
+                "jest-runtime": "^26.2.2",
+                "jest-util": "^26.2.0",
+                "jest-worker": "^26.2.1",
+                "source-map-support": "^0.5.6",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-worker": {
+                    "version": "26.2.1",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.2.1.tgz",
+                    "integrity": "sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-runtime": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.2.2.tgz",
+            "integrity": "sha512-a8VXM3DxCDnCIdl9+QucWFfQ28KdqmyVFqeKLigHdErtsx56O2ZIdQkhFSuP1XtVrG9nTNHbKxjh5XL1UaFDVQ==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.2.0",
+                "@jest/environment": "^26.2.0",
+                "@jest/fake-timers": "^26.2.0",
+                "@jest/globals": "^26.2.0",
+                "@jest/source-map": "^26.1.0",
+                "@jest/test-result": "^26.2.0",
+                "@jest/transform": "^26.2.2",
+                "@jest/types": "^26.2.0",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.2.2",
+                "jest-haste-map": "^26.2.2",
+                "jest-message-util": "^26.2.0",
+                "jest-mock": "^26.2.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.2.2",
+                "jest-snapshot": "^26.2.2",
+                "jest-util": "^26.2.0",
+                "jest-validate": "^26.2.0",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0",
+                "yargs": "^15.3.1"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "camelcase": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "jest-validate": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.2.0.tgz",
+                    "integrity": "sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "camelcase": "^6.0.0",
+                        "chalk": "^4.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "leven": "^3.1.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "leven": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+                    "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+                    "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-serializer": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.2.0.tgz",
+            "integrity": "sha512-V7snZI9IVmyJEu0Qy0inmuXgnMWDtrsbV2p9CRAcmlmPVwpC2ZM8wXyYpiugDQnwLHx0V4+Pnog9Exb3UO8M6Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "graceful-fs": "^4.2.4"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-snapshot": {
+            "version": "26.2.2",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.2.2.tgz",
+            "integrity": "sha512-NdjD8aJS7ePu268Wy/n/aR1TUisG0BOY+QOW4f6h46UHEKOgYmmkvJhh2BqdVZQ0BHSxTMt04WpCf9njzx8KtA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^26.2.0",
+                "@types/prettier": "^2.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^26.2.0",
+                "graceful-fs": "^4.2.4",
+                "jest-diff": "^26.2.0",
+                "jest-get-type": "^26.0.0",
+                "jest-haste-map": "^26.2.2",
+                "jest-matcher-utils": "^26.2.0",
+                "jest-message-util": "^26.2.0",
+                "jest-resolve": "^26.2.2",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^26.2.0",
+                "semver": "^7.3.2"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "@types/prettier": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
+                    "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
+                    "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-diff": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.2.0.tgz",
+                    "integrity": "sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^26.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+                    "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+                    "dev": true
+                },
+                "jest-matcher-utils": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.2.0.tgz",
+                    "integrity": "sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "jest-diff": "^26.2.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.2.0"
+                    }
+                },
+                "pretty-format": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+                    "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.2.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-util": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.2.0.tgz",
+            "integrity": "sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "is-ci": "^2.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
         },
         "jest-validate": {
             "version": "23.6.0",
@@ -13254,6 +25149,233 @@
                 "jest-get-type": "^22.1.0",
                 "leven": "^2.1.0",
                 "pretty-format": "^23.6.0"
+            }
+        },
+        "jest-watch-typeahead": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.6.0.tgz",
+            "integrity": "sha512-mY0u5D1U/mEzeO/tpcDWnWaakuQiBp8gZY1K0HxduMeKSYm4WvbBVfU15a/hWMMs4J9FrXaYjAWs5XGlOpx5IQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.3.1",
+                "chalk": "^4.0.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-watcher": "^26.0.0",
+                "slash": "^3.0.0",
+                "string-length": "^4.0.1",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "string-length": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+                    "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+                    "dev": true,
+                    "requires": {
+                        "char-regex": "^1.0.2",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-watcher": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.2.0.tgz",
+            "integrity": "sha512-674Boco4Joe0CzgKPL6K4Z9LgyLx+ZvW2GilbpYb8rFEUkmDGgsZdv1Hv5rxsRpb1HLgKUOL/JfbttRCuFdZXQ==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^26.2.0",
+                "@jest/types": "^26.2.0",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "jest-util": "^26.2.0",
+                "string-length": "^4.0.1"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+                    "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "string-length": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+                    "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+                    "dev": true,
+                    "requires": {
+                        "char-regex": "^1.0.2",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                }
             }
         },
         "jest-worker": {
@@ -13276,6 +25398,35 @@
                     }
                 }
             }
+        },
+        "jfs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/jfs/-/jfs-0.3.0.tgz",
+            "integrity": "sha1-WrzkRkOw0NLZUWQ5aGjyK7FViwQ=",
+            "dev": true,
+            "requires": {
+                "async": "~2.5.0",
+                "clone": "~2.1.1",
+                "mkdirp": "~0.5.1",
+                "uuid": "^3.1.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+                    "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.14.0"
+                    }
+                }
+            }
+        },
+        "jquery": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+            "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+            "dev": true
         },
         "js-base64": {
             "version": "2.5.2",
@@ -13313,6 +25464,111 @@
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "dev": true
         },
+        "jsdom": {
+            "version": "16.3.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.3.0.tgz",
+            "integrity": "sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.3",
+                "acorn": "^7.1.1",
+                "acorn-globals": "^6.0.0",
+                "cssom": "^0.4.4",
+                "cssstyle": "^2.2.0",
+                "data-urls": "^2.0.0",
+                "decimal.js": "^10.2.0",
+                "domexception": "^2.0.1",
+                "escodegen": "^1.14.1",
+                "html-encoding-sniffer": "^2.0.1",
+                "is-potential-custom-element-name": "^1.0.0",
+                "nwsapi": "^2.2.0",
+                "parse5": "5.1.1",
+                "request": "^2.88.2",
+                "request-promise-native": "^1.0.8",
+                "saxes": "^5.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^3.0.1",
+                "w3c-hr-time": "^1.0.2",
+                "w3c-xmlserializer": "^2.0.0",
+                "webidl-conversions": "^6.1.0",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0",
+                "ws": "^7.2.3",
+                "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.88.2",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+                    "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.3",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.5.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    },
+                    "dependencies": {
+                        "tough-cookie": {
+                            "version": "2.5.0",
+                            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+                            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+                            "dev": true,
+                            "requires": {
+                                "psl": "^1.1.28",
+                                "punycode": "^2.1.1"
+                            }
+                        }
+                    }
+                },
+                "tough-cookie": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+                    "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+                    "dev": true,
+                    "requires": {
+                        "ip-regex": "^2.1.0",
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                },
+                "ws": {
+                    "version": "7.3.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+                    "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+                    "dev": true
+                }
+            }
+        },
         "jsesc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -13341,6 +25597,12 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
         "json-stringify-safe": {
@@ -13757,6 +26019,18 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
+        "kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true
+        },
+        "kuler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+            "dev": true
+        },
         "latest-version": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -13766,11 +26040,41 @@
                 "package-json": "^6.3.0"
             }
         },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true
+        },
         "lcov-parse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
             "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
             "dev": true
+        },
+        "length-prefixed-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-2.0.0.tgz",
+            "integrity": "sha512-dvjTuWTKWe0oEznQcG6a9osfiYknCs7DEFJMP88n9Y581IFhYh1sZIgAFcuDOojKB0G7ftPreKhh4D0kh/VPjQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
+                "varint": "^5.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "less": {
             "version": "3.11.3",
@@ -13839,6 +26143,213 @@
                 }
             }
         },
+        "level": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+            "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+            "dev": true,
+            "requires": {
+                "level-js": "^5.0.0",
+                "level-packager": "^5.1.0",
+                "leveldown": "^5.4.0"
+            }
+        },
+        "level-codec": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+            "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.6.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                }
+            }
+        },
+        "level-concat-iterator": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+            "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
+            "dev": true
+        },
+        "level-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+            "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+            "dev": true,
+            "requires": {
+                "errno": "~0.1.1"
+            }
+        },
+        "level-iterator-stream": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+            "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0",
+                "xtend": "^4.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "level-js": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+            "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+            "dev": true,
+            "requires": {
+                "abstract-leveldown": "~6.2.3",
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.3",
+                "ltgt": "^2.1.2"
+            },
+            "dependencies": {
+                "abstract-leveldown": {
+                    "version": "6.2.3",
+                    "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+                    "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+                    "dev": true,
+                    "requires": {
+                        "buffer": "^5.5.0",
+                        "immediate": "^3.2.3",
+                        "level-concat-iterator": "~2.0.0",
+                        "level-supports": "~1.0.0",
+                        "xtend": "~4.0.0"
+                    }
+                },
+                "buffer": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                }
+            }
+        },
+        "level-mem": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
+            "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
+            "dev": true,
+            "requires": {
+                "level-packager": "^5.0.3",
+                "memdown": "^5.0.0"
+            }
+        },
+        "level-option-wrap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/level-option-wrap/-/level-option-wrap-1.1.0.tgz",
+            "integrity": "sha1-rSDmjZ88IsiJdTHMaqevWWse0Sk=",
+            "dev": true,
+            "requires": {
+                "defined": "~0.0.0"
+            }
+        },
+        "level-packager": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+            "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+            "dev": true,
+            "requires": {
+                "encoding-down": "^6.3.0",
+                "levelup": "^4.3.2"
+            }
+        },
+        "level-party": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/level-party/-/level-party-4.0.0.tgz",
+            "integrity": "sha512-0CA7TsjfJNdWN0jIq7r+/Avcl2niQdoL9t5KpdwVB1ZDnCaX4eJBPj040FEJqqRrVhTdnKm6n/fQ78rXkWtdxw==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.0",
+                "level": "^6.0.0",
+                "multileveldown": "^3.0.0",
+                "pump": "^3.0.0"
+            }
+        },
+        "level-supports": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+            "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+            "dev": true,
+            "requires": {
+                "xtend": "^4.0.2"
+            }
+        },
+        "leveldown": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
+            "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
+            "dev": true,
+            "requires": {
+                "abstract-leveldown": "~6.2.1",
+                "napi-macros": "~2.0.0",
+                "node-gyp-build": "~4.1.0"
+            },
+            "dependencies": {
+                "abstract-leveldown": {
+                    "version": "6.2.3",
+                    "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+                    "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+                    "dev": true,
+                    "requires": {
+                        "buffer": "^5.5.0",
+                        "immediate": "^3.2.3",
+                        "level-concat-iterator": "~2.0.0",
+                        "level-supports": "~1.0.0",
+                        "xtend": "~4.0.0"
+                    }
+                },
+                "buffer": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                }
+            }
+        },
+        "levelup": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+            "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
+            "dev": true,
+            "requires": {
+                "deferred-leveldown": "~5.3.0",
+                "level-errors": "~2.0.0",
+                "level-iterator-stream": "~4.0.0",
+                "level-supports": "~1.0.0",
+                "xtend": "~4.0.0"
+            }
+        },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -13860,6 +26371,16 @@
                     "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
                     "dev": true
                 }
+            }
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "license-webpack-plugin": {
@@ -14139,6 +26660,12 @@
             "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
             "dev": true
         },
+        "lodash.assignwith": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+            "integrity": "sha1-EnqX8CrcQXUalU0ksN4X4QDgOOs=",
+            "dev": true
+        },
         "lodash.capitalize": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -14163,10 +26690,22 @@
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
         },
+        "lodash.groupby": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+            "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
+            "dev": true
+        },
         "lodash.ismatch": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
             "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+            "dev": true
+        },
+        "lodash.isnull": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
+            "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4=",
             "dev": true
         },
         "lodash.isplainobject": {
@@ -14187,10 +26726,40 @@
             "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
             "dev": true
         },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+            "dev": true
+        },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
+        },
+        "lodash.padend": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+            "dev": true
+        },
+        "lodash.partition": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+            "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=",
+            "dev": true
+        },
         "lodash.set": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
             "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+            "dev": true
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
         "lodash.template": {
@@ -14212,10 +26781,34 @@
                 "lodash._reinterpolate": "^3.0.0"
             }
         },
+        "lodash.throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+            "dev": true
+        },
         "lodash.toarray": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
             "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+            "dev": true
+        },
+        "lodash.trimstart": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/lodash.trimstart/-/lodash.trimstart-4.5.1.tgz",
+            "integrity": "sha1-j/TexTLYJIavWVc8OURZFOlEp/E=",
+            "dev": true
+        },
+        "lodash.unescape": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+            "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+            "dev": true
+        },
+        "lodash.unionby": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/lodash.unionby/-/lodash.unionby-4.8.0.tgz",
+            "integrity": "sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M=",
             "dev": true
         },
         "lodash.uniq": {
@@ -14228,6 +26821,12 @@
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
             "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+            "dev": true
+        },
+        "lodash.words": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-4.2.0.tgz",
+            "integrity": "sha1-Xs/q+Oz4rKqODIOGKV8Zk8nPQDY=",
             "dev": true
         },
         "log-driver": {
@@ -14329,11 +26928,75 @@
                 }
             }
         },
+        "logform": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+            "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+            "dev": true,
+            "requires": {
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^4.2.0",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+                    "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
         "loglevel": {
             "version": "1.6.8",
             "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
             "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
             "dev": true
+        },
+        "loglevel-colored-level-prefix": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+            "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "loglevel": "^1.4.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
         },
         "longest": {
             "version": "1.0.1",
@@ -14388,6 +27051,21 @@
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
             }
+        },
+        "lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.2"
+            }
+        },
+        "ltgt": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+            "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+            "dev": true
         },
         "macos-release": {
             "version": "2.3.0",
@@ -14464,6 +27142,33 @@
                 }
             }
         },
+        "make-plural": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+            "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "requires": {
+                "tmpl": "1.0.x"
+            }
+        },
         "mamacro": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
@@ -14537,6 +27242,31 @@
                 "supports-hyperlinks": "^1.0.1"
             }
         },
+        "math-clamp-x": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+            "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
+            "dev": true,
+            "requires": {
+                "to-number-x": "^2.0.0"
+            }
+        },
+        "math-sign-x": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
+            "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
+            "dev": true,
+            "requires": {
+                "is-nan-x": "^1.0.1",
+                "to-number-x": "^2.0.0"
+            }
+        },
+        "max-safe-integer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
+            "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA=",
+            "dev": true
+        },
         "md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -14547,6 +27277,12 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
             }
+        },
+        "mdn-data": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+            "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+            "dev": true
         },
         "mdurl": {
             "version": "1.0.1",
@@ -14570,6 +27306,91 @@
                 "p-is-promise": "^2.0.0"
             }
         },
+        "memdown": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+            "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
+            "dev": true,
+            "requires": {
+                "abstract-leveldown": "~6.2.1",
+                "functional-red-black-tree": "~1.0.1",
+                "immediate": "~3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.2.0"
+            },
+            "dependencies": {
+                "abstract-leveldown": {
+                    "version": "6.2.3",
+                    "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+                    "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+                    "dev": true,
+                    "requires": {
+                        "buffer": "^5.5.0",
+                        "immediate": "^3.2.3",
+                        "level-concat-iterator": "~2.0.0",
+                        "level-supports": "~1.0.0",
+                        "xtend": "~4.0.0"
+                    }
+                },
+                "buffer": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                },
+                "immediate": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+                    "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "dev": true
+                }
+            }
+        },
+        "memfs": {
+            "version": "2.15.5",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-2.15.5.tgz",
+            "integrity": "sha512-x8v6Uok7FRuPt8RNXnIk3HzSFB2kaJtoT6ztpfIxxURjBPPsu4eKA+ZDLQ5GdV8+Lx71+vdMaBzHxy51vLQ7dw==",
+            "dev": true,
+            "requires": {
+                "fast-extend": "0.0.2",
+                "fs-monkey": "^0.3.3"
+            },
+            "dependencies": {
+                "fast-extend": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-0.0.2.tgz",
+                    "integrity": "sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0=",
+                    "dev": true
+                }
+            }
+        },
+        "memoizee": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+            "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.45",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.5"
+            }
+        },
         "memory-fs": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -14579,6 +27400,12 @@
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
             }
+        },
+        "memorystream": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+            "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+            "dev": true
         },
         "meow": {
             "version": "3.7.0",
@@ -14611,6 +27438,70 @@
             "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
             "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
             "dev": true
+        },
+        "merge-deep": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+            "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "clone-deep": "^0.2.4",
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "clone-deep": {
+                    "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+                    "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+                    "dev": true,
+                    "requires": {
+                        "for-own": "^0.1.3",
+                        "is-plain-object": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "lazy-cache": "^1.0.3",
+                        "shallow-clone": "^0.1.2"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                },
+                "shallow-clone": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+                    "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.1",
+                        "kind-of": "^2.0.1",
+                        "lazy-cache": "^0.2.3",
+                        "mixin-object": "^2.0.1"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                            "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.0.2"
+                            }
+                        },
+                        "lazy-cache": {
+                            "version": "0.2.7",
+                            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                            "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -14645,6 +27536,29 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
             "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+            "dev": true
+        },
+        "messageformat": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
+            "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
+            "dev": true,
+            "requires": {
+                "make-plural": "^4.3.0",
+                "messageformat-formatters": "^2.0.1",
+                "messageformat-parser": "^4.1.2"
+            }
+        },
+        "messageformat-formatters": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
+            "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg==",
+            "dev": true
+        },
+        "messageformat-parser": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
+            "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==",
             "dev": true
         },
         "methods": {
@@ -14724,6 +27638,15 @@
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
             "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
             "dev": true
+        },
+        "min-document": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "dev": true,
+            "requires": {
+                "dom-walk": "^0.1.0"
+            }
         },
         "min-indent": {
             "version": "1.0.1",
@@ -14950,6 +27873,30 @@
                 }
             }
         },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+                    "dev": true
+                }
+            }
+        },
+        "mixme": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.3.5.tgz",
+            "integrity": "sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ==",
+            "dev": true
+        },
         "mkdirp": {
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -14967,11 +27914,58 @@
                 }
             }
         },
+        "mockery": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+            "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+            "dev": true
+        },
         "modify-values": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
             "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
             "dev": true
+        },
+        "module-definition": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.3.0.tgz",
+            "integrity": "sha512-HTplA9xwDzH67XJFC1YvZMUElWJD28DV0dUq7lhTs+JKJamUOWA/CcYWSlhW5amJO66uWtY7XdltT+LfX0wIVg==",
+            "dev": true,
+            "requires": {
+                "ast-module-types": "^2.6.0",
+                "node-source-walk": "^4.0.0"
+            }
+        },
+        "module-lookup-amd": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-6.2.0.tgz",
+            "integrity": "sha512-uxHCj5Pw9psZiC1znjU2qPsubt6haCSsN9m7xmIdoTciEgfxUkE1vhtDvjHPuOXEZrVJhjKgkmkP+w73rRuelQ==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.8.1",
+                "debug": "^4.1.0",
+                "file-exists-dazinatorfork": "^1.0.2",
+                "find": "^0.3.0",
+                "requirejs": "^2.3.5",
+                "requirejs-config-file": "^3.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -15009,6 +28003,54 @@
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
             "dev": true
         },
+        "multileveldown": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/multileveldown/-/multileveldown-3.0.0.tgz",
+            "integrity": "sha512-F1R1jotuSM0kD3G5HOGTzJtjv3oHLLkKX6Gy+3fjKxah0Ami1WBR2ZwURbXwo/01XXDfgyBP0ankc7Yn+boSwA==",
+            "dev": true,
+            "requires": {
+                "abstract-leveldown": "^6.2.2",
+                "duplexify": "^4.1.1",
+                "encoding-down": "^6.3.0",
+                "end-of-stream": "^1.1.0",
+                "length-prefixed-stream": "^2.0.0",
+                "levelup": "^4.3.2",
+                "numeric-id-map": "^1.1.0",
+                "protocol-buffers-encodings": "^1.1.0",
+                "reachdown": "^1.0.0"
+            },
+            "dependencies": {
+                "duplexify": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+                    "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.4.1",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^3.1.1",
+                        "stream-shift": "^1.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "murmurhash": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-0.0.2.tgz",
+            "integrity": "sha1-bwe9ihEF5wnCb8iUIMtZMMJFhf4=",
+            "dev": true
+        },
         "mute-stream": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -15019,6 +28061,12 @@
             "version": "2.14.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
             "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+            "dev": true
+        },
+        "nan-x": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.2.tgz",
+            "integrity": "sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ==",
             "dev": true
         },
         "nanomatch": {
@@ -15040,6 +28088,58 @@
                 "to-regex": "^3.0.1"
             }
         },
+        "napi-macros": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+            "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "ncp": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+            "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+            "dev": true
+        },
+        "needle": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+            "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "dev": true
+                }
+            }
+        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -15056,6 +28156,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
             "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "ng-packagr": {
@@ -15325,6 +28431,15 @@
                 "lower-case": "^1.1.1"
             }
         },
+        "node-dir": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+            "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.2"
+            }
+        },
         "node-emoji": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
@@ -15385,6 +28500,18 @@
                 }
             }
         },
+        "node-gyp-build": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+            "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
+            "dev": true
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
+        },
         "node-libs-browser": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -15414,6 +28541,63 @@
                 "url": "^0.11.0",
                 "util": "^0.11.0",
                 "vm-browserify": "^1.0.1"
+            }
+        },
+        "node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true
+        },
+        "node-notifier": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.2.tgz",
+            "integrity": "sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "growly": "^1.3.0",
+                "is-wsl": "^2.2.0",
+                "semver": "^7.3.2",
+                "shellwords": "^0.1.1",
+                "uuid": "^8.2.0",
+                "which": "^2.0.2"
+            },
+            "dependencies": {
+                "is-wsl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+                    "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-docker": "^2.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "uuid": {
+                    "version": "8.3.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+                    "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "node-releases": {
@@ -15494,6 +28678,15 @@
                 "find-parent-dir": "^0.3.0"
             }
         },
+        "node-source-walk": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.2.0.tgz",
+            "integrity": "sha512-hPs/QMe6zS94f5+jG3kk9E7TNm4P2SulrKiLWMzKszBfNZvL/V6wseHlTd7IvfW0NZWqPtK3+9yYNr+3USGteA==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.0.0"
+            }
+        },
         "nopt": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -15502,6 +28695,12 @@
             "requires": {
                 "abbrev": "1"
             }
+        },
+        "normalize-css-color": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-css-color/-/normalize-css-color-1.0.2.tgz",
+            "integrity": "sha1-Apkel8zOxmI/5XOvu/Deah8+n40=",
+            "dev": true
         },
         "normalize-package-data": {
             "version": "2.5.0",
@@ -15540,6 +28739,17 @@
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
+        },
+        "normalize-space-x": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
+            "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "trim-x": "^3.0.0",
+                "white-space-x": "^3.0.0"
+            }
         },
         "normalize-url": {
             "version": "4.5.0",
@@ -19189,6 +32399,77 @@
                 }
             }
         },
+        "npm-run-all": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+            "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "pidtree": "^0.3.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -19221,6 +32502,15 @@
                 "set-blocking": "~2.0.0"
             }
         },
+        "nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "dev": true,
+            "requires": {
+                "boolbase": "~1.0.0"
+            }
+        },
         "null-check": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
@@ -19237,6 +32527,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "numeric-id-map": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/numeric-id-map/-/numeric-id-map-1.1.0.tgz",
+            "integrity": "sha1-ERDkRFrmg+g9R56t0PbZJJ/aO9Y=",
             "dev": true
         },
         "nunjucks": {
@@ -19258,6 +32554,12 @@
                     "dev": true
                 }
             }
+        },
+        "nwsapi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+            "dev": true
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -19307,6 +32609,44 @@
                     }
                 }
             }
+        },
+        "object-diff": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/object-diff/-/object-diff-0.0.4.tgz",
+            "integrity": "sha1-2IOwRE/o/W4E5ZXXu2ZWgskWBH8=",
+            "dev": true
+        },
+        "object-get-own-property-descriptor-x": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
+            "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
+            "dev": true,
+            "requires": {
+                "attempt-x": "^1.1.0",
+                "has-own-property-x": "^3.1.1",
+                "has-symbol-support-x": "^1.4.1",
+                "is-falsey-x": "^1.0.0",
+                "is-index-x": "^1.0.0",
+                "is-primitive": "^2.0.0",
+                "is-string": "^1.0.4",
+                "property-is-enumerable-x": "^1.1.0",
+                "to-object-x": "^1.4.1",
+                "to-property-key-x": "^2.0.1"
+            },
+            "dependencies": {
+                "is-primitive": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                    "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                    "dev": true
+                }
+            }
+        },
+        "object-hash": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+            "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+            "dev": true
         },
         "object-inspect": {
             "version": "1.7.0",
@@ -19406,11 +32746,69 @@
                 "isobject": "^3.0.1"
             }
         },
+        "object.values": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+            "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.6",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+                    "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.0",
+                        "is-regex": "^1.1.0",
+                        "object-inspect": "^1.7.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.0",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+                    "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+                    "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                }
+            }
+        },
         "objectdiff": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/objectdiff/-/objectdiff-1.1.0.tgz",
             "integrity": "sha1-jXoVvmy4Zw34pJDMa+EqTwXqgvQ=",
             "dev": true
+        },
+        "objnest": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/objnest/-/objnest-3.0.9.tgz",
+            "integrity": "sha1-yBHtOVXPRgO6Ncx+A0j+oZUbk5U=",
+            "dev": true,
+            "requires": {
+                "abind": "^1.0.0",
+                "extend": "^3.0.0"
+            }
         },
         "obuf": {
             "version": "1.1.2",
@@ -19448,6 +32846,15 @@
                 "wrappy": "1"
             }
         },
+        "one-time": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+            "dev": true,
+            "requires": {
+                "fn.name": "1.x.x"
+            }
+        },
         "onetime": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -19483,6 +32890,15 @@
                 "is-wsl": "^1.1.0"
             }
         },
+        "optimism": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
+            "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+            "dev": true,
+            "requires": {
+                "@wry/context": "^0.4.0"
+            }
+        },
         "optimist": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -19498,6 +32914,198 @@
                     "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                     "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
                     "dev": true
+                }
+            }
+        },
+        "optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            }
+        },
+        "ora": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.5.tgz",
+            "integrity": "sha512-jCDgm9DqvRcNIAEv2wZPrh7E5PcQiDUnbnWbAfu4NGAE2ZNqPFbDixmWldy1YG2QfLeQhuiu6/h5VRrk6cG50w==",
+            "dev": true,
+            "requires": {
+                "chalk": "^3.0.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.2.0",
+                "is-interactive": "^1.0.0",
+                "log-symbols": "^3.0.0",
+                "mute-stream": "0.0.8",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+                    "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^3.1.0"
+                    }
+                },
+                "cli-spinners": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+                    "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "log-symbols": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+                    "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                            "dev": true,
+                            "requires": {
+                                "color-convert": "^1.9.0"
+                            }
+                        },
+                        "chalk": {
+                            "version": "2.4.2",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^3.2.1",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^5.3.0"
+                            }
+                        },
+                        "color-convert": {
+                            "version": "1.9.3",
+                            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                            "dev": true,
+                            "requires": {
+                                "color-name": "1.1.3"
+                            }
+                        },
+                        "color-name": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                            "dev": true
+                        },
+                        "has-flag": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                            "dev": true
+                        },
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "onetime": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^2.1.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+                    "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
@@ -19560,6 +33168,21 @@
             "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
             "dev": true
         },
+        "p-each-series": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+            "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+            "dev": true
+        },
+        "p-event": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+            "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+            "dev": true,
+            "requires": {
+                "p-timeout": "^3.1.0"
+            }
+        },
         "p-filter": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
@@ -19613,6 +33236,15 @@
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
             "dev": true
         },
+        "p-map-series": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+            "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+            "dev": true,
+            "requires": {
+                "p-reduce": "^1.0.0"
+            }
+        },
         "p-reduce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
@@ -19637,11 +33269,53 @@
                 }
             }
         },
+        "p-series": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-series/-/p-series-2.1.0.tgz",
+            "integrity": "sha512-vEAnkG1ikRT1kPBrKwpj7AFYQkd1hjt/oHeppxtpoPxy5gEt+OWiHZJN3tMqvFa+UJfVwO3lwHoMUpMYBLKnaQ==",
+            "dev": true,
+            "requires": {
+                "@sindresorhus/is": "^0.15.0",
+                "p-reduce": "^2.1.0"
+            },
+            "dependencies": {
+                "@sindresorhus/is": {
+                    "version": "0.15.0",
+                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.15.0.tgz",
+                    "integrity": "sha512-lu8BpxjAtRCAo5ifytTpCPCj99LF7o/2Myn+NXyNCBqvPYn7Pjd76AMmUB5l7XF1U6t0hcWrlEM5ESufW7wAeA==",
+                    "dev": true
+                },
+                "p-reduce": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+                    "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+                    "dev": true
+                }
+            }
+        },
+        "p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "dev": true,
+            "requires": {
+                "p-finally": "^1.0.0"
+            }
+        },
         "p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
+        },
+        "p-wait-for": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
+            "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
+            "dev": true,
+            "requires": {
+                "p-timeout": "^3.0.0"
+            }
         },
         "package-json": {
             "version": "6.5.0",
@@ -19661,6 +33335,15 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 }
+            }
+        },
+        "package-json-validator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-0.6.3.tgz",
+            "integrity": "sha512-juKiFboV4UKUvWQ+OSxstnyukhuluyuEoFmgZw1Rx21XzmwlgDWLcbl3qzjA3789IRORYhVFs7cmAO0YFGwHCg==",
+            "dev": true,
+            "requires": {
+                "optimist": "~0.6.0"
             }
         },
         "pacote": {
@@ -19751,6 +33434,15 @@
                 }
             }
         },
+        "pad-right": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+            "dev": true,
+            "requires": {
+                "repeat-string": "^1.5.2"
+            }
+        },
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -19793,6 +33485,15 @@
                 }
             }
         },
+        "parents": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+            "dev": true,
+            "requires": {
+                "path-platform": "~0.11.15"
+            }
+        },
         "parse-asn1": {
             "version": "5.1.5",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -19805,6 +33506,24 @@
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
+            }
+        },
+        "parse-gitignore": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-1.0.1.tgz",
+            "integrity": "sha512-UGyowyjtx26n65kdAMWhm6/3uy5uSrpcuH7tt+QEVudiBoVS+eqHxD5kbi9oWVRwj7sCzXqwuM+rUGw7earl6A==",
+            "dev": true
+        },
+        "parse-int-x": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
+            "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "nan-x": "^1.0.0",
+                "to-string-x": "^1.4.2",
+                "trim-left-x": "^3.0.0"
             }
         },
         "parse-json": {
@@ -19943,6 +33662,12 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
+        "path-platform": {
+            "version": "0.11.15",
+            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "dev": true
+        },
         "path-to-regexp": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -19983,6 +33708,12 @@
             "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
             "dev": true
         },
+        "pidtree": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+            "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+            "dev": true
+        },
         "pify": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -20002,6 +33733,15 @@
             "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
+            }
+        },
+        "pirates": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+            "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+            "dev": true,
+            "requires": {
+                "node-modules-regexp": "^1.0.0"
             }
         },
         "pkg-conf": {
@@ -20113,6 +33853,12 @@
                 "find-up": "^2.1.0"
             }
         },
+        "pkginfo": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+            "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+            "dev": true
+        },
         "please-upgrade-node": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -20121,6 +33867,18 @@
             "requires": {
                 "semver-compare": "^1.0.0"
             }
+        },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
+        },
+        "porter-stemmer": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/porter-stemmer/-/porter-stemmer-0.9.1.tgz",
+            "integrity": "sha1-oW7Oo6vkRySsiMFIACHqNrqiH5s=",
+            "dev": true
         },
         "portfinder": {
             "version": "1.0.26",
@@ -20204,6 +33962,35 @@
                 }
             }
         },
+        "postcss-js": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-1.0.1.tgz",
+            "integrity": "sha512-smhUUMF5o5W1ZCQSyh5A3lNOXFLdNrxqyhWbLsGolZH2AgVmlyhxhYbIixfsdKE6r1vG5i7O40DPcvEvE1mvjw==",
+            "dev": true,
+            "requires": {
+                "camelcase-css": "^1.0.1",
+                "postcss": "^6.0.11"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "postcss-load-config": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
@@ -20239,6 +34026,126 @@
                 }
             }
         },
+        "postcss-nested": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-3.0.0.tgz",
+            "integrity": "sha512-1xxmLHSfubuUi6xZZ0zLsNoiKfk3BWQj6fkNMaBJC529wKKLcdeCxXt6KJmDLva+trNyQNwEaE/ZWMA7cve1fA==",
+            "dev": true,
+            "requires": {
+                "postcss": "^6.0.14",
+                "postcss-selector-parser": "^3.1.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-safe-parser": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
+            "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
+            "dev": true,
+            "requires": {
+                "postcss": "^6.0.6"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-selector-matches": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz",
+            "integrity": "sha1-5WNAEeE5UIgYYbvdWMLQER/8lqs=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^0.4.2",
+                "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+            "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
+            "dev": true,
+            "requires": {
+                "dot-prop": "^5.2.0",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
+            },
+            "dependencies": {
+                "dot-prop": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+                    "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+                    "dev": true,
+                    "requires": {
+                        "is-obj": "^2.0.0"
+                    }
+                },
+                "is-obj": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+                    "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+                    "dev": true
+                }
+            }
+        },
         "postcss-url": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-8.0.0.tgz",
@@ -20266,6 +34173,12 @@
             "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
             "dev": true
         },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
         "prepend-http": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
@@ -20277,6 +34190,292 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
             "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
             "dev": true
+        },
+        "prettier-eslint": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.2.tgz",
+            "integrity": "sha512-u6EQqxUhaGfra9gy9shcR7MT7r/2twwEfRGy1tfzyaJvLQwSg34M9IU5HuF7FsLW2QUgr5VIUc56EPWibw1pdw==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/parser": "^1.10.2",
+                "common-tags": "^1.4.0",
+                "core-js": "^3.1.4",
+                "dlv": "^1.1.0",
+                "eslint": "^5.0.0",
+                "indent-string": "^4.0.0",
+                "lodash.merge": "^4.6.0",
+                "loglevel-colored-level-prefix": "^1.0.0",
+                "prettier": "^1.7.0",
+                "pretty-format": "^23.0.1",
+                "require-relative": "^0.8.7",
+                "typescript": "^3.2.1",
+                "vue-eslint-parser": "^2.0.2"
+            },
+            "dependencies": {
+                "core-js": {
+                    "version": "3.6.5",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+                    "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+                    "dev": true
+                },
+                "indent-string": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+                    "dev": true
+                }
+            }
+        },
+        "prettier-eslint-cli": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/prettier-eslint-cli/-/prettier-eslint-cli-5.0.0.tgz",
+            "integrity": "sha512-cei9UbN1aTrz3sQs88CWpvY/10PYTevzd76zoG1tdJ164OhmNTFRKPTOZrutVvscoQWzbnLKkviS3gu5JXwvZg==",
+            "dev": true,
+            "requires": {
+                "arrify": "^2.0.1",
+                "boolify": "^1.0.0",
+                "camelcase-keys": "^6.0.0",
+                "chalk": "^2.4.2",
+                "common-tags": "^1.8.0",
+                "core-js": "^3.1.4",
+                "eslint": "^5.0.0",
+                "find-up": "^4.1.0",
+                "get-stdin": "^7.0.0",
+                "glob": "^7.1.4",
+                "ignore": "^5.1.2",
+                "lodash.memoize": "^4.1.2",
+                "loglevel-colored-level-prefix": "^1.0.0",
+                "messageformat": "^2.2.1",
+                "prettier-eslint": "^9.0.0",
+                "rxjs": "^6.5.2",
+                "yargs": "^13.2.4"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "camelcase-keys": {
+                    "version": "6.2.2",
+                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+                    "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.3.1",
+                        "map-obj": "^4.0.0",
+                        "quick-lru": "^4.0.1"
+                    }
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "core-js": {
+                    "version": "3.6.5",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+                    "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "get-stdin": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+                    "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "map-obj": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+                    "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
+                    },
+                    "dependencies": {
+                        "find-up": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "^3.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                            "dev": true,
+                            "requires": {
+                                "p-locate": "^3.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "^2.0.0"
+                            }
+                        },
+                        "path-exists": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "pretty-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+            "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+            "dev": true,
+            "requires": {
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
+            }
         },
         "pretty-format": {
             "version": "23.6.0",
@@ -20325,7 +34524,6 @@
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
             "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "asap": "~2.0.3"
             }
@@ -20354,6 +34552,95 @@
                 }
             }
         },
+        "prompt": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+            "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+            "dev": true,
+            "requires": {
+                "colors": "^1.1.2",
+                "pkginfo": "0.x.x",
+                "read": "1.0.x",
+                "revalidator": "0.1.x",
+                "utile": "0.3.x",
+                "winston": "2.1.x"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+                    "dev": true
+                },
+                "colors": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+                    "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+                    "dev": true
+                },
+                "winston": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+                    "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+                    "dev": true,
+                    "requires": {
+                        "async": "~1.0.0",
+                        "colors": "1.0.x",
+                        "cycle": "1.0.x",
+                        "eyes": "0.1.x",
+                        "isstream": "0.1.x",
+                        "pkginfo": "0.3.x",
+                        "stack-trace": "0.0.x"
+                    },
+                    "dependencies": {
+                        "colors": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+                            "dev": true
+                        },
+                        "pkginfo": {
+                            "version": "0.3.1",
+                            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+                            "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "prompts": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+            "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+            "dev": true,
+            "requires": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.4"
+            }
+        },
+        "prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            }
+        },
+        "proper-lockfile": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
+            "integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "retry": "^0.12.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
         "property-information": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
@@ -20361,6 +34648,26 @@
             "dev": true,
             "requires": {
                 "xtend": "^4.0.0"
+            }
+        },
+        "property-is-enumerable-x": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
+            "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
+            "dev": true,
+            "requires": {
+                "to-object-x": "^1.4.1",
+                "to-property-key-x": "^2.0.1"
+            }
+        },
+        "protocol-buffers-encodings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.1.0.tgz",
+            "integrity": "sha512-SmjEuAf3hc3h3rWZ6V1YaaQw2MNJWK848gLJgzx/sefOJdNLujKinJVXIS0q2cBQpQn2Q32TinawZyDZPzm4kQ==",
+            "dev": true,
+            "requires": {
+                "signed-varint": "^2.0.1",
+                "varint": "^5.0.0"
             }
         },
         "protoduck": {
@@ -20513,6 +34820,27 @@
             "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
             "dev": true
         },
+        "raf": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+            "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+            "dev": true,
+            "requires": {
+                "performance-now": "^2.1.0"
+            }
+        },
+        "ramda": {
+            "version": "0.24.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
+            "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
+            "dev": true
+        },
+        "ramda-adjunct": {
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-2.27.0.tgz",
+            "integrity": "sha512-Z0+z+nEcbAguWSqlBJXLh3g4d2H82s0koDTiBm4WHkv02eXP82otRWRAqbHfoXQbUtb89XKxMz1NJKsQmC2yGA==",
+            "dev": true
+        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -20586,6 +34914,240 @@
                     "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 }
+            }
+        },
+        "reachdown": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reachdown/-/reachdown-1.1.0.tgz",
+            "integrity": "sha512-6LsdRe4cZyOjw4NnvbhUd/rGG7WQ9HMopPr+kyL018Uci4kijtxcGR5kVb5Ln13k4PEE+fEFQbjfOvNw7cnXmA==",
+            "dev": true
+        },
+        "react": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+            "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+            }
+        },
+        "react-app-polyfill": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz",
+            "integrity": "sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==",
+            "dev": true,
+            "requires": {
+                "core-js": "^3.5.0",
+                "object-assign": "^4.1.1",
+                "promise": "^8.0.3",
+                "raf": "^3.4.1",
+                "regenerator-runtime": "^0.13.3",
+                "whatwg-fetch": "^3.0.0"
+            },
+            "dependencies": {
+                "core-js": {
+                    "version": "3.6.5",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+                    "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+                    "dev": true
+                },
+                "promise": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+                    "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+                    "dev": true,
+                    "requires": {
+                        "asap": "~2.0.6"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                    "dev": true
+                }
+            }
+        },
+        "react-docgen": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.3.0.tgz",
+            "integrity": "sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.7.5",
+                "@babel/runtime": "^7.7.6",
+                "ast-types": "^0.13.2",
+                "commander": "^2.19.0",
+                "doctrine": "^3.0.0",
+                "neo-async": "^2.6.1",
+                "node-dir": "^0.1.10",
+                "strip-indent": "^3.0.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
+                    "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "doctrine": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+                    "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                    "dev": true
+                },
+                "strip-indent": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+                    "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+                    "dev": true,
+                    "requires": {
+                        "min-indent": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "react-dom": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+            "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "scheduler": "^0.19.1"
+            },
+            "dependencies": {
+                "scheduler": {
+                    "version": "0.19.1",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+                    "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                }
+            }
+        },
+        "react-hot-loader": {
+            "version": "4.12.21",
+            "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.21.tgz",
+            "integrity": "sha512-Ynxa6ROfWUeKWsTHxsrL2KMzujxJVPjs385lmB2t5cHUxdoRPGind9F00tOkdc1l5WBleOF4XEAMILY1KPIIDA==",
+            "dev": true,
+            "requires": {
+                "fast-levenshtein": "^2.0.6",
+                "global": "^4.3.0",
+                "hoist-non-react-statics": "^3.3.0",
+                "loader-utils": "^1.1.0",
+                "prop-types": "^15.6.1",
+                "react-lifecycles-compat": "^3.0.4",
+                "shallowequal": "^1.1.0",
+                "source-map": "^0.7.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                }
+            }
+        },
+        "react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true
+        },
+        "react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+            "dev": true
+        },
+        "react-native-web": {
+            "version": "0.12.3",
+            "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.12.3.tgz",
+            "integrity": "sha512-6evhZl3tzYz5IUesbHEC4/ooUkXJPIAtrmDJWe3CdpDrV6rvBNNa1Utq192YKbHPzGtETuw+5X59K0O1n5EjWQ==",
+            "dev": true,
+            "requires": {
+                "array-find-index": "^1.0.2",
+                "create-react-class": "^15.6.2",
+                "debounce": "^1.2.0",
+                "deep-assign": "^3.0.0",
+                "fbjs": "^1.0.0",
+                "hyphenate-style-name": "^1.0.3",
+                "inline-style-prefixer": "^5.1.0",
+                "normalize-css-color": "^1.0.2",
+                "prop-types": "^15.6.0",
+                "react-timer-mixin": "^0.13.4"
+            }
+        },
+        "react-reconciler": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
+            "integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "scheduler": "^0.18.0"
+            }
+        },
+        "react-test-renderer": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
+            "integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.8.6",
+                "scheduler": "^0.19.1"
+            },
+            "dependencies": {
+                "scheduler": {
+                    "version": "0.19.1",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+                    "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                }
+            }
+        },
+        "react-timer-mixin": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
+            "integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==",
+            "dev": true
+        },
+        "read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "dev": true,
+            "requires": {
+                "mute-stream": "~0.0.4"
             }
         },
         "read-cache": {
@@ -20728,6 +35290,15 @@
                 "readable-stream": "^2.0.2"
             }
         },
+        "realpath-native": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+            "dev": true,
+            "requires": {
+                "util.promisify": "^1.0.0"
+            }
+        },
         "redent": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -20865,6 +35436,12 @@
                 }
             }
         },
+        "regexpp": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+            "dev": true
+        },
         "regexpu-core": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
@@ -20952,11 +35529,60 @@
                 "xtend": "^4.0.0"
             }
         },
+        "relateurl": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+            "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+            "dev": true
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
             "dev": true
+        },
+        "renderkid": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+            "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+            "dev": true,
+            "requires": {
+                "css-select": "^1.1.0",
+                "dom-converter": "^0.2",
+                "htmlparser2": "^3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "^0.4.0"
+            },
+            "dependencies": {
+                "css-select": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+                    "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+                    "dev": true,
+                    "requires": {
+                        "boolbase": "~1.0.0",
+                        "css-what": "2.1",
+                        "domutils": "1.5.1",
+                        "nth-check": "~1.0.1"
+                    }
+                },
+                "css-what": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+                    "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+                    "dev": true
+                },
+                "domutils": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                    "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+                    "dev": true,
+                    "requires": {
+                        "dom-serializer": "0",
+                        "domelementtype": "1"
+                    }
+                }
+            }
         },
         "repeat-element": {
             "version": "1.1.3",
@@ -20977,6 +35603,16 @@
             "dev": true,
             "requires": {
                 "is-finite": "^1.0.0"
+            }
+        },
+        "replace-comments-x": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
+            "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
+            "dev": true,
+            "requires": {
+                "require-coercible-to-string-x": "^1.0.0",
+                "to-string-x": "^1.4.2"
             }
         },
         "replace-ext": {
@@ -21013,6 +35649,63 @@
                 "uuid": "^3.3.2"
             }
         },
+        "request-promise-core": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.19"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                }
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.4",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            }
+        },
+        "requestify": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/requestify/-/requestify-0.2.5.tgz",
+            "integrity": "sha1-gCSfHKff33n6KmBIrqw31D4jyQU=",
+            "dev": true,
+            "requires": {
+                "jquery": "^3.1.0",
+                "q": "^0.9.7",
+                "underscore": "^1.8.3"
+            },
+            "dependencies": {
+                "q": {
+                    "version": "0.9.7",
+                    "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+                    "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U=",
+                    "dev": true
+                }
+            }
+        },
+        "require-coercible-to-string-x": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.2.tgz",
+            "integrity": "sha512-GZ3BSCL0n/zhho8ITganW9FGPh0Kxhq71nCjck8Qau/30Wf4Po8a3XpQdzEMFiXCwZ/0m0E3lKSdSG8gkcIofQ==",
+            "dev": true,
+            "requires": {
+                "require-object-coercible-x": "^1.4.3",
+                "to-string-x": "^1.4.5"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -21024,6 +35717,46 @@
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
+        },
+        "require-object-coercible-x": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.3.tgz",
+            "integrity": "sha512-5wEaS+NIiU5HLJQTqBQ+6XHtX7yplUS374j/H/nRDlc7rMWfENqp026jnUHWAOCZ+ekixkXuFHEnTF28oqqVLA==",
+            "dev": true,
+            "requires": {
+                "is-nil-x": "^1.4.2"
+            }
+        },
+        "require-relative": {
+            "version": "0.8.7",
+            "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+            "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+            "dev": true
+        },
+        "requirejs": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+            "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+            "dev": true
+        },
+        "requirejs-config-file": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-3.1.2.tgz",
+            "integrity": "sha512-sdLWywcDuNz7EIOhenSbRfT4YF84nItDv90coN2htbokjmU2QeyQuSBZILQUKNksepl8UPVU+hgYySFaDxbJPQ==",
+            "dev": true,
+            "requires": {
+                "esprima": "^4.0.0",
+                "make-dir": "^2.1.0",
+                "stringify-object": "^3.2.1"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                }
+            }
         },
         "requires-port": {
             "version": "1.0.0",
@@ -21045,6 +35778,12 @@
             "requires": {
                 "resolve-from": "^3.0.0"
             }
+        },
+        "resolve-dependency-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-2.0.0.tgz",
+            "integrity": "sha512-DIgu+0Dv+6v2XwRaNWnumKu7GPufBBOr5I1gRPJHkvghrfCGOooJODFvgFimX/KRxk9j0whD2MnKHzM1jYvk9w==",
+            "dev": true
         },
         "resolve-dir": {
             "version": "1.0.1",
@@ -21114,10 +35853,22 @@
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
         },
+        "revalidator": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+            "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+            "dev": true
+        },
         "rfdc": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
             "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+            "dev": true
+        },
+        "rgb-hex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-3.0.0.tgz",
+            "integrity": "sha512-8h7ZcwxCBDKvchSWbWngJuSCqJGQ6nDuLLg+QcRyQDbX9jMWt+PpPeXAhSla0GOooEomk3lCprUpGkMdsLjKyg==",
             "dev": true
         },
         "right-pad": {
@@ -21239,6 +35990,12 @@
             "requires": {
                 "estree-walker": "^0.6.1"
             }
+        },
+        "rsvp": {
+            "version": "4.8.5",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+            "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+            "dev": true
         },
         "run-async": {
             "version": "2.3.0",
@@ -21487,6 +36244,68 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
+        "sane": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+            "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+            "dev": true,
+            "requires": {
+                "@cnakazawa/watch": "^1.0.3",
+                "anymatch": "^2.0.0",
+                "capture-exit": "^2.0.0",
+                "exec-sh": "^0.3.2",
+                "execa": "^1.0.0",
+                "fb-watchman": "^2.0.0",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                }
+            }
+        },
         "sass": {
             "version": "1.26.8",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.8.tgz",
@@ -21668,11 +36487,39 @@
                 }
             }
         },
+        "sass-lookup": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-3.0.0.tgz",
+            "integrity": "sha512-TTsus8CfFRn1N44bvdEai1no6PqdmDiQUiqW5DlpmtT+tYnIt1tXtDIph5KA1efC+LmioJXSnCtUVpcK9gaKIg==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.16.0"
+            }
+        },
         "sax": {
             "version": "0.5.8",
             "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
             "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
             "dev": true
+        },
+        "saxes": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+            "dev": true,
+            "requires": {
+                "xmlchars": "^2.2.0"
+            }
+        },
+        "scheduler": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+            "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+            }
         },
         "schema-utils": {
             "version": "2.7.0",
@@ -22323,6 +37170,23 @@
                 "upper-case-first": "^1.1.2"
             }
         },
+        "serialize-error": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+            "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+            "dev": true,
+            "requires": {
+                "type-fest": "^0.8.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                    "dev": true
+                }
+            }
+        },
         "serialize-javascript": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
@@ -22445,6 +37309,12 @@
                 "kind-of": "^6.0.2"
             }
         },
+        "shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+            "dev": true
+        },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -22459,6 +37329,19 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
+        },
+        "shell-quote": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+            "dev": true
+        },
+        "shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true,
+            "optional": true
         },
         "sigmund": {
             "version": "1.0.1",
@@ -22483,6 +37366,38 @@
                 "pkg-conf": "^2.1.0"
             }
         },
+        "signed-varint": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+            "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+            "dev": true,
+            "requires": {
+                "varint": "~5.0.0"
+            }
+        },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+                    "dev": true
+                }
+            }
+        },
+        "sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true
+        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -22500,6 +37415,36 @@
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
             "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
             "dev": true
+        },
+        "smartwrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-1.2.5.tgz",
+            "integrity": "sha512-bzWRwHwu0RnWjwU7dFy7tF68pDAx/zMSu3g7xr9Nx5J0iSImYInglwEVExyHLxXljy6PWMjkSAbwF7t2mPnRmg==",
+            "dev": true,
+            "requires": {
+                "breakword": "^1.0.5",
+                "grapheme-splitter": "^1.0.4",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1",
+                "yargs": "^15.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
         },
         "snake-case": {
             "version": "2.1.0",
@@ -23099,6 +38044,26 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
+        "ssh2": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.5.tgz",
+            "integrity": "sha1-x3gezS7OcwSiU89iD6taXCK7IjU=",
+            "dev": true,
+            "requires": {
+                "ssh2-streams": "~0.1.18"
+            }
+        },
+        "ssh2-streams": {
+            "version": "0.1.20",
+            "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+            "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.0",
+                "semver": "^5.1.0",
+                "streamsearch": "~0.1.2"
+            }
+        },
         "sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -23125,11 +38090,34 @@
                 "figgy-pudding": "^3.5.1"
             }
         },
+        "stable": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+            "dev": true
+        },
         "stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
             "dev": true
+        },
+        "stack-utils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+            "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                }
+            }
         },
         "staged-git-files": {
             "version": "1.1.1",
@@ -23172,6 +38160,12 @@
             "requires": {
                 "readable-stream": "^2.0.1"
             }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
         },
         "stream-browserify": {
             "version": "2.0.2",
@@ -23222,6 +38216,15 @@
             "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
+        "stream-transform": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.0.2.tgz",
+            "integrity": "sha512-J+D5jWPF/1oX+r9ZaZvEXFbu7znjxSkbNAHJ9L44bt/tCVuOEWZlDqU9qJk7N2xBU1S+K2DPpSKeR/MucmCA1Q==",
+            "dev": true,
+            "requires": {
+                "mixme": "^0.3.1"
+            }
+        },
         "streamroller": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
@@ -23267,6 +38270,12 @@
                 }
             }
         },
+        "streamsearch": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+            "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+            "dev": true
+        },
         "strict-uri-encode": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -23279,6 +38288,59 @@
             "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
             "dev": true
         },
+        "string-format": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/string-format/-/string-format-0.5.0.tgz",
+            "integrity": "sha1-v8SmmiUPF/Jz2XM2eX2vXcpuzzA=",
+            "dev": true
+        },
+        "string-length": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+            "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+            "dev": true,
+            "requires": {
+                "astral-regex": "^1.0.0",
+                "strip-ansi": "^5.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "astral-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+                    "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "string-to-color": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/string-to-color/-/string-to-color-2.2.1.tgz",
+            "integrity": "sha512-8t85UnYqQfBhL3BmAP4Zp3P/jlAqx7KqniiMLBeUKq0o0orGVqL2K7RrCwEsCG1s+V7B2XYfu8lCDXGIG+Geag==",
+            "dev": true,
+            "requires": {
+                "colornames": "^1.1.1",
+                "hex-rgb": "^4.1.0",
+                "lodash.padend": "^4.6.1",
+                "lodash.trimstart": "^4.5.1",
+                "lodash.words": "^4.2.0",
+                "rgb-hex": "^3.0.0"
+            }
+        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -23288,6 +38350,52 @@
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
+            }
+        },
+        "string.prototype.padend": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+            "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.6",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+                    "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.0",
+                        "is-regex": "^1.1.0",
+                        "object-inspect": "^1.7.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.0",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+                    "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+                    "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                }
             }
         },
         "string.prototype.trimend": {
@@ -23411,6 +38519,12 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "stringcase": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/stringcase/-/stringcase-3.2.1.tgz",
+            "integrity": "sha1-iTRRYwSXZM92q89c4Ctkv7ZHLlY=",
+            "dev": true
+        },
         "stringify-entities": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
@@ -23435,6 +38549,12 @@
                 "is-regexp": "^1.0.0"
             }
         },
+        "stringify-package": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
+            "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
+            "dev": true
+        },
         "stringmap": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
@@ -23457,6 +38577,25 @@
             "dev": true,
             "requires": {
                 "is-utf8": "^0.2.0"
+            }
+        },
+        "strip-bom-buf": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+            "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "strip-bom-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+            "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+            "dev": true,
+            "requires": {
+                "first-chunk-stream": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-eof": {
@@ -23485,6 +38624,62 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
+        },
+        "strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
+        "stylable": {
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/stylable/-/stylable-5.4.11.tgz",
+            "integrity": "sha1-pU+9DK2QK1+Y89ASJ7Y1J6appNc=",
+            "dev": true,
+            "requires": {
+                "clean-css": "^4.1.11",
+                "css-selector-tokenizer": "^0.7.0",
+                "deindent": "^0.1.0",
+                "enhanced-resolve": "^4.0.0",
+                "is-vendor-prefixed": "^1.0.0",
+                "lodash.clonedeep": "^4.5.0",
+                "murmurhash": "^0.0.2",
+                "postcss": "^6.0.23",
+                "postcss-js": "^1.0.1",
+                "postcss-nested": "^3.0.0",
+                "postcss-safe-parser": "^3.0.1",
+                "postcss-selector-matches": "^3.0.1",
+                "postcss-value-parser": "^3.3.0",
+                "url-regex": "^4.1.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
         },
         "style-loader": {
             "version": "1.0.0",
@@ -23561,6 +38756,47 @@
                 "when": "~3.6.x"
             }
         },
+        "stylus-lookup": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-3.0.2.tgz",
+            "integrity": "sha512-oEQGHSjg/AMaWlKe7gqsnYzan8DLcGIHe0dUaFkucZZ14z4zjENRlQMCHT4FNsiWnJf17YN9OvrCfCoi7VvOyg==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.8.1",
+                "debug": "^4.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "subleveldown": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-4.1.4.tgz",
+            "integrity": "sha512-njpSBP/Bxh7EahraG6IhR6goOH2ffMTMVt7Ud+k/OhNFHrrmuvK+XYfauI8KnjCm0w381cUF43pejlWeJMZChA==",
+            "dev": true,
+            "requires": {
+                "abstract-leveldown": "^6.1.1",
+                "encoding-down": "^6.2.0",
+                "inherits": "^2.0.3",
+                "level-option-wrap": "^1.1.0",
+                "levelup": "^4.3.1",
+                "reachdown": "^1.0.0"
+            }
+        },
         "sugar": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/sugar/-/sugar-2.0.6.tgz",
@@ -23601,6 +38837,57 @@
                 }
             }
         },
+        "svg-parser": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+            "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+            "dev": true
+        },
+        "svgo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+            "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "coa": "^2.0.2",
+                "css-select": "^2.0.0",
+                "css-select-base-adapter": "^0.1.1",
+                "css-tree": "1.0.0-alpha.37",
+                "csso": "^4.0.2",
+                "js-yaml": "^3.13.1",
+                "mkdirp": "~0.5.1",
+                "object.values": "^1.1.0",
+                "sax": "~1.2.4",
+                "stable": "^0.1.8",
+                "unquote": "~1.1.1",
+                "util.promisify": "~1.0.0"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "1.0.0-alpha.37",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+                    "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+                    "dev": true,
+                    "requires": {
+                        "mdn-data": "2.0.4",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "swap-case": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
@@ -23615,6 +38902,93 @@
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
             "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
             "dev": true
+        },
+        "symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
+        },
+        "symlink-or-copy": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz",
+            "integrity": "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==",
+            "dev": true
+        },
+        "synchronous-promise": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
+            "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==",
+            "dev": true
+        },
+        "table": {
+            "version": "5.4.6",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+            "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "astral-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+                    "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "slice-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+                    "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "astral-regex": "^1.0.0",
+                        "is-fullwidth-code-point": "^2.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
         },
         "tapable": {
             "version": "1.1.3",
@@ -23632,6 +39006,38 @@
                 "fstream": "^1.0.12",
                 "inherits": "2"
             }
+        },
+        "tar-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+            "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+            "dev": true,
+            "requires": {
+                "bl": "^4.0.1",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "temp": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
+            "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
+            "dev": true
         },
         "temp-dir": {
             "version": "1.0.0",
@@ -23692,6 +39098,58 @@
                         "signal-exit": "^3.0.0",
                         "strip-eof": "^1.0.0"
                     }
+                }
+            }
+        },
+        "terminal-link": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+            "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "supports-hyperlinks": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "supports-hyperlinks": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+                    "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
                 }
             }
         },
@@ -23829,10 +39287,39 @@
                 }
             }
         },
+        "test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "requires": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            }
+        },
         "text-extensions": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
             "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+            "dev": true
+        },
+        "text-hex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+            "dev": true
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "throat": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+            "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
             "dev": true
         },
         "through": {
@@ -23866,6 +39353,16 @@
                 "setimmediate": "^1.0.4"
             }
         },
+        "timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
+            }
+        },
         "title-case": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
@@ -23875,6 +39372,12 @@
                 "upper-case": "^1.0.3"
             }
         },
+        "tlds": {
+            "version": "1.207.0",
+            "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.207.0.tgz",
+            "integrity": "sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==",
+            "dev": true
+        },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -23883,6 +39386,12 @@
             "requires": {
                 "os-tmpdir": "~1.0.2"
             }
+        },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
         },
         "to-array": {
             "version": "0.1.4",
@@ -23896,11 +39405,42 @@
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
         },
+        "to-boolean-x": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.3.tgz",
+            "integrity": "sha512-kQiMyJUgFprL8J+0CfgJuaSFKJMs3EvFe27/6aj/hVzVZT0HY4aA1QjPldLNxzBmjhLcapp7CctYHuD8QqtS3g==",
+            "dev": true
+        },
         "to-fast-properties": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
             "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
             "dev": true
+        },
+        "to-integer-x": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
+            "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
+            "dev": true,
+            "requires": {
+                "is-finite-x": "^3.0.2",
+                "is-nan-x": "^1.0.1",
+                "math-sign-x": "^3.0.0",
+                "to-number-x": "^2.0.0"
+            }
+        },
+        "to-number-x": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
+            "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "nan-x": "^1.0.0",
+                "parse-int-x": "^2.0.0",
+                "to-primitive-x": "^1.1.0",
+                "trim-x": "^3.0.0"
+            }
         },
         "to-object-path": {
             "version": "0.3.0",
@@ -23920,6 +39460,51 @@
                         "is-buffer": "^1.1.5"
                     }
                 }
+            }
+        },
+        "to-object-x": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
+            "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "require-object-coercible-x": "^1.4.1"
+            }
+        },
+        "to-primitive-x": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
+            "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
+            "dev": true,
+            "requires": {
+                "has-symbol-support-x": "^1.4.1",
+                "is-date-object": "^1.0.1",
+                "is-function-x": "^3.2.0",
+                "is-nil-x": "^1.4.1",
+                "is-primitive": "^2.0.0",
+                "is-symbol": "^1.0.1",
+                "require-object-coercible-x": "^1.4.1",
+                "validate.io-undefined": "^1.0.3"
+            },
+            "dependencies": {
+                "is-primitive": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                    "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                    "dev": true
+                }
+            }
+        },
+        "to-property-key-x": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
+            "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
+            "dev": true,
+            "requires": {
+                "has-symbol-support-x": "^1.4.1",
+                "to-primitive-x": "^1.1.0",
+                "to-string-x": "^1.4.2"
             }
         },
         "to-readable-stream": {
@@ -23950,6 +39535,37 @@
                 "repeat-string": "^1.6.1"
             }
         },
+        "to-string-symbols-supported-x": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.2.tgz",
+            "integrity": "sha512-3MRqhIhSNVDsVAk4M6WNcuBZrAQe54W13xrXX6RzxXS+pA4nj6DQ96RegQS5z9BSNyYbFsBsPvMVDIpP+a/5RA==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.2",
+                "has-symbol-support-x": "^1.4.2",
+                "is-symbol": "^1.0.1"
+            }
+        },
+        "to-string-tag-x": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.3.tgz",
+            "integrity": "sha512-5+0EZ6dOVt/XArXmkooxPzWxmOR081HM/uXitUow7h11WYg5pPo15uYqDWuqO7ZY+O3Atn/dG26wcJCK+mFevg==",
+            "dev": true,
+            "requires": {
+                "lodash.isnull": "^3.0.0",
+                "validate.io-undefined": "^1.0.3"
+            }
+        },
+        "to-string-x": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.5.tgz",
+            "integrity": "sha512-5xzlZDyDa9BUWNjNzZzHgKQ95PnV7qjvEhbqpFaj1ixaHgfJXOFaa3xdMJ+WLYd4hhaMJaxt8Pt5uKaWXfruXA==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "is-symbol": "^1.0.1"
+            }
+        },
         "toidentifier": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -23966,10 +39582,33 @@
                 "punycode": "^1.4.1"
             }
         },
+        "tr46": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+            "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                }
+            }
+        },
         "traverse": {
             "version": "0.6.6",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
             "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+            "dev": true
+        },
+        "traverse-chain": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+            "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
             "dev": true
         },
         "tree-kill": {
@@ -23977,6 +39616,17 @@
             "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
             "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
             "dev": true
+        },
+        "trim-left-x": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
+            "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "require-coercible-to-string-x": "^1.0.0",
+                "white-space-x": "^3.0.0"
+            }
         },
         "trim-newlines": {
             "version": "1.0.0",
@@ -23990,10 +39640,46 @@
             "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
             "dev": true
         },
+        "trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
         "trim-right": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "trim-right-x": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
+            "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
+            "dev": true,
+            "requires": {
+                "cached-constructors-x": "^1.0.0",
+                "require-coercible-to-string-x": "^1.0.0",
+                "white-space-x": "^3.0.0"
+            }
+        },
+        "trim-x": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
+            "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
+            "dev": true,
+            "requires": {
+                "trim-left-x": "^3.0.0",
+                "trim-right-x": "^3.0.0"
+            }
+        },
+        "triple-beam": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
             "dev": true
         },
         "trough": {
@@ -24009,6 +39695,15 @@
             "dev": true,
             "requires": {
                 "glob": "^7.1.2"
+            }
+        },
+        "ts-invariant": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+            "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.3"
             }
         },
         "ts-node": {
@@ -24105,11 +39800,101 @@
                 "tslib": "^1.8.1"
             }
         },
+        "tsyringe": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.3.0.tgz",
+            "integrity": "sha512-Vzty1M/EQXSsEE8aoIOLl1l793chcPyQAnFJaS1mFDtFvNPY+jknSPwMIF6yfcjua+2GTgwxWFzuA3cjIx4NZA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.3"
+            }
+        },
         "tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
             "dev": true
+        },
+        "tty-table": {
+            "version": "2.8.13",
+            "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-2.8.13.tgz",
+            "integrity": "sha512-eVV/+kB6fIIdx+iUImhXrO22gl7f6VmmYh0Zbu6C196fe1elcHXd7U6LcLXu0YoVPc2kNesWiukYcdK8ZmJ6aQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "^3.0.0",
+                "csv": "^5.3.1",
+                "smartwrap": "^1.2.3",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1",
+                "yargs": "^15.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "tunnel-agent": {
             "version": "0.6.0",
@@ -24124,6 +39909,27 @@
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
         },
         "type-fest": {
@@ -24147,6 +39953,15 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "requires": {
+                "is-typedarray": "^1.0.0"
+            }
         },
         "typescript": {
             "version": "3.5.3",
@@ -24198,6 +40013,18 @@
                     "dev": true
                 }
             }
+        },
+        "uid-number": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+            "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+            "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+            "dev": true
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "1.0.4",
@@ -24254,6 +40081,35 @@
                 "is-extendable": "^0.1.1",
                 "set-value": "^2.0.1"
             }
+        },
+        "unionfs": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-3.0.2.tgz",
+            "integrity": "sha512-PmPNhDthSs60NkvZOj9vUKGacNgZWXpimw5tkqNzNA5Aoan114ISjTnkBxii36b3upQQPKCflz55vQQMQ6z8WQ==",
+            "dev": true,
+            "requires": {
+                "fs-monkey": "^0.2.2"
+            },
+            "dependencies": {
+                "fs-monkey": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-0.2.2.tgz",
+                    "integrity": "sha512-iGmwUuLYN6COLpwBqs9RfBREWkMbbRC7Xj+tsqcW/iaRI7KmUcjnScDLJxSIJo4DM85w76fdVWgagQHzClA0WA==",
+                    "dev": true
+                }
+            }
+        },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "uniqid": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.2.0.tgz",
+            "integrity": "sha512-LH8zsvwJ/GL6YtNfSOmMCrI9piraAUjBfw2MCvleNE6a4pVKJwXjG2+HWhkVeFcSg+nmaPKbMrMOoxwQluZ1Mg==",
+            "dev": true
         },
         "unique-filename": {
             "version": "1.1.1",
@@ -24344,6 +40200,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unquote": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+            "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
             "dev": true
         },
         "unset-value": {
@@ -24516,6 +40378,24 @@
                 }
             }
         },
+        "url-regex": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-4.1.1.tgz",
+            "integrity": "sha512-ViSDgDPNKkrQHI81GLCjdDN+Rsk3tAW/uLXlBOJxtcHzWZjta58Z0APXhfXzS89YszsheMnEvXeDXsWUB53wwA==",
+            "dev": true,
+            "requires": {
+                "ip-regex": "^1.0.1",
+                "tlds": "^1.187.0"
+            },
+            "dependencies": {
+                "ip-regex": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
+                    "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
+                    "dev": true
+                }
+            }
+        },
         "urlencode": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/urlencode/-/urlencode-1.1.0.tgz",
@@ -24530,6 +40410,15 @@
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
+        },
+        "user-home": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+            "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0"
+            }
         },
         "util": {
             "version": "0.11.1",
@@ -24563,6 +40452,98 @@
                 "object.getownpropertydescriptors": "^2.0.3"
             }
         },
+        "util.promisify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+            "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.2",
+                "has-symbols": "^1.0.1",
+                "object.getownpropertydescriptors": "^2.1.0"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.6",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+                    "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.0",
+                        "is-regex": "^1.1.0",
+                        "object-inspect": "^1.7.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.0",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+                    "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+                    "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object.getownpropertydescriptors": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+                    "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.17.0-next.1"
+                    }
+                }
+            }
+        },
+        "utila": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+            "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+            "dev": true
+        },
+        "utile": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+            "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+            "dev": true,
+            "requires": {
+                "async": "~0.9.0",
+                "deep-equal": "~0.2.1",
+                "i": "0.3.x",
+                "mkdirp": "0.x.x",
+                "ncp": "1.0.x",
+                "rimraf": "2.x.x"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "dev": true
+                },
+                "deep-equal": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+                    "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+                    "dev": true
+                }
+            }
+        },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -24574,6 +40555,31 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
             "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
             "dev": true
+        },
+        "v8-compile-cache": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+            "dev": true
+        },
+        "v8-to-istanbul": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+            "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^1.6.0",
+                "source-map": "^0.7.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                }
+            }
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -24594,16 +40600,34 @@
                 "builtins": "^1.0.3"
             }
         },
+        "validate.io-undefined": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
+            "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q=",
+            "dev": true
+        },
         "validate.js": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.12.0.tgz",
             "integrity": "sha512-/x2RJSvbqEyxKj0RPN4xaRquK+EggjeVXiDDEyrJzsJogjtiZ9ov7lj/svVb4DM5Q5braQF4cooAryQbUwOxlA==",
             "dev": true
         },
+        "varint": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+            "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=",
+            "dev": true
+        },
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
+        },
+        "vendor-prefixes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vendor-prefixes/-/vendor-prefixes-1.0.0.tgz",
+            "integrity": "sha1-HHuS7ORuLxoGxakHYT9dUARd9TE=",
             "dev": true
         },
         "verror": {
@@ -24662,6 +40686,41 @@
                 "unist-util-stringify-position": "^2.0.0"
             }
         },
+        "vinyl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+            "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+            "dev": true,
+            "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+            }
+        },
+        "vinyl-file": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-3.0.0.tgz",
+            "integrity": "sha1-sQTZ5ECf+jJfqt1SBkLQo7SIs2U=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.3.0",
+                "strip-bom-buf": "^1.0.0",
+                "strip-bom-stream": "^2.0.0",
+                "vinyl": "^2.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
         "vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -24673,6 +40732,117 @@
             "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
             "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
             "dev": true
+        },
+        "vue-eslint-parser": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
+            "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "eslint-scope": "^3.7.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^3.5.2",
+                "esquery": "^1.0.0",
+                "lodash": "^4.17.4"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.4",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+                    "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+                    "dev": true
+                },
+                "acorn-jsx": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+                    "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "acorn": {
+                            "version": "3.3.0",
+                            "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                            "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                            "dev": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "3.7.3",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+                    "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "espree": {
+                    "version": "3.5.4",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+                    "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^5.5.0",
+                        "acorn-jsx": "^3.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "vue-template-compiler": {
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
+            "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
+            "dev": true,
+            "requires": {
+                "de-indent": "^1.0.2",
+                "he": "^1.1.0"
+            }
+        },
+        "w3c-hr-time": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "w3c-xmlserializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+            "dev": true,
+            "requires": {
+                "xml-name-validator": "^3.0.0"
+            }
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "requires": {
+                "makeerror": "1.0.x"
+            }
         },
         "watchpack": {
             "version": "1.7.2",
@@ -24735,10 +40905,25 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "requires": {
+                "defaults": "^1.0.3"
+            }
+        },
         "web-namespaces": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
             "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+            "dev": true
+        },
+        "webidl-conversions": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
             "dev": true
         },
         "webpack": {
@@ -25174,6 +41359,46 @@
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true
         },
+        "whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "whatwg-fetch": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
+            "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
+            "dev": true
+        },
+        "whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
+            "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^2.0.2",
+                "webidl-conversions": "^5.0.0"
+            },
+            "dependencies": {
+                "webidl-conversions": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                    "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+                    "dev": true
+                }
+            }
+        },
         "when": {
             "version": "3.6.4",
             "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
@@ -25193,6 +41418,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "white-space-x": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.1.tgz",
+            "integrity": "sha512-BwMFXQNPna/4RsNPOgldVYn+FkEv+lc3wUiFzuaW6Z2DH/oSk1UrRD6SBqDgWQO4JU+aBq3PVuPD9Vz0j7mh0w==",
             "dev": true
         },
         "wide-align": {
@@ -25326,6 +41557,33 @@
                 }
             }
         },
+        "winston-transport": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+            "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.3.7",
+                "triple-beam": "^1.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
+            }
+        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -25372,6 +41630,15 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
+        "write": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^0.5.1"
+            }
+        },
         "write-file-atomic": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
@@ -25408,6 +41675,18 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
             "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true
         },
         "xmlhttprequest": {
             "version": "1.8.0",
@@ -25587,6 +41866,31 @@
             "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
             "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
             "dev": true
+        },
+        "yoga-layout-prebuilt": {
+            "version": "1.9.6",
+            "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.6.tgz",
+            "integrity": "sha512-Wursw6uqLXLMjBAO4SEShuzj8+EJXhCF71/rJ7YndHTkRAYSU0GY3OghRqfAk9HPUAAFMuqp3U1Wl+01vmGRQQ==",
+            "dev": true,
+            "requires": {
+                "@types/yoga-layout": "1.9.2"
+            }
+        },
+        "zen-observable": {
+            "version": "0.8.15",
+            "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+            "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+            "dev": true
+        },
+        "zen-observable-ts": {
+            "version": "0.8.21",
+            "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+            "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.3",
+                "zen-observable": "^0.8.0"
+            }
         },
         "zone.js": {
             "version": "0.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4812,6 +4812,16 @@
                 "@types/node": "*"
             }
         },
+        "@types/inquirer": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.0.tgz",
+            "integrity": "sha512-wcPs5jTrZYQBzzPlvUEzBcptzO4We2sijSvkBq8oAKRMJoH8PvrmP6QQnxLB5RScNUmRfujxA+ngxD4gk4xe7Q==",
+            "dev": true,
+            "requires": {
+                "@types/through": "*",
+                "rxjs": "^6.4.0"
+            }
+        },
         "@types/jasmine": {
             "version": "2.8.16",
             "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.16.tgz",
@@ -4890,6 +4900,15 @@
             "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
             "dev": true
         },
+        "@types/through": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+            "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/unist": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -4934,6 +4953,21 @@
                     "dev": true
                 }
             }
+        },
+        "@types/yargs": {
+            "version": "15.0.5",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+            "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+            "dev": true,
+            "requires": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "@types/yargs-parser": {
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+            "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+            "dev": true
         },
         "@webassemblyjs/ast": {
             "version": "1.8.5",
@@ -6741,63 +6775,82 @@
             "dev": true
         },
         "cliui": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
             "dev": true,
             "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
                 "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
                     "dev": true,
                     "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
+                        "ansi-regex": "^5.0.0"
                     }
                 },
                 "wrap-ansi": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.0",
-                        "string-width": "^3.0.0",
-                        "strip-ansi": "^5.0.0"
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
                     }
                 }
             }
@@ -6938,6 +6991,12 @@
                 "strip-json-comments": "3.0.1"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "conventional-commit-types": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
@@ -6990,6 +7049,33 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
+                "inquirer": {
+                    "version": "6.5.0",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+                    "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.2.0",
+                        "chalk": "^2.4.2",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.17.12",
+                        "mute-stream": "0.0.7",
+                        "run-async": "^2.2.0",
+                        "rxjs": "^6.4.0",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^5.1.0",
+                        "through": "^2.3.6"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
                 "longest": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
@@ -7001,6 +7087,50 @@
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
                     "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                            "dev": true
+                        }
+                    }
                 },
                 "strip-bom": {
                     "version": "4.0.0",
@@ -11055,6 +11185,12 @@
             "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
             "dev": true
         },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
         "get-own-enumerable-property-symbols": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
@@ -12263,75 +12399,186 @@
             "dev": true
         },
         "inquirer": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-            "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.2.0",
-                "chalk": "^2.4.2",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
                 "external-editor": "^3.0.3",
-                "figures": "^2.0.0",
-                "lodash": "^4.17.12",
-                "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^6.4.0",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^5.1.0",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.19",
+                "mute-stream": "0.0.8",
+                "run-async": "^2.4.0",
+                "rxjs": "^6.6.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
                 "through": "^2.3.6"
             },
             "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
                 "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+                    "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^3.1.0"
+                    }
+                },
+                "cli-width": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+                    "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "figures": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+                    "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^3.0.0"
-                            }
-                        }
+                        "mimic-fn": "^2.1.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+                    "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "run-async": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+                    "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+                    "dev": true
+                },
+                "rxjs": {
+                    "version": "6.6.2",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+                    "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.9.0"
+                    }
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                            "dev": true
-                        }
+                        "ansi-regex": "^5.0.0"
                     }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
                 }
             }
         },
@@ -14763,9 +15010,9 @@
             "dev": true
         },
         "mute-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "nan": {
@@ -20772,6 +21019,12 @@
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true
         },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
+        },
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -21253,6 +21506,145 @@
                 "lodash": "^4.0.0",
                 "scss-tokenizer": "^0.2.3",
                 "yargs": "^13.3.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
             }
         },
         "sass-loader": {
@@ -24482,6 +24874,18 @@
                 "yargs": "^13.3.2"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
                 "chokidar": {
                     "version": "2.1.8",
                     "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -24502,6 +24906,28 @@
                         "upath": "^1.1.1"
                     }
                 },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        }
+                    }
+                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -24509,6 +24935,37 @@
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
+                    }
+                },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "ms": {
@@ -24523,6 +24980,24 @@
                     "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
                     "dev": true
                 },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
                 "p-retry": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
@@ -24531,6 +25006,12 @@
                     "requires": {
                         "retry": "^0.12.0"
                     }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
                 },
                 "schema-utils": {
                     "version": "1.0.0",
@@ -24549,6 +25030,28 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        }
+                    }
+                },
                 "supports-color": {
                     "version": "6.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -24556,6 +25059,56 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        }
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
@@ -24904,64 +25457,53 @@
             }
         },
         "yargs": {
-            "version": "13.3.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-            "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
             "dev": true,
             "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
                 "get-caller-file": "^2.0.1",
                 "require-directory": "^2.1.1",
                 "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
+                "string-width": "^4.2.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.2"
+                "yargs-parser": "^18.1.2"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 },
                 "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
-                "get-caller-file": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-                    "dev": true
-                },
                 "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
                 "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-limit": {
@@ -24974,12 +25516,12 @@
                     }
                 },
                 "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^2.0.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "p-try": {
@@ -24988,38 +25530,38 @@
                     "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
                 },
-                "require-main-filename": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
                     "dev": true
                 },
                 "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
                     "dev": true,
                     "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
+                        "ansi-regex": "^5.0.0"
                     }
                 }
             }
         },
         "yargs-parser": {
-            "version": "13.1.2",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "ng": "ng",
+    "bit": "bit",
     "start": "npm run dev-mode && ng serve -o",
     "docs": "ts-node scripts/docs.ts && node scripts/generate-usage-docs.js",
     "test": "ng test cashmere",
@@ -21,8 +22,8 @@
     "lint:prettier": "prettier --debug-check \"**/*.{ts,js,scss,css,md,json}\"",
     "build:lib": "ng build cashmere --prod",
     "postbuild:lib": "node scripts/postbuild.js",
-    "prebuild:bit": "cd projects/cashmere-bits && npx --package bit-bin bit config set analytics_reporting false && npx --package bit-bin bit config set error_reporting false",
-    "build:bit": "cd projects/cashmere-bits && npx --package bit-bin bit import && npx --package bit-bin bit build",
+    "prebuild:bit": "cd projects/cashmere-bits && npm run bit -- config set analytics_reporting false && npm run bit -- config set error_reporting false",
+    "build:bit": "cd projects/cashmere-bits && npm run bit -- import && npm run bit -- build",
     "build:user": "ng build user-guide",
     "prebuild:examples": "ts-node scripts/build-examples.ts",
     "build:examples": "ng build cashmere-examples --prod",
@@ -39,7 +40,8 @@
     "dev-mode": "node scripts/dev-mode",
     "postinstall": "npm run install:examples && npm run install:bits",
     "install:examples": "cd projects/cashmere-examples && npm install",
-    "install:bits": "cd projects/cashmere-bits && npm install"
+    "install:bits": "cd projects/cashmere-bits && npm install",
+    "new:example": "ts-node scripts/new-example.ts"
   },
   "dependencies": {
     "@angular/animations": "8.2.14",
@@ -82,10 +84,13 @@
     "@types/d3": "^5.0.0",
     "@types/fs-extra": "^5.0.4",
     "@types/glob": "^5.0.35",
+    "@types/inquirer": "^7.3.0",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "9.6.2",
     "@types/prettier": "^1.15.2",
+    "@types/yargs": "^15.0.5",
+    "bit-bin": "^14.8.8",
     "chalk": "^2.3.0",
     "codelyzer": "^5.0.1",
     "commitizen": "^4.1.2",
@@ -98,6 +103,7 @@
     "glob": "^7.1.2",
     "highlight.js": "^9.18.1",
     "husky": "^0.14.3",
+    "inquirer": "^7.3.3",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "^5.1.0",
@@ -123,7 +129,8 @@
     "tslint-config-prettier": "^1.13.0",
     "typescript": "~3.5.0",
     "typescript-formatter": "^7.0.1",
-    "uglify-js": "3.3.18"
+    "uglify-js": "3.3.18",
+    "yargs": "^15.4.1"
   },
   "config": {
     "commitizen": {

--- a/projects/cashmere-bits/package.json
+++ b/projects/cashmere-bits/package.json
@@ -4,6 +4,7 @@
     "authors": "Health Catalyst",
     "version": "1.0.0",
     "scripts": {
+        "bit": "bit",
         "test": "jest"
     },
     "peerDependencies": {

--- a/scripts/new-example.ts
+++ b/scripts/new-example.ts
@@ -1,0 +1,271 @@
+// script for generating a new example
+// main function is newExample() below
+
+// tslint:disable:no-console - as this is run from the CLI we are OK with console logging
+import chalk from 'chalk';
+import * as yargs from 'yargs';
+import {readdirSync, lstatSync, mkdirSync, readFileSync, writeFileSync, existsSync} from 'fs';
+import {join} from 'path';
+import {execSync} from 'child_process';
+import inquirer = require('inquirer');
+import {paramCase, pascalCase, titleCase} from 'change-case';
+import {DocItem, DocItemCategory} from 'src/app/core/document-items.service';
+import * as prettier from 'prettier';
+
+let prettierConfig: prettier.Options;
+
+console.info(chalk.gray('Gathering information...'));
+
+const cashmereComponentDir = join(__dirname, '../projects/cashmere/src/lib');
+const cashmereComponents = readdirSync(cashmereComponentDir)
+    .filter(i => lstatSync(join(cashmereComponentDir, i)).isDirectory() && i !== 'pipes')
+    .concat(
+        readdirSync(join(cashmereComponentDir, 'pipes')).filter(i => lstatSync(join(join(cashmereComponentDir, 'pipes'), i)).isDirectory())
+    );
+
+const bitComponentDir = join(__dirname, '../projects/cashmere-bits/src/lib');
+const bitComponents = readdirSync(bitComponentDir).filter(i => lstatSync(join(bitComponentDir, i)).isDirectory());
+
+const examplesDir = join(__dirname, '../projects/cashmere-examples/src/lib');
+const existingExamples = readdirSync(examplesDir).filter(
+    i => lstatSync(join(examplesDir, i)).isDirectory() && readdirSync(join(examplesDir, i)).length
+);
+
+const currentExampleDependencies = Object.keys(
+    JSON.parse(readFileSync(join(__dirname, '../projects/cashmere-examples/package.json')).toString()).peerDependencies
+);
+
+const categories = ['cashmere', 'bit'];
+const exampleTypes = ['simple', 'module'];
+
+let args = yargs
+    .option('category', {
+        alias: 'cat',
+        describe: 'choose a component category ("cashmere" or "bit")',
+        choices: categories,
+        required: false
+    })
+    .option('component', {
+        alias: 'c',
+        describe: `choose which component's documentation this example will be attached to`,
+        required: false,
+        choices: cashmereComponents.concat(bitComponents)
+    })
+    .option('name', {
+        alias: 'n',
+        describe: 'choose a name for your example',
+        type: 'string',
+        required: false,
+        default: ''
+    })
+    .option('type', {
+        alias: 't',
+        describe: 'choose either simple type example or complex requiring module',
+        choices: exampleTypes,
+        required: false
+    })
+    .option('requiredPackages', {
+        alias: 'r',
+        describe: 'are there any additional NPM packages (other than what Cashmere already depends on) required by this example?',
+        type: 'array',
+        required: false
+    })
+    .help('help').argv;
+
+async function promptForMissingArguments() {
+    const input = await inquirer.prompt([
+        {
+            name: 'category',
+            message: `Is this example for a component in the main Cashmere library or a Cashmere Bit?`,
+            type: 'list',
+            choices: categories,
+            when: () => !args.category
+        },
+        {
+            name: 'component',
+            message: `Which component is this example for?`,
+            type: 'list',
+            choices: x => (x.category === 'bit' ? bitComponents : cashmereComponents),
+            // when the component isn't specified in args or the component that is specified in args is invalid for the specified category
+            when: x =>
+                !args.component || !((x.category || args.category) === 'bit' ? bitComponents : cashmereComponents).includes(args.component)
+        },
+        {
+            name: 'name',
+            message: 'What is the name of this example?',
+            type: 'input',
+            validate: x => (!!paramCase(x) && !existingExamples.includes(paramCase(x))) || 'Example name required and must be unique.',
+            when: () => !args.name || existingExamples.includes(paramCase(args.name))
+        },
+        {
+            name: 'type',
+            message:
+                'Is this a simple example (self-contained within single component) or do you need an entire module file for this example?',
+            type: 'list',
+            choices: exampleTypes,
+            when: () => !args.type
+        },
+        {
+            name: 'requiredPackages',
+            message: `Specify any new NPM packages (other than the following) required by this example as a comma-separated list:`,
+            suffix: currentExampleDependencies.join(','),
+            type: 'input',
+            required: false,
+            // Only prompt if other prompts have happened.  Don't want to prompt if all other required params were given as args.
+            when: x => Object.keys(x).length,
+            // transforms the user input from comma-separated string to an array of strings
+            filter: x => (x || '').split(',')
+        }
+    ]);
+
+    args = {...args, ...input};
+    args.name = paramCase(args.name);
+    args.requiredPackages = (args.requiredPackages || [])
+        .map((p: string) => p!.trim().toLowerCase())
+        .filter(p => !currentExampleDependencies.includes(p));
+
+    prettierConfig = (await prettier.resolveConfig(__dirname))!;
+}
+
+(async function newExample() {
+    await promptForMissingArguments();
+    createFiles();
+    await registerWithDocumentItemsService();
+    if (args.requiredPackages!.length) {
+        installAdditionalPackages();
+    }
+    runBuild();
+
+    console.log(chalk.green('All done! Check your pending changes for TODOs for completing your example.'));
+})();
+
+function createFiles() {
+    const newExampleDir = join(examplesDir, args.name);
+    if (!existsSync(newExampleDir)) {
+        mkdirSync(newExampleDir);
+    }
+
+    const exampleComponentFileName = join(newExampleDir, `${args.name}-example.component.ts`);
+    console.info(chalk.gray(`creating ${exampleComponentFileName}...`));
+    const componentFileContents = `import {Component} from '@angular/core';
+
+@Component({
+selector: 'hc-${args.name}-example',
+templateUrl: '${args.name}-example.component.html',
+// TODO: delete the SCSS file if you don't need it in the example
+styleUrls: ['${args.name}-example.component.scss']
+})
+export class ${pascalCase(args.name)}ExampleComponent {
+// TODO: implement your example here
+}
+`;
+    writeFileSync(exampleComponentFileName, prettier.format(componentFileContents, {...prettierConfig, parser: 'typescript'}));
+
+    const exampleHtmlFileName = join(newExampleDir, `${args.name}-example.component.html`);
+    console.info(chalk.gray(`creating ${exampleHtmlFileName}...`));
+    writeFileSync(exampleHtmlFileName, `\n`);
+
+    const exampleScssFileName = join(newExampleDir, `${args.name}-example.component.scss`);
+    console.info(chalk.gray(`creating ${exampleScssFileName}...`));
+    writeFileSync(exampleScssFileName, `\n`);
+
+    if (args.type === 'module') {
+        const exampleModuleFileName = join(newExampleDir, `${args.name}-example.module.ts`);
+        const componentName = `${pascalCase(args.name)}ExampleComponent`;
+        console.info(chalk.gray(`creating ${exampleModuleFileName}...`));
+        const moduleFileContents =
+            `import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {CashmereModule} from '../cashmere.module';
+import {${componentName}} from './${args.name}-example.component';
+
+@NgModule({
+imports: [CommonModule, CashmereModule],
+declarations: [${componentName}],
+exports: [${componentName}],
+entryComponents: [${componentName}]
+})
+export class ${pascalCase(args.name)}ExampleModule {
+}
+`.trim() + '\n';
+        writeFileSync(exampleModuleFileName, prettier.format(moduleFileContents, {...prettierConfig, parser: 'typescript'}));
+    }
+}
+
+async function registerWithDocumentItemsService() {
+    console.info(chalk.gray(`registering example with document items service...`));
+    const docItemsDirectory = join(__dirname, '../src/app/core');
+    let docItemsFile: string;
+    if (args.category === 'cashmere') {
+        docItemsFile = join(docItemsDirectory, './cashmere-components-document-items.json');
+    } else if (args.category === 'bit') {
+        docItemsFile = join(docItemsDirectory, './cashmere-bits-document-items.json');
+    } else {
+        console.warn(
+            chalk.bold.yellowBright('Warning: cannot register with document items service since an unrecognized category was provided.')
+        );
+        return;
+    }
+
+    const docItems = JSON.parse(readFileSync(docItemsFile).toString());
+    if (!docItems[args.component!]) {
+        console.warn(
+            chalk.yellowBright(
+                `It seems that the component for this example has not yet been registered with the document items service.  Let's take care of that right now.`
+            )
+        );
+        const answers = await inquirer.prompt([
+            {
+                name: 'category',
+                message: 'What accordion would this component fit under on the Cashmere docs site?',
+                choices: ['buttons', 'forms', 'layout', 'nav', 'pipes', 'popups', 'table'] as DocItemCategory[]
+            }
+        ]);
+        docItems[args.component!] = {
+            category: answers.category,
+            name: titleCase(args.component!),
+            examples: [],
+            id: args.component,
+            usageDoc: existsSync(
+                join(args.type === 'bit' ? bitComponentDir : cashmereComponentDir, args.component!, `${args.component}.md`)
+            ),
+            hideApi: false
+        } as DocItem;
+
+        const cashmereModulePath = join(__dirname, '../src/app/shared/cashmere.module.ts');
+        const cashmereModule = readFileSync(cashmereModulePath).toString();
+        if (!cashmereModule.includes(`${pascalCase(args.component!)}Module`)) {
+            writeFileSync(cashmereModulePath, `// TODO: add ${pascalCase(args.component!)}Module to this file\n${cashmereModule}`);
+            console.warn(
+                chalk.yellowBright(
+                    `It seems that the component for this example has not yet been added to the CashmereModule in 'src/app/shared/cashmere.module.ts'. You will need to do this on your own.`
+                )
+            );
+        }
+    }
+    docItems[args.component!].examples.push(args.name);
+    const jsonString = JSON.stringify(docItems);
+    writeFileSync(docItemsFile, prettier.format(jsonString, {...prettierConfig, parser: 'json'}));
+}
+
+function installAdditionalPackages() {
+    console.info(chalk.gray('installing additional NPM packages to the docs project...'));
+    execSync(`npm install --save ${args.requiredPackages!.join(' ')}`, {cwd: join(__dirname, '../'), stdio: 'inherit'});
+
+    console.info(chalk.gray('installing additional NPM packages to the examples project...'));
+    const cashmereExamplesProjectDir = join(__dirname, '../projects/cashmere-examples');
+    execSync(`npm install --save ${args.requiredPackages!.join(' ')}`, {cwd: cashmereExamplesProjectDir, stdio: 'inherit'});
+
+    console.info(chalk.gray('moving dependencies to peer dependencies...'));
+    const packageJsonPath = join(cashmereExamplesProjectDir, 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
+    packageJson.peerDependencies = {...packageJson.peerDependencies, ...packageJson.dependencies};
+    delete packageJson.dependencies;
+    const jsonString = JSON.stringify(packageJson);
+    writeFileSync(packageJsonPath, prettier.format(jsonString, {...prettierConfig, parser: 'json'}));
+}
+
+function runBuild() {
+    console.info(chalk.gray('Performing initial build with the new example...'));
+    execSync('npm run build', {cwd: join(__dirname, '../'), stdio: 'inherit'});
+}

--- a/src/app/components/components.component.ts
+++ b/src/app/components/components.component.ts
@@ -71,8 +71,8 @@ export class ComponentsComponent implements OnInit, OnDestroy {
         }
 
         this.allDocItems = this.docItemService.getDocItems(this.docType);
-        if (!this.id) {
-            this.navUpdate(this.allDocItems[0].id);
+        if (!this.id && this.categorizedDocItems[0] && this.categorizedDocItems[0].items && this.categorizedDocItems[0].items.length) {
+            this.navUpdate(this.categorizedDocItems[0].items[0].id);
             return;
         }
         this.activeItem = this.allDocItems.find(i => i.id === this.id);

--- a/src/app/core/cashmere-bits-document-items.json
+++ b/src/app/core/cashmere-bits-document-items.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "./document-items.schema.json",
+
+    "change-case-pipe": {
+        "name": "Change Case",
+        "category": "pipes",
+        "examples": ["change-case-pipe-overview"],
+        "usageDoc": true,
+        "hideApi": true
+    }
+}

--- a/src/app/core/cashmere-components-document-items.json
+++ b/src/app/core/cashmere-components-document-items.json
@@ -1,0 +1,212 @@
+{
+    "$schema": "./document-items.schema.json",
+    "accordion": {
+        "name": "Accordion",
+        "category": "layout",
+        "examples": ["accordion-overview"]
+    },
+    "banner": {
+        "name": "Banner",
+        "category": "popups",
+        "examples": ["banner-overview"]
+    },
+    "breadcrumbs": {
+        "name": "Breadcrumbs",
+        "category": "nav",
+        "examples": [],
+        "usageDoc": true
+    },
+    "button": {
+        "name": "Button",
+        "category": "buttons",
+        "examples": ["button-anchor", "button-colors", "button-icon", "button-link", "button-size", "button-split", "button-type"],
+        "usageDoc": true
+    },
+    "checkbox": {
+        "name": "Checkbox",
+        "category": "forms",
+        "examples": ["checkbox-align", "checkbox-forms", "checkbox-indeterminate", "checkbox-standard"],
+        "usageDoc": true
+    },
+    "chip": {
+        "name": "Chip",
+        "category": "buttons",
+        "examples": ["chip-action", "chip-basic", "chip-row", "chip-singlerow"]
+    },
+    "date-range": {
+        "name": "DateRange",
+        "category": "forms",
+        "examples": ["date-range", "date-range-time"],
+        "usageDoc": true
+    },
+    "datepicker": {
+        "name": "Datepicker",
+        "category": "forms",
+        "examples": ["datepicker", "datepicker-selected-value", "datepicker-sugar"],
+        "usageDoc": true
+    },
+    "drawer": {
+        "name": "Drawer",
+        "category": "layout",
+        "examples": ["drawer-basic", "drawer-menu", "drawer-overlay", "drawer-side"]
+    },
+    "ellipsis-pipe": {
+        "name": "Ellipsis",
+        "category": "pipes",
+        "examples": ["ellipsis-overview"],
+        "hideApi": true,
+        "usageDoc": true
+    },
+    "file-size-pipe": {
+        "name": "File Size",
+        "category": "pipes",
+        "examples": ["file-size-overview"],
+        "hideApi": true,
+        "usageDoc": true
+    },
+    "form-field": {
+        "name": "Form Field",
+        "category": "forms",
+        "examples": ["form-field-labels", "form-field-overview", "form-field-tight"],
+        "usageDoc": true
+    },
+    "highlight-pipe": {
+        "name": "Highlight",
+        "category": "pipes",
+        "examples": ["highlight-overview"],
+        "hideApi": true,
+        "usageDoc": true
+    },
+    "icon": {
+        "name": "Icon",
+        "category": "buttons",
+        "examples": ["icon-overview"]
+    },
+    "input": {
+        "name": "Input",
+        "category": "forms",
+        "examples": ["input-prefix", "input-required", "input-suffix", "input-text-area"],
+        "usageDoc": true
+    },
+    "list": {
+        "name": "List",
+        "category": "layout",
+        "examples": ["list-overview"]
+    },
+    "modal": {
+        "name": "Modal",
+        "category": "popups",
+        "examples": ["modal-overview"]
+    },
+    "multiselect": {
+        "name": "Multiselect & Typeahead",
+        "category": "forms",
+        "examples": ["multiselect-custom-templates", "multiselect-embed-checkbox", "multiselect-overview"],
+        "hideApi": true,
+        "usageDoc": true
+    },
+    "navbar": {
+        "name": "Navbar",
+        "category": "nav",
+        "examples": ["navbar-app-switcher", "navbar-overview"],
+        "usageDoc": true
+    },
+    "null-or-empty-string-pipe": {
+        "name": "IfNullOrEmpty",
+        "category": "pipes",
+        "examples": ["null-or-empty-string-overview"],
+        "hideApi": true,
+        "usageDoc": true
+    },
+    "number-abbreviator-pipe": {
+        "name": "Number Abbreviator",
+        "category": "pipes",
+        "examples": ["number-abbreviator-overview"],
+        "hideApi": true,
+        "usageDoc": true
+    },
+    "pagination": {
+        "name": "Pagination",
+        "category": "nav",
+        "examples": ["pagination-load-more", "pagination-simple", "pagination-standard"],
+        "usageDoc": true
+    },
+    "picklist": {
+        "name": "Picklist",
+        "category": "layout",
+        "examples": ["picklist-simple", "picklist-valueset"],
+        "usageDoc": true
+    },
+    "pop": {
+        "name": "Popover",
+        "category": "popups",
+        "examples": ["popover-menu", "popover-overview", "popover-right-click", "popover-simple", "tooltip-overview"],
+        "usageDoc": true
+    },
+    "progress-indicators": {
+        "name": "Progress Indicators",
+        "category": "buttons",
+        "examples": ["progress-dots", "progress-spinner"],
+        "usageDoc": true
+    },
+    "radio-button": {
+        "name": "Radio Button",
+        "category": "forms",
+        "examples": ["radio-button-disabled", "radio-button-forms", "radio-button-standard"],
+        "usageDoc": true
+    },
+    "scroll-nav": {
+        "name": "ScrollNav",
+        "category": "nav",
+        "examples": ["scroll-nav"]
+    },
+    "select": {
+        "name": "Select",
+        "category": "forms",
+        "examples": ["select-disabled", "select-forms", "select-standard", "select-validation"],
+        "usageDoc": true
+    },
+    "sort": {
+        "name": "Sort",
+        "category": "table",
+        "examples": [],
+        "usageDoc": true
+    },
+    "stepper": {
+        "name": "Stepper",
+        "category": "layout",
+        "examples": ["stepper-overview"]
+    },
+    "subnav": {
+        "name": "Subnav",
+        "category": "nav",
+        "examples": ["subnav-overview"]
+    },
+    "table": {
+        "name": "Table",
+        "category": "table",
+        "examples": ["resizable-columns", "table-filter", "table-sort"],
+        "usageDoc": true
+    },
+    "tabs": {
+        "name": "Tabs",
+        "category": "layout",
+        "examples": ["tabs-horizontal", "tabs-vertical"]
+    },
+    "tile": {
+        "name": "Tile",
+        "category": "layout",
+        "examples": ["tile-overview"]
+    },
+    "toaster": {
+        "name": "Toaster Messages",
+        "category": "popups",
+        "examples": ["toaster-overview"]
+    },
+    "typeform-survey": {
+        "name": "Typeform Survey",
+        "category": "popups",
+        "examples": ["typeform-survey-overview"],
+        "usageDoc": true
+    }
+}

--- a/src/app/core/document-items.schema.json
+++ b/src/app/core/document-items.schema.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Cashmere Document Items",
+    "additionalProperties": {
+        "type": "object",
+        "required": ["name", "category", "examples"],
+        "properties": {
+            "name": {
+                "$id": "#root/name",
+                "title": "Name",
+                "type": "string",
+                "default": "",
+                "examples": ["Button"],
+                "pattern": "^.*$"
+            },
+            "category": {
+                "$id": "#root/category",
+                "title": "Category",
+                "type": "string",
+                "default": "",
+                "examples": ["buttons"],
+                "pattern": "forms|nav|layout|buttons|popups|table|pipes"
+            },
+            "examples": {
+                "$id": "#root/examples",
+                "title": "Examples",
+                "type": "array",
+                "default": [],
+                "items": {
+                    "$id": "#root/examples/items",
+                    "title": "Items",
+                    "type": "string",
+                    "default": "",
+                    "examples": ["button-anchor"],
+                    "pattern": "^.*$"
+                }
+            },
+            "usageDoc": {
+                "$id": "#root/usageDoc",
+                "title": "Usage Doc?",
+                "type": "boolean",
+                "examples": [true],
+                "default": false
+            },
+            "hideApi": {
+                "$id": "#root/hideApi",
+                "title": "Hide API?",
+                "type": "boolean",
+                "examples": [true],
+                "default": false
+            }
+        }
+    }
+}

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -1,4 +1,6 @@
 import {Injectable} from '@angular/core';
+import * as cashmereComponentsDocumentItems from './cashmere-components-document-items.json';
+import * as cashmereBitsDocumentItems from './cashmere-bits-document-items.json';
 
 export type DocItemCategory = 'forms' | 'nav' | 'layout' | 'buttons' | 'popups' | 'table' | 'pipes';
 
@@ -6,189 +8,28 @@ export interface DocItem {
     id: string;
     name: string;
     category: DocItemCategory;
-    examples?: string[];
+    examples: string[];
     usageDoc?: boolean;
     hideApi?: boolean;
 }
 
 export type DocItemType = 'components' | 'bits';
 
-const componentDocs: DocItem[] = [
-    {
-        id: 'checkbox',
-        name: 'Checkbox',
-        category: 'forms',
-        examples: ['checkbox-standard', 'checkbox-indeterminate', 'checkbox-align', 'checkbox-forms'],
-        usageDoc: true
-    },
-    {id: 'accordion', name: 'Accordion', category: 'layout', examples: ['accordion-overview']},
-    {id: 'banner', name: 'Banner', category: 'popups', examples: ['banner-overview']},
-    {id: 'breadcrumbs', name: 'Breadcrumbs', category: 'nav', usageDoc: true},
-    {
-        id: 'button',
-        name: 'Button',
-        category: 'buttons',
-        usageDoc: true,
-        examples: ['button-type', 'button-split', 'button-size', 'button-anchor', 'button-link', 'button-icon', 'button-colors']
-    },
-    {
-        id: 'chip',
-        name: 'Chip',
-        category: 'buttons',
-        examples: ['chip-basic', 'chip-action', 'chip-row', 'chip-singlerow']
-    },
-    {
-        id: 'datepicker',
-        name: 'Datepicker',
-        category: 'forms',
-        examples: ['datepicker', 'datepicker-sugar', 'datepicker-selected-value'],
-        usageDoc: true
-    },
-    {
-        id: 'date-range',
-        name: 'DateRange',
-        category: 'forms',
-        examples: ['date-range', 'date-range-time'],
-        usageDoc: true
-    },
-    {
-        id: 'drawer',
-        name: 'Drawer',
-        category: 'layout',
-        examples: ['drawer-basic', 'drawer-overlay', 'drawer-side', 'drawer-menu']
-    },
-    {id: 'ellipsis-pipe', name: 'Ellipsis', category: 'pipes', usageDoc: true, hideApi: true, examples: ['ellipsis-overview']},
-    {id: 'highlight-pipe', name: 'Highlight', category: 'pipes', usageDoc: true, hideApi: true, examples: ['highlight-overview']},
-    {id: 'file-size-pipe', name: 'File Size', category: 'pipes', usageDoc: true, hideApi: true, examples: ['file-size-overview']},
-    {
-        id: 'number-abbreviator-pipe',
-        name: 'Number Abbreviator',
-        category: 'pipes',
-        usageDoc: true,
-        hideApi: true,
-        examples: ['number-abbreviator-overview']
-    },
-    {
-        id: 'form-field',
-        name: 'Form Field',
-        category: 'forms',
-        usageDoc: true,
-        examples: ['form-field-overview', 'form-field-tight', 'form-field-labels']
-    },
-    {id: 'icon', name: 'Icon', category: 'buttons', examples: ['icon-overview']},
-    {
-        id: 'input',
-        name: 'Input',
-        category: 'forms',
-        usageDoc: true,
-        examples: ['input-required', 'input-suffix', 'input-prefix', 'input-text-area']
-    },
-    {
-        id: 'null-or-empty-string-pipe',
-        name: 'IfNullOrEmpty',
-        category: 'pipes',
-        usageDoc: true,
-        hideApi: true,
-        examples: ['null-or-empty-string-overview']
-    },
-    {id: 'list', name: 'List', category: 'layout', examples: ['list-overview']},
-    {id: 'modal', name: 'Modal', category: 'popups', examples: ['modal-overview']},
-    {
-        id: 'navbar',
-        name: 'Navbar',
-        category: 'nav',
-        examples: ['navbar-overview', 'navbar-app-switcher'],
-        usageDoc: true
-    },
-    {
-        id: 'multiselect',
-        name: 'Multiselect & Typeahead',
-        category: 'forms',
-        hideApi: true,
-        usageDoc: true,
-        examples: ['multiselect-overview', 'multiselect-custom-templates', 'multiselect-embed-checkbox']
-    },
-    {
-        id: 'pagination',
-        name: 'Pagination',
-        category: 'nav',
-        usageDoc: true,
-        examples: ['pagination-standard', 'pagination-load-more', 'pagination-simple']
-    },
-    {id: 'picklist', name: 'Picklist', category: 'layout', examples: ['picklist-simple', 'picklist-valueset'], usageDoc: true},
-    {
-        id: 'pop',
-        name: 'Popover',
-        category: 'popups',
-        examples: ['popover-simple', 'popover-menu', 'tooltip-overview', 'popover-right-click', 'popover-overview'],
-        usageDoc: true
-    },
-    {
-        id: 'progress-indicators',
-        name: 'Progress Indicators',
-        category: 'buttons',
-        examples: ['progress-spinner', 'progress-dots'],
-        usageDoc: true
-    },
-    {
-        id: 'radio-button',
-        name: 'Radio Button',
-        category: 'forms',
-        examples: ['radio-button-standard', 'radio-button-disabled', 'radio-button-forms'],
-        usageDoc: true
-    },
-    {
-        id: 'scroll-nav',
-        name: 'ScrollNav',
-        category: 'nav',
-        examples: ['scroll-nav']
-    },
-    {
-        id: 'select',
-        name: 'Select',
-        category: 'forms',
-        examples: ['select-standard', 'select-disabled', 'select-validation', 'select-forms'],
-        usageDoc: true
-    },
-    {id: 'sort', name: 'Sort', category: 'table', usageDoc: true},
-    {id: 'stepper', name: 'Stepper', category: 'layout', examples: ['stepper-overview']},
-    {id: 'subnav', name: 'Subnav', category: 'nav', examples: ['subnav-overview']},
-    {
-        id: 'table',
-        name: 'Table',
-        category: 'table',
-        examples: ['resizable-columns', 'table-sort', 'table-filter'],
-        usageDoc: true
-    },
-    {
-        id: 'tabs',
-        name: 'Tabs',
-        category: 'layout',
-        examples: ['tabs-horizontal', 'tabs-vertical']
-    },
-    {id: 'tile', name: 'Tile', category: 'layout', examples: ['tile-overview']},
-    {id: 'toaster', name: 'Toaster Messages', category: 'popups', examples: ['toaster-overview']},
-    {
-        id: 'typeform-survey',
-        name: 'Typeform Survey',
-        category: 'popups',
-        examples: ['typeform-survey-overview'],
-        usageDoc: true
-    }
-];
-
-const bitDocs: DocItem[] = [
-    {id: 'change-case-pipe', name: 'Change Case', category: 'pipes', usageDoc: true, hideApi: true, examples: ['change-case-pipe-overview']}
-];
+const cashmereComponents: DocItem[] = Object.keys(cashmereComponentsDocumentItems)
+    .filter(name => name !== '$schema')
+    .map(name => ({...cashmereComponentsDocumentItems[name], id: name}));
+const cashmereBits: DocItem[] = Object.keys(cashmereBitsDocumentItems)
+    .filter(name => name !== '$schema')
+    .map(name => ({...cashmereBitsDocumentItems[name], id: name}));
 
 @Injectable()
 export class DocumentItemsService {
     getDocItems(type: DocItemType): DocItem[] {
         switch (type) {
             case 'components':
-                return componentDocs;
+                return cashmereComponents;
             case 'bits':
-                return bitDocs;
+                return cashmereBits;
             default:
                 throw new Error(`Unrecognized doc type: ${type}`);
         }

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -9,6 +9,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "strictNullChecks": true,
+        "resolveJsonModule": true,
         "target": "es5",
         "typeRoots": ["node_modules/@types"],
         "lib": ["es2017", "dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "strictNullChecks": true,
+        "resolveJsonModule": true,
         "target": "es5",
         "typeRoots": ["node_modules/@types"],
         "lib": ["es2017", "dom"],

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -9,6 +9,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "strictNullChecks": true,
+        "resolveJsonModule": true,
         "target": "es5",
         "typeRoots": ["node_modules/@types"],
         "lib": ["es2017", "dom"],


### PR DESCRIPTION
Creating an example should only take a few minutes now, and require little reading of the
documentation! :)

Ever since I revamped the examples to make them work with StackBlitz, I've always felt a bit guilty as to how unfriendly the example creation process is.  The docs were lengthy, incomplete, and difficult to get everything right.

So I finally bit the bullet and wrote a script for generating a new example!

Now you can just run `npm run new:example` and it will scaffold All The Things needed for that example to run.  It even runs the build so that you can `npm start` and immediately start dev'ing your new example!

This work is in preparation for similar scripting for creating new Cashmere Components and Cashmere Bits (those processes will generate an "___ overview" example).  With these automations, the barrier to contribution to the Cashmere project should be greatly reduced!