### PR TITLE
Drawer unit tests / emitter fixes

### DIFF
--- a/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.component.html
+++ b/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.component.html
@@ -1,9 +1,9 @@
 <div class="drawer-container">
     <hc-drawer-container>
-        <hc-drawer align="left" #leftDrawer>
+        <hc-drawer align="left" [(opened)]="leftState" #leftDrawer>
             Left drawer content
         </hc-drawer>
-        <hc-drawer align="right" #rightDrawer>
+        <hc-drawer align="right" [(opened)]="rightState" #rightDrawer>
             Right drawer content
         </hc-drawer>
 
@@ -14,4 +14,6 @@
             Toggle Right Drawer
         </button>
     </hc-drawer-container>
+    <p>Left Drawer State: <strong>{{leftState?"Opened":"Closed"}}</strong></p>
+    <p>Right Drawer State: <strong>{{rightState?"Opened":"Closed"}}</strong></p>
 </div>

--- a/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.component.ts
+++ b/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.component.ts
@@ -8,4 +8,7 @@ import {Component} from '@angular/core';
     templateUrl: 'drawer-basic-example.component.html',
     styleUrls: ['drawer-basic-example.component.scss']
 })
-export class DrawerBasicExampleComponent {}
+export class DrawerBasicExampleComponent {
+    leftState = false;
+    rightState = false;
+}

--- a/projects/cashmere/src/lib/drawer/drawer-container.component.spec.ts
+++ b/projects/cashmere/src/lib/drawer/drawer-container.component.spec.ts
@@ -1,0 +1,92 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {Drawer} from './drawer.component';
+import {DrawerContainer} from './drawer-container.component';
+import {DrawerModule} from './drawer.module';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Component, ViewChild} from '@angular/core';
+
+@Component({
+    template: `
+        <hc-drawer-container #d>
+            <hc-drawer align="left" #leftDrawer></hc-drawer>
+            <hc-drawer align="right" #rightDrawer></hc-drawer>
+        </hc-drawer-container>
+    `
+})
+export class TestDrawerContainer {
+    @ViewChild('d', {static: false})
+    drawerContainer: DrawerContainer;
+    @ViewChild('leftDrawer', {static: false})
+    leftDrawer: Drawer;
+    @ViewChild('rightDrawer', {static: false})
+    rightDrawer: Drawer;
+}
+
+@Component({
+    template: `
+        <hc-drawer-container #d>
+            <hc-drawer *ngFor="let drawer of drawers"></hc-drawer>
+        </hc-drawer-container>
+    `
+})
+export class InvalidDrawerContainer {
+    @ViewChild('d', {static: false})
+    drawerContainer: DrawerContainer;
+
+    drawers = ["one"];
+}
+
+describe('DrawerContainer', () => {
+    let component: TestDrawerContainer;
+    let fixture: ComponentFixture<TestDrawerContainer>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestDrawerContainer, InvalidDrawerContainer],
+            imports: [DrawerModule, NoopAnimationsModule]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestDrawerContainer);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should open all included drawers when open is called', async () => {
+        expect( component.leftDrawer.opened ).toBe(false);
+        expect( component.rightDrawer.opened ).toBe(false);
+
+        component.drawerContainer.open();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        expect( component.leftDrawer.opened ).toBe(true);
+        expect( component.rightDrawer.opened ).toBe(true);
+    });
+
+    it('should close all included drawers when closed is called', async () => {
+        component.leftDrawer.toggleOpen();
+        component.rightDrawer.toggleOpen();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        expect( component.leftDrawer.opened ).toBe(true);
+        expect( component.rightDrawer.opened ).toBe(true);
+
+        component.drawerContainer.close();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        expect( component.leftDrawer.opened ).toBe(false);
+        expect( component.rightDrawer.opened ).toBe(false);
+    });
+
+    it('should throw an error if multiple drawers are assigned to the same side', () => {
+        let invalidFixture = TestBed.createComponent(InvalidDrawerContainer);
+        invalidFixture.detectChanges();
+
+        invalidFixture.componentInstance.drawers.push("two");
+        expect( () => invalidFixture.componentInstance.drawerContainer._validateDrawers() ).toThrowError(/A drawer was already declared for .*/);
+    });
+});

--- a/projects/cashmere/src/lib/drawer/drawer-container.component.ts
+++ b/projects/cashmere/src/lib/drawer/drawer-container.component.ts
@@ -78,7 +78,7 @@ export class DrawerContainer implements AfterContentInit, DoCheck, OnDestroy {
                     .subscribe(() => {
                         this._calculateContentMargins();
                     });
-                drawer._openChange.pipe(takeUntil(this._drawers.changes)).subscribe(isOpen => {
+                drawer.openedChange.pipe(takeUntil(this._drawers.changes)).subscribe(isOpen => {
                     if (isOpen) {
                         this._setContainerClass(true);
                     } else {
@@ -136,7 +136,7 @@ export class DrawerContainer implements AfterContentInit, DoCheck, OnDestroy {
         }
     }
 
-    private _validateDrawers(): void {
+    _validateDrawers(): void {
         for (let drawer of this._drawers.toArray()) {
             if (drawer.align === 'right') {
                 if (this._rightDrawer != null) {

--- a/projects/cashmere/src/lib/drawer/drawer.component.spec.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.spec.ts
@@ -1,0 +1,188 @@
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {animate, AnimationEvent, state, style, transition, trigger} from '@angular/animations';
+import {DrawerPromiseResult, Drawer} from './drawer.component';
+import * as util from '../util';
+import {ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {async} from '@angular/core/testing';
+
+describe('DrawerComponent', () => {
+    let component: Drawer;
+    let fixture: ComponentFixture<Drawer>;
+    // should e1 be a constant ?
+    let e1: ElementRef = new ElementRef({focus() {}});
+    // beforeEach(() => (component = new Drawer(e1)));
+    // describe('angular initialization', () => {
+    beforeEach(async done => {
+        await TestBed.configureTestingModule({
+            declarations: [Drawer],
+            imports: [NoopAnimationsModule],
+            providers: [{provide: ElementRef, useValue: e1}]
+        }).compileComponents();
+        fixture = TestBed.createComponent(Drawer);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        done();
+    });
+    it('should create the component without error', () => {
+        expect(component).toBeTruthy();
+    });
+    // });
+
+    describe('.mode', () => {
+        describe('by default', () => {
+            it('should be "push"', () => expect(component.mode).toBe('push'));
+        });
+        describe('after setting to valid value', () => {
+            beforeEach(() => (component.mode = 'side'));
+            it('should be the set value', () => expect(component.mode).toBe('side'));
+        });
+        describe('when setting to invalid value', () => {
+            const setInvalid = () => (component.mode = 'someInvalidValue' as string);
+            it('should throw an error', () => expect(setInvalid).toThrowError());
+        });
+    });
+
+    describe('.align', () => {
+        describe('by default', () => {
+            it('should be "left"', () => expect(component.align).toBe('left'));
+        });
+        describe('after setting to valid value', () => {
+            beforeEach(() => (component.align = 'right'));
+            it('should be the set value', () => expect(component.align).toBe('right'));
+        });
+        describe('when setting to invalid value', () => {
+            const setInvalid = () => (component.align = 'someInvalidValue' as string);
+            it('should throw an error', () => expect(setInvalid).toThrowError());
+        });
+    });
+
+    describe('.opened', () => {
+        describe('by default', () => {
+            it('should be "false"', () => expect(component.opened).toBe(false));
+        });
+        describe('after setting to valid value', () => {
+            beforeEach(() => (component.opened = true as boolean));
+            it('should be the set value', () => expect(component.opened).toBe(true));
+        });
+        describe('when setting to invalid value', () => {
+            const setInvalid = () => (component.opened = ('someInvalidValue' as any) as boolean);
+            it('should throw an error', () => expect(setInvalid).toThrowError());
+        });
+    });
+
+    // Test Case we were working on in the meeting
+    describe('.openStart', () => {
+        describe('when the drawer starts to open', () => {
+            let spy: jasmine.Spy;
+            beforeEach(() => {
+                spy = jasmine.createSpy('openStart');
+                component.openStart.subscribe(spy);
+                component.toggleOpen();
+            });
+
+            it('should emit', () => {
+                expect(spy).toHaveBeenCalled();
+            });
+            it('opened is false', () => {
+                expect(component.opened).toBe(false);
+            });
+        });
+    });
+
+    // a different try for the function we were working on
+    // still failing
+    describe('.openStart', () => {
+        describe('when the drawer is toggled', () => {
+            let spy: jasmine.Spy;
+
+            beforeEach(fakeAsync(() => {
+                spy = jasmine.createSpy('openStart');
+                component.openStart.subscribe(spy);
+                //component.toggleOpen();
+                let event: Partial<AnimationEvent> = {fromState: 'void', toState: 'open'};
+                component._onAnimationStart((event as any) as AnimationEvent);
+                tick();
+            }));
+            it('should not emit', () => expect(spy).toHaveBeenCalled());
+        });
+    });
+    // function if emitted or not are working properly
+    describe('.openStart', () => {
+        describe('when the drawer is already open', () => {
+            let spy: jasmine.Spy;
+
+            beforeEach(fakeAsync(() => {
+                spy = jasmine.createSpy('openStart');
+                component.openStart.subscribe(spy);
+                let event: Partial<AnimationEvent> = {fromState: 'open', toState: 'open'};
+                component._onAnimationStart((event as any) as AnimationEvent);
+                tick();
+            }));
+            it('should not emit', () => expect(spy).not.toHaveBeenCalled());
+        });
+    });
+
+    describe('.closeStart', () => {
+        describe('when the drawer starts to close', () => {
+            let spy: jasmine.Spy;
+
+            beforeEach(fakeAsync(() => {
+                spy = jasmine.createSpy('closeStart');
+                component.closeStart.subscribe(spy);
+                let event: Partial<AnimationEvent> = {fromState: 'open', toState: 'void'};
+                component._onAnimationStart((event as any) as AnimationEvent);
+                tick();
+            }));
+            it('should emit', () => expect(spy).toHaveBeenCalled());
+        });
+    });
+
+    describe('.closeStart', () => {
+        describe('when the drawer is already closed', () => {
+            let spy: jasmine.Spy;
+
+            beforeEach(fakeAsync(() => {
+                spy = jasmine.createSpy('closeStart');
+                component.closeStart.subscribe(spy);
+                let event: Partial<AnimationEvent> = {fromState: 'void', toState: 'void'};
+                component._onAnimationStart((event as any) as AnimationEvent);
+                tick();
+            }));
+            it('should not emit', () => expect(spy).not.toHaveBeenCalled());
+        });
+    });
+
+    describe('._openChange', () => {
+        describe('when the drawer has opened', () => {
+            let spy: jasmine.Spy;
+            let spyIsOpened: jasmine.Spy;
+            let spyIsClosed: jasmine.Spy;
+            beforeEach(fakeAsync(() => {
+                spy = jasmine.createSpy('_openChange');
+                component._openChange.subscribe(spy);
+                let event: Partial<AnimationEvent> = {fromState: 'void', toState: 'open'};
+                component._onAnimationEnd((event as any) as AnimationEvent);
+                spyIsOpened = spyOnProperty(component, '_isOpened', 'get').and.callThrough();
+                spyIsClosed = spyOnProperty(component, '_isClosed', 'get').and.callThrough();
+                tick();
+            }));
+
+            it('should emit', async(() => {
+                expect(spy).toHaveBeenCalled();
+            }));
+            // Should be true
+            it('_isOpened is false', async(() => {
+                fixture.whenRenderingDone().then(() => {
+                    expect(component._isOpened).toBe(false);
+                });
+            }));
+            // Should be false
+            it('_isClosed is true', async(() => {
+                fixture.whenRenderingDone();
+                expect(component._isClosed).toBe(true);
+            }));
+        });
+    });
+});

--- a/projects/cashmere/src/lib/drawer/drawer.component.spec.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.spec.ts
@@ -1,23 +1,18 @@
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {animate, AnimationEvent, state, style, transition, trigger} from '@angular/animations';
-import {DrawerPromiseResult, Drawer} from './drawer.component';
-import * as util from '../util';
-import {ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Drawer} from './drawer.component';
+import {ElementRef} from '@angular/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {async} from '@angular/core/testing';
 
 describe('DrawerComponent', () => {
     let component: Drawer;
     let fixture: ComponentFixture<Drawer>;
-    // should e1 be a constant ?
-    let e1: ElementRef = new ElementRef({focus() {}});
-    // beforeEach(() => (component = new Drawer(e1)));
-    // describe('angular initialization', () => {
+    let el: ElementRef = new ElementRef({focus() {}});
+
     beforeEach(async done => {
         await TestBed.configureTestingModule({
             declarations: [Drawer],
             imports: [NoopAnimationsModule],
-            providers: [{provide: ElementRef, useValue: e1}]
+            providers: [{provide: ElementRef, useValue: el}]
         }).compileComponents();
         fixture = TestBed.createComponent(Drawer);
         component = fixture.componentInstance;
@@ -28,7 +23,6 @@ describe('DrawerComponent', () => {
     it('should create the component without error', () => {
         expect(component).toBeTruthy();
     });
-    // });
 
     describe('.mode', () => {
         describe('by default', () => {
@@ -72,117 +66,57 @@ describe('DrawerComponent', () => {
         });
     });
 
-    // Test Case we were working on in the meeting
-    describe('.openStart', () => {
-        describe('when the drawer starts to open', () => {
-            let spy: jasmine.Spy;
-            beforeEach(() => {
-                spy = jasmine.createSpy('openStart');
-                component.openStart.subscribe(spy);
-                component.toggleOpen();
-            });
+    it('should dispatch an event when a drawer is opened', async () => {
+        const spy = jasmine.createSpy('openedChange called');
+        component.openedChange.subscribe(spy);
 
-            it('should emit', () => {
-                expect(spy).toHaveBeenCalled();
-            });
-            it('opened is false', () => {
-                expect(component.opened).toBe(false);
-            });
-        });
+        component.toggleOpen();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(component.opened).toBe(true);
     });
 
-    // a different try for the function we were working on
-    // still failing
-    describe('.openStart', () => {
-        describe('when the drawer is toggled', () => {
-            let spy: jasmine.Spy;
+    it('should emit openStart when a drawer is opened', async () => {
+        const spy = jasmine.createSpy('openStart called');
+        component.openStart.subscribe(spy);
 
-            beforeEach(fakeAsync(() => {
-                spy = jasmine.createSpy('openStart');
-                component.openStart.subscribe(spy);
-                //component.toggleOpen();
-                let event: Partial<AnimationEvent> = {fromState: 'void', toState: 'open'};
-                component._onAnimationStart((event as any) as AnimationEvent);
-                tick();
-            }));
-            it('should not emit', () => expect(spy).toHaveBeenCalled());
-        });
-    });
-    // function if emitted or not are working properly
-    describe('.openStart', () => {
-        describe('when the drawer is already open', () => {
-            let spy: jasmine.Spy;
+        component.toggleOpen();
+        fixture.detectChanges();
 
-            beforeEach(fakeAsync(() => {
-                spy = jasmine.createSpy('openStart');
-                component.openStart.subscribe(spy);
-                let event: Partial<AnimationEvent> = {fromState: 'open', toState: 'open'};
-                component._onAnimationStart((event as any) as AnimationEvent);
-                tick();
-            }));
-            it('should not emit', () => expect(spy).not.toHaveBeenCalled());
-        });
+        await fixture.whenStable();
+        expect(spy).toHaveBeenCalled();
     });
 
-    describe('.closeStart', () => {
-        describe('when the drawer starts to close', () => {
-            let spy: jasmine.Spy;
+    it('should dispatch an event when a drawer is closed', async () => {
+        const spy = jasmine.createSpy('openedChange called');
+        component.openedChange.subscribe(spy);
 
-            beforeEach(fakeAsync(() => {
-                spy = jasmine.createSpy('closeStart');
-                component.closeStart.subscribe(spy);
-                let event: Partial<AnimationEvent> = {fromState: 'open', toState: 'void'};
-                component._onAnimationStart((event as any) as AnimationEvent);
-                tick();
-            }));
-            it('should emit', () => expect(spy).toHaveBeenCalled());
-        });
+        component.toggleOpen();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        component.toggleClose();
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(component.opened).toBe(false);
     });
 
-    describe('.closeStart', () => {
-        describe('when the drawer is already closed', () => {
-            let spy: jasmine.Spy;
+    it('should emit closeStart when a drawer is closed', async () => {
+        const spy = jasmine.createSpy('closeStart called');
+        component.closeStart.subscribe(spy);
 
-            beforeEach(fakeAsync(() => {
-                spy = jasmine.createSpy('closeStart');
-                component.closeStart.subscribe(spy);
-                let event: Partial<AnimationEvent> = {fromState: 'void', toState: 'void'};
-                component._onAnimationStart((event as any) as AnimationEvent);
-                tick();
-            }));
-            it('should not emit', () => expect(spy).not.toHaveBeenCalled());
-        });
-    });
+        component.toggleOpen();
+        fixture.detectChanges();
 
-    describe('._openChange', () => {
-        describe('when the drawer has opened', () => {
-            let spy: jasmine.Spy;
-            let spyIsOpened: jasmine.Spy;
-            let spyIsClosed: jasmine.Spy;
-            beforeEach(fakeAsync(() => {
-                spy = jasmine.createSpy('_openChange');
-                component._openChange.subscribe(spy);
-                let event: Partial<AnimationEvent> = {fromState: 'void', toState: 'open'};
-                component._onAnimationEnd((event as any) as AnimationEvent);
-                spyIsOpened = spyOnProperty(component, '_isOpened', 'get').and.callThrough();
-                spyIsClosed = spyOnProperty(component, '_isClosed', 'get').and.callThrough();
-                tick();
-            }));
+        await fixture.whenStable();
+        component.toggleClose();
+        fixture.detectChanges();
 
-            it('should emit', async(() => {
-                expect(spy).toHaveBeenCalled();
-            }));
-            // Should be true
-            it('_isOpened is false', async(() => {
-                fixture.whenRenderingDone().then(() => {
-                    expect(component._isOpened).toBe(false);
-                });
-            }));
-            // Should be false
-            it('_isClosed is true', async(() => {
-                fixture.whenRenderingDone();
-                expect(component._isClosed).toBe(true);
-            }));
-        });
+        await fixture.whenStable();
+        expect(spy).toHaveBeenCalled();
     });
 });

--- a/projects/cashmere/src/lib/drawer/drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.ts
@@ -80,7 +80,6 @@ const openStateAnimation = '400ms cubic-bezier(0.25, 0.8, 0.25, 1)';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class Drawer implements AfterContentInit {
-    readonly _openChange = new EventEmitter<boolean>();
     private _mode: string = 'push';
     private _align: string = 'left';
 
@@ -110,7 +109,7 @@ export class Drawer implements AfterContentInit {
     @Output()
     get openStart(): Observable<void> {
         return this._animationStarted.pipe(
-            filter(event => event.fromState === 'void' && event.toState === 'open'),
+            filter(event => event.fromState === 'void' && event.toState.startsWith('open-') ),
             map(() => {})
         );
     }
@@ -119,28 +118,13 @@ export class Drawer implements AfterContentInit {
     @Output()
     get closeStart(): Observable<void> {
         return this._animationStarted.pipe(
-            filter(event => event.fromState === 'open' && event.toState === 'void'),
+            filter(event => event.fromState.startsWith('open-') && event.toState === 'void'),
             map(() => {})
         );
     }
 
-    /** Event emitted when drawer has opened */
-    @Output('opened')
-    get _openStream() {
-        return this._openChange.pipe(
-            filter(value => value),
-            map(() => {})
-        );
-    }
-
-    /** Event emitted when drawer has closed */
-    @Output('closed')
-    get _closeStream() {
-        return this._openChange.pipe(
-            filter(value => !value),
-            map(() => {})
-        );
-    }
+    /* Allows for two-way binding of the `opened` property */
+    @Output() openedChange = new EventEmitter<boolean>();
 
     /** Tabindex of the element */
     @HostBinding()
@@ -162,7 +146,9 @@ export class Drawer implements AfterContentInit {
     }
 
     set opened(opened) {
-        this.toggle(parseBooleanAttribute(opened));
+        if ( opened !== this._drawerOpened ) {
+            this.toggle(parseBooleanAttribute(opened));
+        }
     }
 
     get _width(): number {
@@ -213,7 +199,7 @@ export class Drawer implements AfterContentInit {
 
     @HostListener('@openState.done', ['$event'])
     _onAnimationEnd(event: AnimationEvent) {
-        this._openChange.next(this.opened);
+        this.openedChange.next(this.opened);
 
         if (this._animationPromise) {
             this._resolveAnimationPromise();


### PR DESCRIPTION
`openStart`, `closeStart`, and `openChanged` outputs fixed; adds unit tests

@hassankhan986 deserves a medal for taking this one on, building tests around all these animationEvents was driving me up a wall.  Thanks @joeskeen for the "phone a friend" support at the end of the day to get things unstuck.

closes #1438
closes #572