### PR TITLE
fix(datepicker): time input bug

### DIFF
--- a/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
@@ -112,6 +112,9 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
         this._value = value;
         this._formatValue(value);
 
+        if ( value ) {
+            this._timeDate = value;
+        }
         if (!this._dateAdapter.sameDate(oldDate, value)) {
             this._valueChange.emit(value);
         }
@@ -191,6 +194,9 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
     private _datepickerSubscription = Subscription.EMPTY;
 
     private _localeSubscription = Subscription.EMPTY;
+
+    // Stores a placeholder date value to be used for parsing when in time-only mode
+    private _timeDate: Date = new Date();
 
     /** The form control validator for whether the input parses. */
     private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
@@ -320,7 +326,14 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
     }
 
     _onInput(value: string) {
+        // Add stored date value to a time-only input for javascript date object parsing
+        let pickerMode = this._datepicker ? this._datepicker.mode : this._mode;
+        if ( pickerMode === 'time' ) {
+            value = this._timeDate.getDate()  + '/' + (this._timeDate.getMonth() + 1) + '/' + this._timeDate.getFullYear() + ' ' + value;
+        }
+
         let date = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
+
         /** Two-digit year input conversion method for IE
          * Based on the current year, assume that the four-digit year date should be in
          * either the next 30 years, or the preceding 70 years */


### PR DESCRIPTION
Fixes bug on time-only input parsing. Great catch by Brent, I'm surprised this didn't crop up sooner.

The issue is that the Javascript Date object won't parse a time-only string.  It will parse a date without a time, but not the other way around.  So we have to have a placeholder date to include on time-only strings.  But it can't just be a random date because that could interfere with date comparisons on the date-range component.

So I added a placeholder value that takes the value of whatever the picker is set to, or the current date if none is set.

closes #1456