### PR TITLE
fix(popover): fix keyboard accessibility issue

### DIFF
--- a/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
@@ -160,9 +160,18 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
         this.togglePopover();
     }
 
+    /** So popover anchors can be accessible via keyboard. */
     @HostListener('keydown', ['$event'])
     _showOrHideOnEnter(event: KeyboardEvent): void {
-        if (this.trigger !== 'click' || event.keyCode !== KEY_CODE.ENTER) {
+        // buttons already trigger a click when you press enter, so executing this event handler would be redundant
+        const targetElement = event.target as Element;
+        const triggerFromButton = targetElement && targetElement.tagName === "BUTTON";
+        // not triggering popover on keypress unless the key pressed was enter or spacebar
+        const keyPressedShouldTrigger = event.keyCode === KEY_CODE.ENTER || event.keyCode === KEY_CODE.SPACEBAR;
+        // not triggering popover on keypress unless the trigger is 'click'
+        const anchorHasClickTrigger = this.trigger === 'click';
+
+        if (triggerFromButton || !keyPressedShouldTrigger || !anchorHasClickTrigger ) {
             return;
         }
         this.togglePopover();

--- a/projects/cashmere/src/lib/pop/popover-accessibility.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-accessibility.service.ts
@@ -5,7 +5,8 @@ export enum KEY_CODE {
     UP_ARROW = 38,
     LEFT_ARROW = 37,
     TAB = 9,
-    ENTER = 13
+    ENTER = 13,
+    SPACEBAR = 32
 }
 
 export interface HcPopKeyboardNotifier {


### PR DESCRIPTION
fix #1387

Found another case I'd missed before when trying to make hcPops easier to trigger for our saavy keyboard/shortcut users. Would love to get this into a Cashmere patch release ASAP after a review & merge-  we'd like to have this working in our next PopBuilder release.