### PR TITLE
fix(split button): keyboard accessibility

### DIFF
--- a/projects/cashmere-examples/src/lib/button-size/button-size-example.component.html
+++ b/projects/cashmere-examples/src/lib/button-size/button-size-example.component.html
@@ -1,14 +1,14 @@
 <hc-split-button buttonStyle="primary-alt" size="sm">
     Small Split
-    <div hcButtonItem>Button menu</div>
+    <div hcMenuItem>Button menu</div>
 </hc-split-button>
 <hc-split-button buttonStyle="primary-alt" size="md">
     Medium Split
-    <div hcButtonItem>Button menu</div>
+    <div hcMenuItem>Button menu</div>
 </hc-split-button>
 <hc-split-button buttonStyle="primary-alt" size="lg">
     Large Split
-    <div hcButtonItem>Button menu</div>
+    <div hcMenuItem>Button menu</div>
 </hc-split-button>
 
 <div>

--- a/projects/cashmere-examples/src/lib/button-split/button-split-example.component.html
+++ b/projects/cashmere-examples/src/lib/button-split/button-split-example.component.html
@@ -1,30 +1,30 @@
 <hc-split-button>
     Menu
-    <button hcButtonItem>
+    <button hcMenuItem>
         <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-snowflake-o"></hc-icon>
         <span hcMenuText>Menu item 1</span> <span hcMenuSubText>Ctrl + S</span>
     </button>
-    <button hcButtonItem>
+    <button hcMenuItem>
         <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-plus"></hc-icon>
         <span hcMenuText>Menu item 2</span>
     </button>
-    <div hcButtonItem hcDivider></div>
-    <button hcButtonItem disabled>
+    <div hcMenuItem hcDivider></div>
+    <button hcMenuItem disabled>
         <span hcMenuIcon></span> <span hcMenuText>Menu item 3</span> <span hcMenuSubText>I'm disabled</span>
     </button>
 </hc-split-button>
 
 <hc-split-button buttonStyle="secondary" menuPosition="start">
     Simple Dropdown
-    <div hcButtonItem>Dropdown with menuPosition set to 'start'</div>
+    <div hcMenuItem>Dropdown with menuPosition set to 'start'</div>
 </hc-split-button>
 
 <hc-split-button buttonStyle="destructive" disabled>
     Disabled
-    <div hcButtonItem>Simple item</div>
+    <div hcMenuItem>Simple item</div>
 </hc-split-button>
 
 <hc-split-button buttonStyle="minimal">
     Minimal
-    <div hcButtonItem>Minimal Split Button Item</div>
+    <div hcMenuItem>Minimal Split Button Item</div>
 </hc-split-button>

--- a/projects/cashmere/src/lib/button/button.md
+++ b/projects/cashmere/src/lib/button/button.md
@@ -8,8 +8,8 @@ The text inside a button should be formatted in title case. In title case, all m
 
 **hc-split-button**
 
-To use `hc-split-button` you encapsulate the content you want to be shown on the button. Anything marked with the directive `hcButtonItem` will get transferred into the dropdown menu. Everything else will be shown as the main button's content
+To use `hc-split-button` you encapsulate the content you want to be shown on the button. Anything marked with the directive `hcMenuItem` will get transferred into the dropdown menu. Everything else will be shown as the main button's content
 
-**hcButtonItem**
+**hcMenuItem**
 
 Marks an element for being put into the dropdown menu of the button. Multiple things can be marked with this directive

--- a/projects/cashmere/src/lib/button/split-button/split-button.component.html
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.html
@@ -29,6 +29,6 @@
 
 <hc-pop #splitMenu [xAlign]="menuPosition" [autoCloseOnContentClick]="autoCloseMenuOnClick" [showArrow]="false">
     <div hcMenu>
-        <ng-content select="[hcButtonItem]"></ng-content>
+        <ng-content select="[hcButtonItem], [hcMenuItem]"></ng-content>
     </div>
 </hc-pop>

--- a/projects/cashmere/src/lib/button/split-button/split-button.component.spec.ts
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.spec.ts
@@ -53,7 +53,7 @@ describe('SplitButtonComponent', () => {
     template: `
         <hc-split-button (click)="primaryButtonClick()">
             Button Text
-            <div hcButtonItem (click)="menuItemClick()">Menu Item</div>
+            <div hcMenuItem (click)="menuItemClick()">Menu Item</div>
         </hc-split-button>
     `
 })

--- a/projects/cashmere/src/lib/button/split-button/split-button.component.ts
+++ b/projects/cashmere/src/lib/button/split-button/split-button.component.ts
@@ -7,11 +7,14 @@ import {
     Input,
     Output,
     ViewEncapsulation,
-    ViewChild
+    ViewChild,
+    ContentChildren,
+    QueryList
 } from '@angular/core';
 import {parseBooleanAttribute} from '../../util';
 import {validateStyleInput, validateSizeInput, ButtonComponent} from '../button.component';
 import {HcPopComponent} from '../../pop/popover.component';
+import {MenuItemDirective} from '../../pop/directives/menu-item.directive';
 
 const supportedStyles = ['primary', 'primary-alt', 'destructive', 'neutral', 'secondary', 'minimal', 'link', 'link-inline'];
 
@@ -39,6 +42,8 @@ export class SplitButtonComponent {
 
     @ViewChild('splitMenu', {static: false})
     _splitMenu: HcPopComponent;
+
+    @ContentChildren(MenuItemDirective, {descendants: true}) _menuItems: QueryList<MenuItemDirective>;
 
     /** Primary button's click event */
     @Output()
@@ -159,6 +164,9 @@ export class SplitButtonComponent {
 
     /** Manually open the menu */
     openMenu() {
+        // pass menuItems on to the HcPop instance so that keyboard accessibility works
+        if (this._splitMenu) { this._splitMenu._menuItems = this._menuItems; }
+
         this._splitMenu.open();
     }
 }


### PR DESCRIPTION
So split button menus are accessible via keyboard (like other popup menus).
fix #1360