### PR TITLE
fix(change-case-pipe-overview): fix change-case incompatibility

### DIFF
--- a/projects/cashmere-examples/src/lib/change-case-pipe-overview/change-case-pipe-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/change-case-pipe-overview/change-case-pipe-overview-example.component.html
@@ -6,7 +6,7 @@
     <hc-form-field>
         <hc-label>Input Text</hc-label>
         <hc-select [formControl]="caseControl">
-            <option *ngFor="let option of availableCases" [ngValue]="option">{{ option | changeCase: 'titleCase' }}</option>
+            <option *ngFor="let option of availableCases" [ngValue]="option">{{ option | changeCase: 'sentenceCase' }}</option>
         </hc-select>
     </hc-form-field>
     <pre *ngIf="caseControl.value; let case">{{ textControl.value | changeCase: case }}</pre>


### PR DESCRIPTION
use sentenceCase instead of titleCase in the example since titleCase does not exist in v4 (renamed
to capitalCase)

re #1395