### PR TITLE
feat(chips): adds blue chip type

### DIFF
--- a/guides/using-cashmere-bits.md
+++ b/guides/using-cashmere-bits.md
@@ -1,6 +1,10 @@
 # Using Cashmere Bits
 
-## What's a Cashmere Bit?
+###### Last updated October 12, 2020
+
+:::
+
+##### What's a Cashmere Bit?
 
 The Cashmere project aims to deliver lightweight and bulletproof components for your applications.
 As part of that commitment, components that require additional third-party dependencies are not
@@ -11,7 +15,11 @@ Cashmere Bits come in.
 Cashmere Bits are independently packaged and installed Cashmere-family components, hosted by
 [bit.dev](https://bit.dev/healthcatalyst/cashmere). Bits are installed and managed through NPM.
 
-## Setting up Cashmere Bit support in your project
+:::
+
+:::
+
+##### Setting up Cashmere Bit support in your project
 
 Because Cashmere Bits are published on `bit.dev`, you need to tell NPM how to find that repository.
 In the root of your project (as a sibling to your `package.json` file), create (or add to) an `.npmrc`
@@ -28,3 +36,4 @@ would run the following command:
 ```bash
 npm i @bit/healthcatalyst.cashmere.change-case-pipe
 ```
+:::

--- a/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.component.html
+++ b/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.component.html
@@ -5,6 +5,7 @@
 </hc-chip>
 <hc-chip color="yellow">Warning Chip</hc-chip>
 <hc-chip color="green">Success Chip</hc-chip>
+<hc-chip color="blue">Info Chip</hc-chip>
 <hc-chip color="yellow">
     <hc-icon class="example-chip-icon" fontSet="fa" fontIcon="fa-exclamation-triangle" hcIconSm></hc-icon>
     This is an example of a chip that line wraps. If you have an icon included you can set its margin and

--- a/projects/cashmere/src/lib/chip/chip.component.html
+++ b/projects/cashmere/src/lib/chip/chip.component.html
@@ -1,4 +1,4 @@
-<div class="hc-chip hc-chip-{{color}}" [ngClass]="{'hc-chip-padding': !tight}" [ngStyle]="{'width': width}">
+<div class="hc-chip hc-chip-{{color}}" [class.hc-chip-padding]="!tight" [style.width]="width">
     <span class="hc-chip-content-{{color}}">
         <ng-content></ng-content>
     </span>

--- a/projects/cashmere/src/lib/chip/chip.component.html
+++ b/projects/cashmere/src/lib/chip/chip.component.html
@@ -1,4 +1,4 @@
-<div class="hc-chip hc-chip-{{color}}">
+<div class="hc-chip hc-chip-{{color}}" [ngClass]="{'hc-chip-padding': !tight}" [ngStyle]="{'width': width}">
     <span class="hc-chip-content-{{color}}">
         <ng-content></ng-content>
     </span>

--- a/projects/cashmere/src/lib/chip/chip.component.scss
+++ b/projects/cashmere/src/lib/chip/chip.component.scss
@@ -4,13 +4,18 @@
     @include hc-chip();
 }
 
+.hc-chip-padding {
+    @include hc-chip-padding();
+}
+
 .hc-chip-content-neutral {
     @include hc-chip-content();
 }
 
 .hc-chip-content-red,
 .hc-chip-content-yellow,
-.hc-chip-content-green {
+.hc-chip-content-green,
+.hc-chip-content-blue {
     @include hc-chip-content-color();
 }
 
@@ -34,6 +39,10 @@
     @include hc-chip-green();
 }
 
+.hc-chip-blue {
+    @include hc-chip-blue();
+}
+
 .hc-chip-close-icon {
     @include hc-chip-close-icon();
 
@@ -51,6 +60,10 @@
 
     .hc-chip-green & {
         @include hc-chip-close-icon-green();
+    }
+
+    .hc-chip-blue & {
+        @include hc-chip-close-icon-blue();
     }
 }
 

--- a/projects/cashmere/src/lib/chip/chip.component.ts
+++ b/projects/cashmere/src/lib/chip/chip.component.ts
@@ -1,7 +1,7 @@
 import {Component, Input, ViewEncapsulation, Output, EventEmitter} from '@angular/core';
 import {parseBooleanAttribute} from '../util';
 
-const supportedColors = ['neutral', 'yellow', 'green', 'red'];
+const supportedColors = ['neutral', 'yellow', 'green', 'red', 'blue'];
 
 export function validateColorInput(inputStr: string) {
     if (supportedColors.indexOf(inputStr) < 0) {
@@ -19,12 +19,13 @@ export function validateColorInput(inputStr: string) {
 export class ChipComponent {
     private _hasCloseButton: boolean = false;
     private _color: string = 'neutral';
+    _tight = false;
 
     /** Emitted when the 'X' close button is clicked. `(click)` may be used for clicks on the entire chip */
     @Output()
     closeClick = new EventEmitter<MouseEvent>();
 
-    /** Sets chip color to one of: `neutral`, `yellow`, `green`, or `red` (default=`neutral`) */
+    /** Sets chip color to one of: `neutral`, `yellow`, `green`, `red`, or `blue` (default=`neutral`) */
     @Input()
     get color(): string {
         return this._color;
@@ -46,6 +47,20 @@ export class ChipComponent {
     set hasCloseButton(hasButton) {
         this._hasCloseButton = parseBooleanAttribute(hasButton);
     }
+
+    /** If true, removes the margins & padding from the chip; defaults to `false` */
+    @Input()
+    get tight(): boolean {
+        return this._tight;
+    }
+
+    set tight(val) {
+        this._tight = parseBooleanAttribute(val);
+    }
+
+    /** Allows you to customize the width of a chip (ie. `100%`, `250px`); defaults to `auto` */
+    @Input()
+    width: string = 'auto';
 
     /** Called on a click of the X close button */
     _closeClick(e: MouseEvent) {

--- a/projects/cashmere/src/lib/sass/chip.scss
+++ b/projects/cashmere/src/lib/sass/chip.scss
@@ -6,9 +6,12 @@
     @include fontSize(14px);
     border-radius: 6px;
     display: inline-flex;
-    margin: 5px;
+}
+
+@mixin hc-chip-padding() {
     padding-left: 15px;
     padding-right: 15px;
+    margin: 5px;
 }
 
 @mixin hc-chip-content() {
@@ -55,6 +58,12 @@
     color: $green;
 }
 
+@mixin hc-chip-blue() {
+    background-color: desaturate(lighten($blue, 40%), 50%);
+    border: 2px solid desaturate(lighten($blue, 30%), 50%);
+    color: $dark-blue;
+}
+
 @mixin hc-chip-close-icon() {
     background-repeat: no-repeat;
     background-size: contain;
@@ -78,6 +87,10 @@
 
 @mixin hc-chip-close-icon-green() {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOS44ODgiIGhlaWdodD0iMTkuODg4IiB2aWV3Qm94PSIwIDAgMTkuODg4IDE5Ljg4OCI+CiAgPHBhdGggaWQ9IlBhdGhfNCIgZGF0YS1uYW1lPSJQYXRoIDQiIGQ9Ik0yMS43My0zLjU4M2ExLjYyMywxLjYyMywwLDAsMC0uNDY5LTEuMTM4TDE2LjMzOS05LjY0M2w0LjkyMi00LjkyMkExLjYyMywxLjYyMywwLDAsMCwyMS43My0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLS40NjktMS4xMzhsLTIuMjc3LTIuMjc3YTEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LS40NjksMS42MjMsMS42MjMsMCwwLDAtMS4xMzguNDY5TDExLjc4Ni0xNC4yLDYuODY0LTE5LjExOGExLjYyMywxLjYyMywwLDAsMC0xLjEzOC0uNDY5LDEuNjIzLDEuNjIzLDAsMCwwLTEuMTM4LjQ2OUwyLjMxLTE2Ljg0MkExLjYyMywxLjYyMywwLDAsMCwxLjg0Mi0xNS43YTEuNjIzLDEuNjIzLDAsMCwwLC40NjksMS4xMzhMNy4yMzItOS42NDMsMi4zMS00LjcyMWExLjYyMywxLjYyMywwLDAsMC0uNDY5LDEuMTM4QTEuNjIzLDEuNjIzLDAsMCwwLDIuMzEtMi40NDRMNC41ODctLjE2N0ExLjYyMywxLjYyMywwLDAsMCw1LjcyNS4zLDEuNjIzLDEuNjIzLDAsMCwwLDYuODY0LS4xNjdsNC45MjItNC45MjJMMTYuNzA4LS4xNjdBMS42MjMsMS42MjMsMCwwLDAsMTcuODQ2LjNhMS42MjMsMS42MjMsMCwwLDAsMS4xMzgtLjQ2OWwyLjI3Ny0yLjI3N0ExLjYyMywxLjYyMywwLDAsMCwyMS43My0zLjU4M1oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xLjg0MiAxOS41ODcpIiBmaWxsPSIjMDBhODU5Ii8+Cjwvc3ZnPgo=');
+}
+
+@mixin hc-chip-close-icon-blue() {
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgMTkuOSAxOS45IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxOS45IDE5Ljk7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojMDA2RDlBO30KPC9zdHlsZT4KPHBhdGggaWQ9IlBhdGhfNCIgY2xhc3M9InN0MCIgZD0iTTE5LjksMTZjMC0wLjQtMC4yLTAuOC0wLjUtMS4xbC00LjktNC45TDE5LjQsNWMwLjMtMC4zLDAuNS0wLjcsMC41LTEuMWMwLTAuNC0wLjItMC44LTAuNS0xLjEKCWwtMi4zLTIuM0MxNi44LDAuMiwxNi40LDAsMTYsMGMtMC40LDAtMC44LDAuMi0xLjEsMC41TDkuOSw1LjRMNSwwLjVDNC43LDAuMiw0LjMsMCwzLjksMEMzLjUsMCwzLDAuMiwyLjcsMC41TDAuNSwyLjcKCUMwLjIsMywwLDMuNSwwLDMuOUMwLDQuMywwLjIsNC43LDAuNSw1bDQuOSw0LjlsLTQuOSw0LjlDMC4yLDE1LjIsMCwxNS42LDAsMTZjMCwwLjQsMC4yLDAuOCwwLjUsMS4xbDIuMywyLjMKCWMwLjMsMC4zLDAuNywwLjUsMS4xLDAuNWMwLjQsMCwwLjgtMC4yLDEuMS0wLjVsNC45LTQuOWw0LjksNC45YzAuMywwLjMsMC43LDAuNSwxLjEsMC41YzAuNCwwLDAuOC0wLjIsMS4xLTAuNWwyLjMtMi4zCglDMTkuNywxNi44LDE5LjksMTYuNCwxOS45LDE2eiIvPgo8L3N2Zz4=');
 }
 
 @mixin hc-chip-row-contents() {

--- a/src/app/components/component-viewer/component-viewer.component.html
+++ b/src/app/components/component-viewer/component-viewer.component.html
@@ -1,6 +1,8 @@
 <div class="demo-content">
     <h1>{{ docItem?.name }}</h1>
-    <code *ngIf="docItem?.npmPackage">{{ docItem!.npmPackage }}</code>
+    <div class="npm-package-code">
+        <code *ngIf="docItem?.npmPackage">{{ docItem!.npmPackage }}</code>
+    </div>
     <hc-tab-set direction="horizontal" class="overflow-visible" *ngIf="docItem">
         <hc-tab *ngFor="let section of sections" [tabTitle]="section" [routerLink]="section.toLowerCase()"></hc-tab>
     </hc-tab-set>

--- a/src/app/components/components.component.html
+++ b/src/app/components/components.component.html
@@ -20,21 +20,17 @@
 
     <div class="hc-components-left-column">
         <div class="hc-components-nav-container">
-            <div class="banner-wrapper" *ngIf="docType === 'bits'">
-                <hc-banner [type]="'info'">
-                    <div></div>
-                    <div>
-                        <h4 class="banner-title">
-                            <hc-icon [fontSet]="'hc-icons'" [fontIcon]="'hci-help'" icon-sm></hc-icon>
-                            What's a Bit?
-                        </h4>
-                        <p>
+            <div class="hc-components-chip-wrapper" *ngIf="docType === 'bits'">
+                <hc-chip color="blue" tight="true" width="100%">
+                    <div class="hc-components-chip-content">
+                        <hc-icon fontSet="hc-icons" fontIcon="hci-help" hcIconSm></hc-icon>
+                        What's a Bit?
+                        <p class="hc-components-chip-link">
                             Learn about Cashmere Bits
-                            <a [routerLink]="'/guides/using-cashmere-bits'">here</a>
-                            .
+                            <a [routerLink]="'/guides/using-cashmere-bits'">in this guide</a>.
                         </p>
                     </div>
-                </hc-banner>
+                </hc-chip>
             </div>
             <hc-tile>
                 <div class="hc-components-nav-list">

--- a/src/app/components/components.component.scss
+++ b/src/app/components/components.component.scss
@@ -70,16 +70,21 @@
     }
 }
 
-.banner-wrapper {
+.hc-components-chip-wrapper {
     margin-bottom: 10px;
-    border-left: 1px solid desaturate(lighten($blue, 30%), 50%);
-    border-right: 1px solid desaturate(lighten($blue, 30%), 50%);
+}
 
-    p {
-        font-size: small;
+.hc-components-chip-content {
+    padding: 5px 25px;
+
+    hc-icon {
+        margin-right: 2px;
     }
 }
 
-h4.banner-title {
-    margin: 0 0 10px 0;
+.hc-components-chip-link {
+    font-size: 13px;
+    line-height: 13px;
+    margin-top: 7px;
+    margin-bottom: 0;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -40,6 +40,14 @@ body {
     }
 }
 
+.npm-package-code {
+    margin-bottom: 15px;
+
+    code {
+        background-color: transparent;
+    }
+}
+
 .popoverContainer {
     li {
         margin: 0 10px !important;


### PR DESCRIPTION
Hey Joe, I made some style adjustments to your PR.  Based on how it was being used, it made more sense for that notification above the Bit tile to be a chip - but as I made that switch it exposed a few shortcomings of the component.  I added a `tight` param that we have on several other components that removes margin/padding.  And I added a `width` param so the dev can decide whether the chip should take the full width of its space (it's currently set to auto).

I also cleaned up some formatting on your guide. Let me know if you have any concerns.