### PR TITLE
fix(navbar): allow keyboard accessibility

### DIFF
--- a/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-app-switcher/navbar-app-switcher-example.component.html
@@ -6,10 +6,10 @@
     <hc-navbar-link [active]="false" uri="undefined" linkText="Cardiovascular"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Rehabilition"></hc-navbar-link>
     <hc-navbar-link [active]="false" uri="undefined" linkText="Intensive Care"></hc-navbar-link>
-    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-th" [hcPop]="appSwitcher"></hc-icon>
-    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-question-circle-o" [hcPop]="options"></hc-icon>
+    <hc-icon class="hc-navbar-icon" tabindex="0" fontSet="fa" fontIcon="fa-th" [hcPop]="appSwitcher"></hc-icon>
+    <hc-icon class="hc-navbar-icon" tabindex="0" fontSet="fa" fontIcon="fa-question-circle-o" [hcPop]="options"></hc-icon>
     <span class="hc-navbar-vertical-separator"></span>
-    <div class="hc-navbar-username" *ngIf="user" [hcPop]="user">
+    <div class="hc-navbar-username" *ngIf="user" [hcPop]="user" tabindex="0">
         <span class="hc-text-ellipsis">{{ username }}</span>
         <hc-icon fontSet="fa" fontIcon="fa-angle-down"></hc-icon>
     </div>
@@ -40,7 +40,7 @@
 <p><em><strong>Note:</strong> the code for this example demonstrates how to setup a mobile menu in the navbar, however
     its display has been disabled here to prevent it from colliding with the Cashmere site navigation.</em></p>
 
-<hc-pop #appSwitcher [showArrow]="false" horizontalAlign="end">
+<hc-pop #appSwitcher [showArrow]="false" horizontalAlign="end" [autoFocus]="true">
     <hc-app-switcher [serviceName]="currentAppName" [serviceVersion]="currentAppVersion"></hc-app-switcher>
 </hc-pop>
 

--- a/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/navbar-overview/navbar-overview-example.component.html
@@ -35,9 +35,9 @@
     </hc-navbar-dropdown>
     <hc-navbar-link uri="undefined" linkText="Platform"></hc-navbar-link>
     <hc-navbar-link uri="undefined" linkText="Applications"></hc-navbar-link>
-    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-question-circle-o" [hcPop]="options"></hc-icon>
+    <hc-icon class="hc-navbar-icon" fontSet="fa" fontIcon="fa-question-circle-o" [hcPop]="options" tabindex="0"></hc-icon>
     <span class="hc-navbar-vertical-separator"></span>
-    <div class="hc-navbar-username" *ngIf="user" [hcPop]="user">
+    <div class="hc-navbar-username" *ngIf="user" [hcPop]="user" tabindex="0">
         <span>
             <span>{{ username }}</span>
             <br />

--- a/projects/cashmere/src/lib/navbar/navbar-dropdown/navbar-dropdown.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar-dropdown/navbar-dropdown.component.html
@@ -5,6 +5,7 @@
     class="navbar-dropdown"
     [ngClass]="{active: this.active === true, inactive: this.active === false}"
     [hcPop]="menuPop"
+    tabindex="0"
 >
     {{linkText}}
     <hc-icon fontSet="fa" fontIcon="fa-chevron-down" hcIconSm></hc-icon>

--- a/projects/cashmere/src/lib/navbar/navbar.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <nav #navbar class="hc-navbar" [ngClass]="{'fixed-top': fixedTop}">
     <div class="navbar-brand">
-        <a [routerLink]="homeUri" class="brand">
+        <a [routerLink]="homeUri" class="brand" tabIndex="-1">
             <img *ngIf="_brandIconType() == 'string'" src="{{ brandIcon }}" />
             <hc-icon
                 *ngIf="_brandIconType() != 'string'"
@@ -17,7 +17,7 @@
     </div>
     <div #navlinks class="hc-navbar-link-container">
         <ng-content select="hc-navbar-link, hc-navbar-dropdown"></ng-content>
-        <div class="hc-navbar-more-links" title="More" *ngIf="_collapse" [hcPop]="navbarMore" #moreLink="hcPopAnchor">
+        <div class="hc-navbar-more-links" tabindex="0" title="More" *ngIf="_collapse" [hcPop]="navbarMore" #moreLink="hcPopAnchor">
             More
             <hc-icon fontSet="fa" fontIcon="fa-chevron-down" hcIconSm></hc-icon>
         </div>

--- a/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
@@ -158,6 +158,14 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
         this.togglePopover();
     }
 
+    @HostListener('keydown', ['$event'])
+    _showOrHideOnEnter(event: KeyboardEvent): void {
+        if (this.trigger !== 'click' || event.keyCode !== KEY_CODE.ENTER) {
+            return;
+        }
+        this.togglePopover();
+    }
+
     @HostListener('touchstart', ['$event'])
     @HostListener('mousedown', ['$event'])
     _showOrHideOnMouseOver($event: MouseEvent): void {

--- a/projects/cashmere/src/lib/pop/popover-accessibility.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-accessibility.service.ts
@@ -4,7 +4,8 @@ export enum KEY_CODE {
     RIGHT_ARROW = 39,
     UP_ARROW = 38,
     LEFT_ARROW = 37,
-    TAB = 9
+    TAB = 9,
+    ENTER = 13
 }
 
 export interface HcPopKeyboardNotifier {

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -60,12 +60,12 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
 
 @mixin navbar-app {
     height: 100%;
-    padding-left: $navbar-app-padding-left;
 
     a {
         display: flex;
         align-items: center;
         justify-content: center;
+        padding-left: $navbar-app-padding-left;
         padding-right: $navbar-app-padding-right;
         height: 100%;
 
@@ -73,6 +73,10 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
             height: 30px;
             width: auto;
             padding-top: 2px;
+        }
+
+        &:focus {
+            outline-offset: -8px;
         }
     }
 
@@ -110,6 +114,11 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         outline: none;
         color: $navbar-text;
         background-color: darken($navbar-color, 5%);
+    }
+    &:focus {
+        outline: none;
+        color: $navbar-text;
+        background-color: darken($navbar-color, 8%);
     }
     &:active:not(.inactive),
     &.active:not(.inactive) {
@@ -154,6 +163,10 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         outline: none;
         color: $navbar-text;
         background-color: darken($navbar-color, 5%);
+    }
+    &:focus {
+        outline: none;
+        background-color: darken($navbar-color, 8%);
     }
 }
 
@@ -214,6 +227,11 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         outline: none;
         color: $navbar-text;
         background-color: darken($navbar-color, 5%);
+    }
+    &:focus {
+        outline: none;
+        color: $navbar-text;
+        background-color: darken($navbar-color, 8%);
     }
     &.active:not(.inactive) {
         color: $navbar-text;


### PR DESCRIPTION
- popover anchor with a trigger of "click" can be opened by enter key when that anchor has focus
- tweak styles for anchor links and icons when focused
- updated examples to illustrate proper tabindex settings in the navbar

re #1361