### PR TITLE
fix(chip): remove flex on chip content

### DIFF
--- a/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.component.html
+++ b/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.component.html
@@ -7,7 +7,11 @@
 <hc-chip color="green">Success Chip</hc-chip>
 <hc-chip color="blue">Info Chip</hc-chip>
 <hc-chip color="yellow">
-    <hc-icon class="example-chip-icon" fontSet="fa" fontIcon="fa-exclamation-triangle" hcIconSm></hc-icon>
-    This is an example of a chip that line wraps. If you have an icon included you can set its margin and
-    vertical alignment relative to the other chip content.
+    <div class="example-chip-banner">
+        <hc-icon class="example-chip-icon" fontSet="fa" fontIcon="fa-exclamation-triangle" hcIconSm></hc-icon>
+        <div>
+            This is an example of a chip that line wraps. If you have an icon included you can set its margin and
+            vertical alignment relative to the other chip content.
+        </div>
+    </div>
 </hc-chip>

--- a/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.component.scss
+++ b/projects/cashmere-examples/src/lib/chip-basic/chip-basic-example.component.scss
@@ -1,3 +1,7 @@
-.example-chip-icon {
-    margin-right: 10px;
+.example-chip-banner {
+    display: flex;
+
+    hc-icon {
+        margin-right: 10px;
+    }
 }

--- a/projects/cashmere-examples/src/lib/icon-overview/icon-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/icon-overview/icon-overview-example.component.html
@@ -1,3 +1,13 @@
+<hc-chip color="blue">
+    <div class="example-chip-banner">
+        <hc-icon fontSet="fa" fontIcon="fa-exclamation-triangle" hcIconSm></hc-icon>
+        <div>
+            <strong>Note:</strong> this is the Cashmere Angular library's icon component.
+            <a href="/foundations/icons">Click here</a> for information about Health Catalyst's icon font.
+        </div>
+    </div>
+</hc-chip>
+
 <table class="icon-table">
     <tr class="icon-row">
         <td class="icon-column">

--- a/projects/cashmere-examples/src/lib/icon-overview/icon-overview-example.component.scss
+++ b/projects/cashmere-examples/src/lib/icon-overview/icon-overview-example.component.scss
@@ -1,4 +1,4 @@
-* {
+table * {
     vertical-align: middle;
 }
 
@@ -9,4 +9,12 @@ tr {
 .icon-column {
     width: 60px;
     text-align: center;
+}
+
+.example-chip-banner {
+    display: flex;
+
+    hc-icon {
+        margin-right: 8px;
+    }
 }

--- a/projects/cashmere/src/lib/sass/chip.scss
+++ b/projects/cashmere/src/lib/sass/chip.scss
@@ -21,7 +21,6 @@
 }
 
 @mixin hc-chip-content-color() {
-    display: flex;
     padding-top: 7px;
     padding-bottom: 7px;
 }


### PR DESCRIPTION
Having flex on the chip content is annoying because if you put any tags in the chip beyond just text, it will try and try and flex divide them within the space (which is very problematic on line wrap). I don't believe we need it, and I'd rather leave it to developers to add flex if they feel like they need it.  I've updated one example accordingly.

Also added a banner to the icon component to let folks know that its the component and the icon font is somewhere else.