### PR TITLE
docs(content): add edit buttons to usage items

### DIFF
--- a/src/app/content/usage/usage-list/usage-list.component.html
+++ b/src/app/content/usage/usage-list/usage-list.component.html
@@ -90,7 +90,7 @@
                             <hc-error *ngIf="showErrors">Please enter your email.</hc-error>
                         </hc-form-field>
                     </div>
-                    <button hc-button title="Submit Form" class="usage-submit-btn" type="submit" [title]="editListForm.valid ? 'Submit your entry' : 'Disabled until the form data is valid'" [disabled]="!editListForm.valid" (click)="onSubmit()">Submit</button>
+                    <button hc-button title="Submit Form" class="usage-submit-btn" type="submit" (click)="onSubmit()">Submit</button>
                     <button hc-button title="Reset Form" buttonStyle="secondary" (click)="onCancel()">Reset Form</button>
                 </form>
             </div>

--- a/src/app/content/usage/usage-list/usage-list.component.html
+++ b/src/app/content/usage/usage-list/usage-list.component.html
@@ -90,8 +90,8 @@
                             <hc-error *ngIf="showErrors">Please enter your email.</hc-error>
                         </hc-form-field>
                     </div>
-                    <button hc-button title="Submit Form" style="margin-right:30px;" buttonStyle="primary" type="submit" [title]="editListForm.valid ? 'Submit your entry' : 'Disabled until the form data is valid'" (click)="onSubmit()">Submit</button>
-                    <button hc-button title="Reset Form" buttonStyle="secondary" formControlName="resetButton" type="" (click)="onCancel()">Reset Form</button>
+                    <button hc-button title="Submit Form" class="usage-submit-btn" type="submit" [title]="editListForm.valid ? 'Submit your entry' : 'Disabled until the form data is valid'" [disabled]="!editListForm.valid" (click)="onSubmit()">Submit</button>
+                    <button hc-button title="Reset Form" buttonStyle="secondary" (click)="onCancel()">Reset Form</button>
                 </form>
             </div>
 

--- a/src/app/content/usage/usage-list/usage-list.component.html
+++ b/src/app/content/usage/usage-list/usage-list.component.html
@@ -1,6 +1,6 @@
 <div class="tab-demo">
-    <hc-tab-set direction="horizontal">
-        <hc-tab tabTitle="Term List">
+    <hc-tab-set direction="horizontal" #tabSetElement>
+        <hc-tab tabTitle="Term List" tabindex="2">
             <div>
                 <div class="usage-table-filters">
                     <hc-form-field class="usage-table-filters-input" inline>
@@ -32,8 +32,8 @@
                     <!-- Edit Buttons -->
                     <ng-container hcColumnDef="edit">
                         <th hc-header-cell *hcHeaderCellDef style="border-left-style: none;"></th>
-                        <td hc-cell *hcCellDef style="border-left-style: none;">
-                            <button *ngIf=false hc-icon-button><hc-icon fontSet="hc-icons" fontIcon="hci-scratch-pad" hcIconMd disabled = true></hc-icon></button>
+                        <td hc-cell *hcCellDef="let usageItem" style="border-left-style: none;">
+                            <button *ngIf=true hc-icon-button (click)="getFormFillData(usageItem)"><hc-icon fontSet="hc-icons" fontIcon="hci-scratch-pad" hcIconMd disabled = true></hc-icon></button>
                         </td>
                     </ng-container>
 
@@ -53,7 +53,7 @@
         </hc-tab>
 
         <!-- New Tab -->
-        <hc-tab>
+        <hc-tab #formTab tabindex="1">
             <hc-tab-title>
                 <span style="color: #00aeff; font-weight: 600">
                     <i class="fa fa-plus"></i>
@@ -63,37 +63,42 @@
 
             <!-- Form to add or change term -->
             <div>
-                <form [formGroup]="editListForm" style="padding-top:50px">
+                <form [formGroup]="editListForm" #formDirective="ngForm" style="padding-top:50px">
                     <div class="form-container">
                         <hc-form-field>
                             <hc-label for="addTermId">Term to Add/Change</hc-label>
                             <input hcInput id="addTermId" placeholder="What term would you like to add/change? (required)" name="addTermId" formControlName="addTerm" />
-                            <hc-error>Please enter a term to add or change.</hc-error>
+                            <hc-error *ngIf="showErrors">Please enter a term to add or change.</hc-error>
                         </hc-form-field>
                         <hc-form-field>
                             <hc-label>Definition/Usage Rule</hc-label>
                             <textarea hcInput id="addDefId" rows="4" cols="50" placeholder="What is the definition/usage rule for this term? (required)" name="addDefId" formControlName="addDef"></textarea>
-                            <hc-error>Please enter a definition or usage rule.</hc-error>
+                            <hc-error *ngIf="showErrors">Please enter a definition or usage rule.</hc-error>
+                        </hc-form-field>
+                        <hc-form-field>
+                            <hc-label>Comment (optional)</hc-label>
+                            <textarea hcInput id="CommentId" rows="4" cols="50" placeholder="Why are you suggesting this change? (optional)" name="addCommentId" formControlName="comment"></textarea>
                         </hc-form-field>
                         <hc-form-field>
                             <hc-label>Contributor Name</hc-label>
                             <input hcInput id="yourNameId" placeholder="What is your name? (required)" name="yourName" formControlName="yourName" />
-                            <hc-error>Please enter your name.</hc-error>
+                            <hc-error *ngIf="showErrors">Please enter your name.</hc-error>
                         </hc-form-field>
                         <hc-form-field>
                             <hc-label>Contributor Email</hc-label>
                             <input hcInput id="yourEmailId" placeholder="At what email can we reach you? (required)" name="yourEmail" formControlName="yourEmail" />
-                            <hc-error>Please enter your email.</hc-error>
+                            <hc-error *ngIf="showErrors">Please enter your email.</hc-error>
                         </hc-form-field>
                     </div>
-                    <button hc-button title="Submit Form" class="usage-submit-btn" type="submit" [title]="editListForm.valid ? 'Submit your entry' : 'Disabled until the form data is valid'" [disabled]="!editListForm.valid" (click)="onSubmit()">Submit</button>
-                    <button hc-button title="Reset Form" buttonStyle="secondary" (click)="onCancel()">Reset Form</button>
+                    <button hc-button title="Submit Form" style="margin-right:30px;" buttonStyle="primary" type="submit" [title]="editListForm.valid ? 'Submit your entry' : 'Disabled until the form data is valid'" (click)="onSubmit()">Submit</button>
+                    <button hc-button title="Reset Form" buttonStyle="secondary" formControlName="resetButton" type="" (click)="onCancel()">Reset Form</button>
                 </form>
             </div>
 
             <!-- <br>Dirty: {{ editListForm.dirty }}
             <br>Touched: {{ editListForm.touched }}
             <br>Valid: {{ editListForm.valid }}
+            <br>Submitted: {{ formSubmitted }}
             <br>Value: {{ editListForm.value | json }} -->
 
         </hc-tab>

--- a/src/app/content/usage/usage-list/usage-list.component.ts
+++ b/src/app/content/usage/usage-list/usage-list.component.ts
@@ -1,14 +1,12 @@
 import {Component, OnInit, ViewChild, AfterViewInit} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
-import {FormControl, FormGroup, FormBuilder, Validators, FormGroupDirective, ControlContainer} from '@angular/forms';
+import {FormControl, FormGroup, FormBuilder, Validators, FormGroupDirective} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {GoogleSheetsDbService} from 'ng-google-sheets-db';
-import {PaginationComponent, HcTableDataSource, TabChangeEvent, TabComponent, TabSetComponent} from '@healthcatalyst/cashmere';
+import {PaginationComponent, HcTableDataSource, TabComponent, TabSetComponent} from '@healthcatalyst/cashmere';
 import {SectionService} from 'src/app/shared/section.service';
 import {BaseDemoComponent} from '../../../shared/base-demo.component';
 import {IUsage, usageAttributesMapping} from '../usage';
-// import { TabSetComponent } from 'dist/cashmere/public_api';
-
 
 @Component({
     selector: 'hc-usage-list',
@@ -23,7 +21,7 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
     searchControl = new FormControl();
     termList$: Observable<IUsage[]>;
     terms: IUsage[];
- 
+
     editListForm: FormGroup;
     formSubmitted = false;
     scriptURL = 'https://script.google.com/macros/s/AKfycbwWZCf0aBg1e5BFD9G-hVTb-zbSTXT1KGFSwoyRLwMhu7FZF2g/exec';
@@ -32,7 +30,7 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
     @ViewChild('tabSetElement') tabSetRef: TabSetComponent;
     @ViewChild('formTab') formTabRef: TabComponent;
     @ViewChild('formDirective') formDirective: FormGroupDirective;
-   
+
     displayedColumns: string[] = ['term', 'usage', 'edit'];
     dataSource: HcTableDataSource<IUsage>;
     pageNumber = 1;
@@ -54,11 +52,9 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
     @ViewChild(PaginationComponent)
     paginator: PaginationComponent;
 
-    
-
     applyFilter() {
         const filterStr = this.searchControl.value;
-        if ( filterStr ) {
+        if (filterStr) {
             this.dataSource.filter = filterStr.trim().toLowerCase();
         } else {
             this.dataSource.filter = ' ';
@@ -66,15 +62,14 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
     }
 
     ngOnInit(): void {
-
         this.termList$ = this.googleSheetsDbService.get<IUsage>('18lD03x12tYE_DTqiXPX9oqR3sqRdMXEE_jhIGvTF_xk', 1, usageAttributesMapping);
         this.termList$.subscribe(data => {
             this.usageList = data;
-            this.filteredUsageList = this.usageList.sort((a, b) => (a.TermName > b.TermName) ? 1 : -1);
+            this.filteredUsageList = this.usageList.sort((a, b) => (a.TermName > b.TermName ? 1 : -1));
             this.dataSource = new HcTableDataSource(this.filteredUsageList);
-            this.dataSource.filterPredicate = (data: IUsage, filter: string) => this.usageFilter(data, filter);
+            this.dataSource.filterPredicate = (filterData: IUsage, filter: string) => this.usageFilter(filterData, filter);
             this.dataSource.paginator = this.paginator;
-        })
+        });
 
         this.editListForm = this.fb.group({
             addTerm: ['', Validators.required],
@@ -82,17 +77,8 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
             comment: '',
             yourEmail: ['', [Validators.required, Validators.email]],
             yourName: ['', [Validators.required, Validators.minLength(3)]],
-            addNew: 'true',
+            addNew: 'true'
         });
-    }
-    ngAfterViewInit(): void {
-        // this.dataSource.paginator = this.paginator;
-        // this.tabSetRef.defaultTab = 1;
-        this.tabSetRef.selectTab(0);
-        this.tabSetRef.selectTab(this.formTabRef);
-        this.formTabRef.tabClick;
-        console.log("tabSetRef " + this.tabSetRef._tabs.length);
-
     }
 
     usageFilter(data: IUsage, filter: string) {
@@ -109,18 +95,14 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
         this.formDirective.resetForm();
         this.formSubmitted = false;
         this.showErrors = false;
-        // Object.keys(this.editListForm.controls).forEach(key => {this.editListForm.get(key)?.setErrors(null);
-        // });
-        
     }
 
     onSubmit() {
-        
         if (this.editListForm.invalid) {
             this.showErrors = true;
             return;
         }
-        
+
         this.formSubmitted = true;
         const formData = new FormData();
         formData.append('addTerm', this.editListForm.controls.addTerm.value);
@@ -130,9 +112,6 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
         formData.append('comment', this.editListForm.controls.comment.value);
         formData.append('addNew', this.editListForm.controls.addNew.value);
 
-        const formObject = this.editListForm.getRawValue();
-        const serializedForm = JSON.stringify(formObject);
-
         this.httpClient.post<any>(this.scriptURL, formData).subscribe(
             res => console.log(res),
             err => console.log(err)
@@ -140,9 +119,6 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
 
         this.editListForm.reset();
         this.formDirective.resetForm();
-        // Object.keys(this.editListForm.controls).forEach(key => {this.editListForm.get(key)?.setErrors(null);
-        // });
-       
     }
 
     getFormFillData(termItem: IUsage): void {
@@ -152,6 +128,5 @@ export class UsageListComponent extends BaseDemoComponent implements OnInit, Aft
             addDef: termItem.TermUsage,
             addNew: 'false'
         });
-        // alert(termItem.TermID + " " + termItem.TermName);
     }
 }

--- a/src/app/content/usage/usage.component.html
+++ b/src/app/content/usage/usage.component.html
@@ -1,6 +1,6 @@
 <div class="demo-content">
     <h1>Health Catalyst Documentation Style and Usage</h1>
-    <h6>Last updated January 12, 2021</h6>
+    <h6>Last updated: Data for this page is updated at least weekly.</h6>
 
     <hc-tile>
         <h5 id="overview">Overview</h5>


### PR DESCRIPTION
Here's another go at my last PR. Hopefully this one will work better! 

I added edit buttons to each row in the abbreviations list. Clicking the button takes you to the add/change form and autopopulates some of the data for the form. 

I also changed the form validation a bit so that it now validates when you hit submit rather than having a disabled submit button and ever-present validation errors. 