### PR TITLE
1352 hc select compare with

### DIFF
--- a/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.html
@@ -1,0 +1,5 @@
+<hc-select [compareWith]="pizzaToppingsComparer" [(ngModel)]="selectedTopping">
+    <option *ngFor="let topping of toppings" [ngValue]="topping">{{topping.name}} - {{topping.price}}</option>
+</hc-select>
+
+<p class="example-results">Form control value: <code>{{selectedTopping | json}}</code></p>

--- a/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.scss
+++ b/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.scss
@@ -1,0 +1,4 @@
+.example-results {
+    margin-top: 20px;
+    font-size: 14px;
+}

--- a/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.ts
@@ -1,0 +1,31 @@
+import {Component} from '@angular/core';
+
+interface Topping {
+    id: number;
+    name: string;
+    price: string;
+}
+
+/**
+ * @title Select using compareWith
+ */
+@Component({
+    selector: 'hc-select-compare-with-example',
+    templateUrl: 'select-compare-with-example.component.html',
+    styleUrls: ['select-compare-with-example.component.scss']
+})
+export class SelectCompareWithExampleComponent {
+    toppings: Array<Topping> = [
+        {id: 1, name: 'Pepperoni', price: "$0.59"},
+        {id: 2, name: 'Olives', price: "$0.79"},
+        {id: 3, name: 'Sausage', price: "$0.99"},
+        {id: 4, name: 'Bacon', price: "$0.99"},
+        {id: 5, name: 'Chicken', price: "$0.99"},
+    ];
+
+    selectedTopping = {id: 5, name: 'Chicken', price: "$0.99"};
+
+    pizzaToppingsComparer(option1: Topping, option2: Topping): boolean {
+        return option1 && option2 && option1.id === option2.id;
+    }
+}

--- a/projects/cashmere/src/lib/select/hc-option.directive.ts
+++ b/projects/cashmere/src/lib/select/hc-option.directive.ts
@@ -1,13 +1,47 @@
 /* tslint:disable:directive-selector */
 
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, ElementRef, Optional, Host, Renderer2, OnDestroy} from '@angular/core';
+import {SelectComponent, _buildValueString} from './select.component';
 
 /** Utility directive to hold objects used in ngValue */
 @Directive({
-    selector: 'option[ngValue]'
+    selector: 'option'
 })
-export class HcOptionDirective {
-    /** Stores the content of ngValue, including objects */
-    @Input()
-    ngValue: any;
+export class HcOptionDirective implements OnDestroy {
+    /** id of the option element, use in identifying stringifyied values */
+    _id: string;
+
+    constructor(
+        private _element: ElementRef,
+        private _renderer: Renderer2,
+        @Optional() @Host() private _select: SelectComponent) {
+            if (this._select) {this._id = this._select._registerOption(); }
+    }
+
+    /** Tracks the value bound to the option element. Unlike the value binding, ngValue supports binding to objects. */
+    @Input('ngValue')
+    set ngValue(value: any) {
+        if (this._select == null) { return; }
+        this._select._optionMap.set(this._id, value);
+        this._setElementValue(_buildValueString(this._id, value));
+        this._select.writeValue(this._select.value);
+    }
+
+    /** Tracks simple string values bound to the option element. For objects, use the `ngValue` input binding. */
+    @Input('value')
+    set value(value: any) {
+        this._setElementValue(value);
+        if (this._select) { this._select.writeValue(this._select.value); }
+    }
+
+    _setElementValue(value: string): void {
+        this._renderer.setProperty(this._element.nativeElement, 'value', value);
+    }
+
+    ngOnDestroy(): void {
+        if (this._select) {
+            this._select._optionMap.delete(this._id);
+            this._select.writeValue(this._select.value);
+        }
+    }
 }

--- a/projects/cashmere/src/lib/select/select.component.html
+++ b/projects/cashmere/src/lib/select/select.component.html
@@ -5,7 +5,6 @@
         class="hc-select-input"
         [disabled]="disabled"
         (change)="_change($event, selectInput.value)"
-        [value]="value"
         (focus)="focus.next()"
         (blur)="blur.next()"
         [required]="required"

--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -23,7 +23,7 @@
 .hc-select-input {
     @include hc-select-input();
 
-    &:hover {
+    &:not([disabled]):hover {
         @include hc-select-input-hover();
     }
 

--- a/projects/cashmere/src/lib/select/select.module.ts
+++ b/projects/cashmere/src/lib/select/select.module.ts
@@ -1,10 +1,11 @@
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
 import {SelectComponent} from './select.component';
 import {HcOptionDirective} from './hc-option.directive';
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [CommonModule, FormsModule],
     exports: [SelectComponent, HcOptionDirective],
     declarations: [SelectComponent, HcOptionDirective]
 })

--- a/src/app/core/cashmere-components-document-items.json
+++ b/src/app/core/cashmere-components-document-items.json
@@ -163,7 +163,7 @@
     "select": {
         "name": "Select",
         "category": "forms",
-        "examples": ["select-disabled", "select-forms", "select-standard", "select-validation"],
+        "examples": ["select-standard", "select-forms", "select-disabled", "select-validation", "select-compare-with"],
         "usageDoc": true
     },
     "sort": {


### PR DESCRIPTION
re #1352 

- Added support for `compareWith` on `hc-select`
- Fixed buggy behavior when in IE
- Turned off hover styles when the component is disabled

Relied heavily on the angular codebase while implementing. Referenced this file - (https://github.com/angular/angular/blob/10.0.11/packages/forms/src/directives/select_control_value_accessor.ts#L28-L194)