### PR TITLE
style(form-field): label color to inherit

### DIFF
--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -177,7 +177,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     margin-bottom: 3px;
     font: inherit;
     font-size: calculateRem(14px);
-    color: $text;
+    color: inherit;
 }
 
 @mixin hc-form-field-label-extension() {
@@ -190,7 +190,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     width: 100%;
     font: inherit;
     font-size: calculateRem(14px);
-    color: $text;
+    color: inherit;
 }
 
 @mixin hc-form-field-label-tight() {


### PR DESCRIPTION
form-field labels now inherit their color

I think this is a good suggestion from @isaaclyman. I suppose if an app didn't have an overall color set to `$text` on `body` or on parent, then this could cause labels to change color for developers after upgrading. So probably best to get it in now with a big release coming up.  I've marked this as a breaking change so we don't forget to call it out.

closes #1304