### PR TITLE
fix(hc-select): make compareWith work with FormBuilder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5573,7 +5573,7 @@
         "@samverschueren/stream-to-observable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-            "integrity": "sha1-7N9I1TLFjqR3rPyrgDSEJPjQZi8=",
+            "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
             "dev": true,
             "requires": {
                 "any-observable": "^0.3.0"
@@ -8716,7 +8716,7 @@
         "@types/node": {
             "version": "9.6.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.2.tgz",
-            "integrity": "sha1-5JrBrbRYg16VymSHvCD5FrN6/yM=",
+            "integrity": "sha512-UWkRY9X7RQHp5OhhRIIka58/gVVycL1zHZu0OTsT5LI86ABaMOSbUjAl+b0FeDhQcxclrkyft3kW5QWdMRs8wQ==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -9626,7 +9626,7 @@
         "any-observable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-            "integrity": "sha1-r5M0deWAamfQ198JDdXovvZdEZs=",
+            "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
             "dev": true
         },
         "anymatch": {
@@ -9831,7 +9831,7 @@
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
         },
         "are-we-there-yet": {
@@ -9886,7 +9886,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "arr-union": {
@@ -9991,7 +9991,7 @@
         "asn1.js": {
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-            "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
@@ -10950,7 +10950,7 @@
         "babylon": {
             "version": "6.18.0",
             "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
             "dev": true
         },
         "backo2": {
@@ -10974,7 +10974,7 @@
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-            "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
@@ -12594,7 +12594,7 @@
         "browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-            "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
                 "buffer-xor": "^1.0.3",
@@ -12685,7 +12685,7 @@
         "browserify-zlib": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-            "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
                 "pako": "~1.0.5"
@@ -12737,7 +12737,7 @@
         "buffer-indexof": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-            "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
+            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
             "dev": true
         },
         "buffer-xor": {
@@ -12822,7 +12822,7 @@
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-            "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
@@ -13198,7 +13198,7 @@
         "cipher-base": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
@@ -13214,7 +13214,7 @@
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-            "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
@@ -13882,7 +13882,7 @@
         "concat-stream": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -13982,7 +13982,7 @@
         "content-type": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "dev": true
         },
         "conventional-changelog-angular": {
@@ -14557,7 +14557,7 @@
         "copy-concurrently": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-            "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+            "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
                 "aproba": "^1.1.1",
@@ -15135,7 +15135,7 @@
         "crypto-browserify": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-            "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
                 "browserify-cipher": "^1.0.0",
@@ -15400,7 +15400,7 @@
         "d3": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-            "integrity": "sha1-qyNv+M8M/CeoHmm/L7dRi8m08z0=",
+            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
             "requires": {
                 "d3-array": "1.2.1",
                 "d3-axis": "1.0.8",
@@ -15437,7 +15437,7 @@
         "d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
-            "integrity": "sha1-0coz3i9qwx76244FCgIdfiOW1dw="
+            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "d3-axis": {
             "version": "1.0.8",
@@ -15483,7 +15483,7 @@
         "d3-drag": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha1-343UxQL7SQ/HRiBGqK2YpcR5KC0=",
+            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
             "requires": {
                 "d3-dispatch": "1",
                 "d3-selection": "1"
@@ -15492,7 +15492,7 @@
         "d3-dsv": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha1-kH4kDVezhmGNxWRous/na/GXZK4=",
+            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
             "requires": {
                 "commander": "2",
                 "iconv-lite": "0.4",
@@ -15507,7 +15507,7 @@
         "d3-force": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha1-zr88aU8QePzD1Nr45Wey+9cNTqM=",
+            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
             "requires": {
                 "d3-collection": "1",
                 "d3-dispatch": "1",
@@ -15518,12 +15518,12 @@
         "d3-format": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha1-GjnEecilf+UFGy5no77icGGnTno="
+            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
         },
         "d3-geo": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-            "integrity": "sha1-FX47D5FzedD3O+v/875Tf0n6c1Y=",
+            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
             "requires": {
                 "d3-array": "1"
             }
@@ -15536,7 +15536,7 @@
         "d3-interpolate": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha1-LPOVriOBgE3wiqG/dmt/l7X2j7Y=",
+            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
             "requires": {
                 "d3-color": "1"
             }
@@ -15569,7 +15569,7 @@
         "d3-request": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha1-oQRKnvTsKMgkFxyTefrm15R0sZ8=",
+            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
             "requires": {
                 "d3-collection": "1",
                 "d3-dispatch": "1",
@@ -15580,7 +15580,7 @@
         "d3-scale": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha1-+pAySz6op3ZCK9BHKvqwslKglF0=",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "requires": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -15594,7 +15594,7 @@
         "d3-selection": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha1-1TdyOC09xPdQe/sovNLWrtKgrW0="
+            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "d3-shape": {
             "version": "1.2.0",
@@ -15607,12 +15607,12 @@
         "d3-time": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-            "integrity": "sha1-29LWAHv0Fv5np20XlHt4S//qHoQ="
+            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
         "d3-time-format": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-            "integrity": "sha1-hbfN+8n/yhh/FNPEVv/aJoCBuzE=",
+            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
             "requires": {
                 "d3-time": "1"
             }
@@ -15620,12 +15620,12 @@
         "d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-            "integrity": "sha1-35ZQylh/bJZgf/TmDMOCKejdhTE="
+            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
         },
         "d3-transition": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha1-2O+Jw7hIc1sGDlSjmzKq66pCEDk=",
+            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
             "requires": {
                 "d3-color": "1",
                 "d3-dispatch": "1",
@@ -15643,7 +15643,7 @@
         "d3-zoom": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha1-AvQ7PD4ttU82RYLX5KI2zMVQa2M=",
+            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
             "requires": {
                 "d3-dispatch": "1",
                 "d3-drag": "1",
@@ -15717,7 +15717,7 @@
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -15941,7 +15941,7 @@
         "define-property": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-            "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
@@ -16018,7 +16018,7 @@
                 },
                 "array-union": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "resolved": "https://healthcatalyst.pkgs.visualstudio.com/_packaging/CatalystShared/npm/registry/array-union/-/array-union-1.0.2.tgz",
                     "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
                     "dev": true,
                     "requires": {
@@ -16338,7 +16338,7 @@
         "dns-packet": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-            "integrity": "sha1-EqpCaYEHW+UAuRDu3NC0fdfe2lo=",
+            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
             "dev": true,
             "requires": {
                 "ip": "^1.1.0",
@@ -16417,7 +16417,7 @@
         "domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-            "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true
         },
         "domelementtype": {
@@ -16886,7 +16886,7 @@
         "errno": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-            "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
+            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
                 "prr": "~1.0.1"
@@ -17283,7 +17283,7 @@
         "esrecurse": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
                 "estraverse": "^4.1.0"
@@ -17347,7 +17347,7 @@
         "evp_bytestokey": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-            "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
                 "md5.js": "^1.3.4",
@@ -17747,7 +17747,7 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
@@ -19014,7 +19014,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
         "functional-red-black-tree": {
@@ -19464,7 +19464,7 @@
         "globals": {
             "version": "9.18.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
             "dev": true
         },
         "globby": {
@@ -20436,7 +20436,7 @@
         "husky": {
             "version": "0.14.3",
             "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-            "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
+            "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
             "dev": true,
             "requires": {
                 "is-ci": "^1.0.10",
@@ -20698,7 +20698,7 @@
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
         "ini-builder": {
@@ -21483,7 +21483,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
         "is-callable": {
@@ -21762,7 +21762,7 @@
         "is-observable": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-            "integrity": "sha1-s+mGyPRN6VCGfKtUA/WjRlAFl14=",
+            "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
             "dev": true,
             "requires": {
                 "symbol-observable": "^1.1.0"
@@ -21812,7 +21812,7 @@
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
@@ -21942,7 +21942,7 @@
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
         "is-wsl": {
@@ -22174,7 +22174,7 @@
         "jasmine-spec-reporter": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz",
-            "integrity": "sha1-HWMq7ANBZwrTJPkrqEtLMrNeniI=",
+            "integrity": "sha512-FZBoZu7VE5nR7Nilzy+Np8KuVIOxF4oXDPDknehCYBDE080EnlPu0afdZNmpGDBRCUBv3mj5qgqCRmk6W/K8vg==",
             "dev": true,
             "requires": {
                 "colors": "1.1.2"
@@ -23653,7 +23653,7 @@
         "jest-get-type": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-            "integrity": "sha1-46hQTYR5NC3UQgI2syKGnxiQDOQ=",
+            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
             "dev": true
         },
         "jest-haste-map": {
@@ -25682,7 +25682,7 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
         "json-schema": {
@@ -26046,7 +26046,7 @@
         "karma-chrome-launcher": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
-            "integrity": "sha1-zxudBxNswY/iOTJ9JGVMPbw2is8=",
+            "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
             "dev": true,
             "requires": {
                 "fs-access": "^1.0.0",
@@ -26558,7 +26558,7 @@
                 "execa": {
                     "version": "0.9.0",
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-                    "integrity": "sha1-rbfOYs+YUHH2BYDetKiLnjRxLQE=",
+                    "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
                     "dev": true,
                     "requires": {
                         "cross-spawn": "^5.0.1",
@@ -26936,7 +26936,7 @@
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1"
@@ -27137,7 +27137,7 @@
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
             "dev": true
         },
         "lru-cache": {
@@ -27698,7 +27698,7 @@
         "miller-rabin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-            "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
@@ -27716,7 +27716,7 @@
         "mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true
         },
         "mime-db": {
@@ -27813,7 +27813,7 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
@@ -27977,7 +27977,7 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
@@ -28113,7 +28113,7 @@
         "multicast-dns": {
             "version": "6.2.3",
             "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-            "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
+            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
             "dev": true,
             "requires": {
                 "dns-packet": "^1.3.1",
@@ -28549,7 +28549,7 @@
         "no-case": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-            "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
+            "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "requires": {
                 "lower-case": "^1.1.1"
             }
@@ -28804,7 +28804,7 @@
         "node-sass-tilde-importer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz",
-            "integrity": "sha1-GhUQXBU/ZIMjtDR2k/2w8zG60c4=",
+            "integrity": "sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==",
             "dev": true,
             "requires": {
                 "find-parent-dir": "^0.3.0"
@@ -32442,7 +32442,7 @@
         "npm-font-open-sans": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/npm-font-open-sans/-/npm-font-open-sans-1.1.0.tgz",
-            "integrity": "sha1-jCelbkOHJ0e4RI3MMGU6ZJhmxu8="
+            "integrity": "sha512-t1y5ShWm6a8FSLwBdINT47XYMcuKY2rkTBsTdz/76YB2MtX0YD89RUkY2eSS2/XOmlZfBe1HFBAwD+b9+/UfmQ=="
         },
         "npm-normalize-package-bin": {
             "version": "1.0.1",
@@ -32476,7 +32476,7 @@
         "npm-path": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
-            "integrity": "sha1-xkE0el/51qCeTZvOVYDE9QUnjmQ=",
+            "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
             "dev": true,
             "requires": {
                 "which": "^1.2.10"
@@ -32625,7 +32625,7 @@
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -32945,7 +32945,7 @@
         "obuf": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-            "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
             "dev": true
         },
         "octokit-pagination-methods": {
@@ -33281,7 +33281,7 @@
         "osenv": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-            "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
                 "os-homedir": "^1.0.0",
@@ -33365,7 +33365,7 @@
         "p-map": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-            "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+            "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
             "dev": true
         },
         "p-map-series": {
@@ -33818,7 +33818,7 @@
         "path-type": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
                 "pify": "^3.0.0"
@@ -34069,7 +34069,7 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 },
                 "supports-color": {
@@ -34663,7 +34663,7 @@
         "promise": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-            "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
             "dev": true,
             "requires": {
                 "asap": "~2.0.3"
@@ -34994,7 +34994,7 @@
         "randomfill": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-            "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.0.5",
@@ -35491,7 +35491,7 @@
         "regenerator-runtime": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
             "dev": true
         },
         "regenerator-transform": {
@@ -35524,7 +35524,7 @@
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-            "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
@@ -35984,7 +35984,7 @@
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
         "retry": {
@@ -37439,7 +37439,7 @@
         "sha.js": {
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
@@ -37603,7 +37603,7 @@
         "snapdragon": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-            "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
                 "base": "^0.11.1",
@@ -37639,7 +37639,7 @@
         "snapdragon-node": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-            "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
@@ -37690,7 +37690,7 @@
         "snapdragon-util": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-            "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
@@ -38058,7 +38058,7 @@
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
@@ -38170,7 +38170,7 @@
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-            "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
@@ -38268,7 +38268,7 @@
         "staged-git-files": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
-            "integrity": "sha1-N8IhjvDW0mF4sTEHGTCaFqWfj3s=",
+            "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
             "dev": true
         },
         "static-extend": {
@@ -38900,7 +38900,7 @@
         "stylus-loader": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.2.tgz",
-            "integrity": "sha1-J6cGQgsFo44DjnyssVNXjUUFE8Y=",
+            "integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
             "dev": true,
             "requires": {
                 "loader-utils": "^1.0.2",
@@ -39668,7 +39668,7 @@
         "to-regex": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-            "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
@@ -39861,7 +39861,7 @@
         "ts-node": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
-            "integrity": "sha1-eOXRyz9wTeG2QeQ7dr4tQJTwb4E=",
+            "integrity": "sha512-XK7QmDcNHVmZkVtkiwNDWiERRHPyU8nBqZB1+iv2UhOG0q3RQ9HsZ2CMqISlFbxjrYFGfG2mX7bW4dAyxBVzUw==",
             "dev": true,
             "requires": {
                 "arrify": "^1.0.0",
@@ -40145,7 +40145,7 @@
         "uglify-js": {
             "version": "3.3.18",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.18.tgz",
-            "integrity": "sha1-4W32bXFjjfPJvGHM6CfkbyS9rAI=",
+            "integrity": "sha512-VhjIFv93KnTx/ntNi9yTBbfrsWnQnqUy02MT32uqU/5i2oEJ8GAEJ0AwYV206JeOmIzSjm41Ba0iXVKv6j7y9g==",
             "dev": true,
             "requires": {
                 "commander": "~2.15.0",
@@ -40155,13 +40155,13 @@
                 "commander": {
                     "version": "2.15.1",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-                    "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
                     "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
             }
@@ -41065,7 +41065,7 @@
         "wbuf": {
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-            "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
             "dev": true,
             "requires": {
                 "minimalistic-assert": "^1.0.0"
@@ -41496,7 +41496,7 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
             }
@@ -41512,7 +41512,7 @@
         },
         "websocket-driver": {
             "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+            "resolved": "https://healthcatalyst.pkgs.visualstudio.com/_packaging/CatalystShared/npm/registry/websocket-driver/-/websocket-driver-0.6.5.tgz",
             "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
             "dev": true,
             "requires": {
@@ -41625,7 +41625,7 @@
                 "string-width": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
@@ -41874,7 +41874,7 @@
         "xxhashjs": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-            "integrity": "sha1-imJRVnYhocRqWuIE2gJJx/jKqdg=",
+            "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
             "dev": true,
             "requires": {
                 "cuint": "^0.2.2"
@@ -41883,7 +41883,7 @@
         "y18n": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
             "dev": true
         },
         "yallist": {

--- a/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.html
@@ -1,5 +1,9 @@
-<hc-select [compareWith]="pizzaToppingsComparer" [(ngModel)]="selectedTopping">
-    <option *ngFor="let topping of toppings" [ngValue]="topping">{{topping.name}} - {{topping.price}}</option>
-</hc-select>
+<form [formGroup]="pizzaToppingForm">
+    <hc-form-field>
+        <hc-select formControlName="selectedTopping" [compareWith]="pizzaToppingsComparer">
+            <option *ngFor="let topping of toppings" [ngValue]="topping">{{topping.name}} - {{topping.price}}</option>
+        </hc-select>
+    </hc-form-field>
+</form>
 
-<p class="example-results">Form control value: <code>{{selectedTopping | json}}</code></p>
+<p class="example-results">Form control value: <code>{{ pizzaToppingForm.get("selectedTopping")?.value | json }}</code></p>

--- a/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-compare-with/select-compare-with-example.component.ts
@@ -1,4 +1,5 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup} from "@angular/forms";
 
 interface Topping {
     id: number;
@@ -14,7 +15,8 @@ interface Topping {
     templateUrl: 'select-compare-with-example.component.html',
     styleUrls: ['select-compare-with-example.component.scss']
 })
-export class SelectCompareWithExampleComponent {
+export class SelectCompareWithExampleComponent implements OnInit {
+    pizzaToppingForm: FormGroup;
     toppings: Array<Topping> = [
         {id: 1, name: 'Pepperoni', price: "$0.59"},
         {id: 2, name: 'Olives', price: "$0.79"},
@@ -23,7 +25,13 @@ export class SelectCompareWithExampleComponent {
         {id: 5, name: 'Chicken', price: "$0.99"},
     ];
 
-    selectedTopping = {id: 5, name: 'Chicken', price: "$0.99"};
+    constructor(private formBuilder: FormBuilder) { }
+
+    public ngOnInit() {
+        this.pizzaToppingForm = this.formBuilder.group({
+            "selectedTopping": {id: 5, name: 'Chicken', price: '$0.99'}
+        });
+    }
 
     pizzaToppingsComparer(option1: Topping, option2: Topping): boolean {
         return option1 && option2 && option1.id === option2.id;

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -11,7 +11,8 @@ import {
     Output,
     EventEmitter,
     ViewChild,
-    Renderer2
+    Renderer2,
+    AfterViewInit
 } from '@angular/core';
 import {ControlValueAccessor, NgForm, FormGroupDirective, NgControl} from '@angular/forms';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
@@ -38,7 +39,7 @@ export function _buildValueString(id: string|null, value: any): string {
     encapsulation: ViewEncapsulation.None,
     providers: [{provide: HcFormControlComponent, useExisting: forwardRef(() => SelectComponent)}]
 })
-export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck {
+export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck, AfterViewInit {
     private _uniqueInputId = `hc-select-${uniqueId++}`;
     private _form: NgForm | FormGroupDirective | null;
     private _tight: boolean = false;
@@ -161,6 +162,10 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
 
     private onTouched: (val: any) => void = () => {};
 
+    ngAfterViewInit() {
+        this._applyValueToNativeControl();
+    }
+
     registerOnChange(fn: any) {
         this.onChange = fn;
     }
@@ -171,13 +176,17 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
 
     writeValue(value: any) {
         this._value = value;
-        const id: string|null = this._getOptionId(value);
+        this._applyValueToNativeControl();
+    }
+
+    _applyValueToNativeControl() {
+        const id: string|null = this._getOptionId(this._value);
         if (!this._nativeSelect) { return; }
         if (id == null) {
             const selectedIndex = this.placeholder ? 0 : -1;
             this._renderer.setProperty(this._nativeSelect.nativeElement, 'selectedIndex', -1);
         }
-        const valueString = _buildValueString(id, value);
+        const valueString = _buildValueString(id, this._value);
         this._renderer.setProperty(this._nativeSelect.nativeElement, 'value', valueString);
     }
 


### PR DESCRIPTION
Fixes an issue where preselected option weren't showing as selected in the control.

In a previous commit when I added the compareWith parameter, I removed a piece of code like this:
```
ngAfterContentInit() {	
        if (this._valueData) {	
            setTimeout(() => {	
                this.writeValue(this._valueData);	
            });	
        }	
    }
```

I thought it wasn't needed any longer, but it's important to call `writeValue()` after the view is ready for the FormBuilder + compareWith case. I added back in a similar bit of code that runs in `ngAfterViewInit` and accomplishes the same thing.

Changed the compareWith example to use angular forms instead of ngModel.