### PR TITLE
docs(readme): updated readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/HealthCatalyst/Fabric.Cashmere/badge.svg?branch=master)](https://coveralls.io/github/HealthCatalyst/Fabric.Cashmere?branch=master)
 ![Cashmere Banner](https://raw.githubusercontent.com/HealthCatalyst/Fabric.Cashmere/master/CashmereBanner.png)
 
-An Angular component library that makes any task feel luxurious.
+Cashmere is Health Catalyst’s comprehensive design system. The Cashmere Angular UI library includes components and styles for Health Catalyst branded web applications.
 
 ## Quick Links
 
@@ -12,19 +12,16 @@ An Angular component library that makes any task feel luxurious.
 -   [Content](http://cashmere.healthcatalyst.net/content)
 -   [Getting Started](http://cashmere.healthcatalyst.net/web/guides/getting-started)
 -   [Guidelines for Contribution](http://cashmere.healthcatalyst.net/web/guides/contribution-guide)
--   [Packaging Library](http://cashmere.healthcatalyst.net/web/guides/packaging-library)
 -   [Submit an Issue](http://cashmere.healthcatalyst.net/web/guides/submit-an-issue)
 -   [Supported Browsers](http://cashmere.healthcatalyst.net/web/guides/supported-browsers)
 
 ## Installing to an Existing Project
 
--   Run `npm i --save @healthcatalyst/cashmere`
+-   Refer to the instructions in our [Getting Started](http://cashmere.healthcatalyst.net/web/guides/getting-started) guide.
 
 ## Running the Demo Application
 
--   Clone the repository `git clone https://github.com/HealthCatalyst/Fabric.Cashmere.git`
--   Run `cd Fabric.Cashmere && npm install && npm start`
--   View the demo application at `http://localhost:4200`
+-   To run the Cashmere demo site locally, refer to the instructions in our [Guidelines for Contribution](http://cashmere.healthcatalyst.net/web/guides/contribution-guide) guide to setup your environment.
 
 ## Sponsors
 

--- a/projects/cashmere/README.md
+++ b/projects/cashmere/README.md
@@ -2,7 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/HealthCatalyst/Fabric.Cashmere/badge.svg?branch=master)](https://coveralls.io/github/HealthCatalyst/Fabric.Cashmere?branch=master)
 ![Cashmere Banner](https://raw.githubusercontent.com/HealthCatalyst/Fabric.Cashmere/master/CashmereBanner.png)
 
-An Angular component library that makes any task feel luxurious.
+Cashmere is Health Catalyst’s comprehensive design system. The Cashmere Angular UI library includes components and styles for Health Catalyst branded web applications.
 
 ## Quick Links
 


### PR DESCRIPTION
@corykon - seemed like our best bet here is to link to the documentation on the site so we aren't duplicating content.  Let me know if you'd suggest any other changes.

closes #1493