### PR TITLE
1420 scrollnav active

### DIFF
--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
@@ -36,5 +36,6 @@ export class HcScrollNavComponent implements AfterViewInit {
             e.classList.remove(this.ACTIVE_CLASS);
         });
         element.classList.add(this.ACTIVE_CLASS);
+        element.focus();
     }
 }

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
@@ -36,6 +36,6 @@ export class HcScrollNavComponent implements AfterViewInit {
             e.classList.remove(this.ACTIVE_CLASS);
         });
         element.classList.add(this.ACTIVE_CLASS);
-        element.focus();
+        element.blur();
     }
 }

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
@@ -32,10 +32,14 @@ export class HcScrollNavComponent implements AfterViewInit {
     }
 
     private setActiveClass(element: HTMLElement): void {
+        const focusedEl = document.activeElement;
         this._links.forEach(e => {
             e.classList.remove(this.ACTIVE_CLASS);
+            // If a nav item on the scroll list currently has focus, remove it so a highlight border doesn't persist on scroll
+            if ( focusedEl === e ) {
+                e.blur();
+            }
         });
         element.classList.add(this.ACTIVE_CLASS);
-        element.blur();
     }
 }

--- a/src/app/styles/code/code-demo.component.html
+++ b/src/app/styles/code/code-demo.component.html
@@ -3,7 +3,7 @@
     <h6>Last updated Jan 30, 2019</h6>
 
     <hc-tile>
-        <h5>Overview</h5>
+        <h5 id="overview">Overview</h5>
         <p>
             Source code often needs to be included within app documentation or within apps themselves. The following are guidelines on how
             to style code used in these instances, both inline or within larger code blocks. The primary goal of code styling is
@@ -15,7 +15,7 @@
     </hc-tile>
 
     <hc-tile>
-        <h5>Elements</h5>
+        <h5 id="elements">Elements</h5>
         <table class="api-table">
             <tr>
                 <td>

--- a/src/app/styles/table/table-demo.component.html
+++ b/src/app/styles/table/table-demo.component.html
@@ -86,7 +86,7 @@
     </hc-tile>
 
     <hc-tile>
-        <h5>Sorting Indicators</h5>
+        <h5 id="sorting-indicators">Sorting Indicators</h5>
         <p>Add
             <code>.hc-col-sortable</code> to a
             <code>&lt;th&gt;</code> so that it appears sortable.</p>
@@ -155,7 +155,7 @@
     </hc-tile>
 
     <hc-tile>
-        <h5>Condensed Table</h5>
+        <h5 id="condensed-table">Condensed Table</h5>
         <p>Add
             <code>.hc-table-small</code> (in addition to
             <code>.hc-table</code>) for a smaller table.</p>
@@ -205,7 +205,7 @@
     </hc-tile>
 
     <hc-tile>
-        <h5>Selected Row</h5>
+        <h5 id="selected-row">Selected Row</h5>
         <p>Add
             <code>.hc-row-selected</code> to a
             <code>&lt;tr&gt;</code> so it appears selected.</p>
@@ -258,7 +258,7 @@
     </hc-tile>
 
     <hc-tile>
-        <h5>Borders</h5>
+        <h5 id="borders">Borders</h5>
         <p>Add
             <code>.hc-table-borders</code> (in addition to
             <code>.hc-table</code>) for borders all around.</p>


### PR DESCRIPTION
Gives scrollnav links focus when they are set to active - ensures the highlight border follows as the page is scrolled, but users can still keyboard navigate using the highlight to tab through links.

Also included two small fixes for search indexing two style pages I noticed needed ids on their headers.

closes #1420 