### PR TITLE
feat(date-range): the dev can now center the date-range component

### DIFF
--- a/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
@@ -12,5 +12,5 @@
         <span class="label">Time range:</span> <span class="value"> {{ range.fromDate | date:'h:mm a' }} - {{ range.toDate | date:'h:mm a' }} </span>
         <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="icon-right" hcIconSm></hc-icon>
     </button>
-    <p><em>Setting the center option to 'true' will center the Date Range Time component to the screen, instead of the target.</em></p>
+    <p>In this example, the center value is set to <code>true</code> in <code>DateRangeOptions</code>, which centers the component to the screen, instead of anchoring to the target.</p>
 </div>

--- a/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
@@ -4,7 +4,6 @@
         hcDateRange
         title="Time Range"
         buttonStyle="link"
-        popperPlacement="bottom"
         (selectedDateRangeChanged)="updateRange($event)"
         [selectedDate]="range"
         [options]="options"
@@ -13,4 +12,5 @@
         <span class="label">Time range:</span> <span class="value"> {{ range.fromDate | date:'h:mm a' }} - {{ range.toDate | date:'h:mm a' }} </span>
         <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="icon-right" hcIconSm></hc-icon>
     </button>
+    <p><em>Setting the center option to 'true' will center the Date Range Time component to the screen, instead of the target.</em></p>
 </div>

--- a/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.ts
+++ b/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.ts
@@ -16,7 +16,8 @@ export class DateRangeTimeExampleComponent implements OnInit {
             startDatePrefix: "Start Time",
             endDatePrefix: "End Time",
             invalidDateLabel: 'Start time must precede end time',
-            applyLabel: 'Apply'
+            applyLabel: 'Apply',
+            center: true
         };
     }
 

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
@@ -4,7 +4,6 @@
         hcDateRange
         title="Date Range"
         buttonStyle="link"
-        popperPlacement="bottom"
         (selectedDateRangeChanged)="updateRange($event)"
         (selectedPresetChanged)="updatePreset($event)"
         [selectedDate]="selected"

--- a/projects/cashmere/src/lib/date-range/date-range/date-range.directive.ts
+++ b/projects/cashmere/src/lib/date-range/date-range/date-range.directive.ts
@@ -67,6 +67,6 @@ export class DateRangeDirective implements OnInit, OnDestroy, OnChanges {
 
     @HostListener('click')
     _onClick() {
-        this._overlayRef = this.calendarOverlayService.open(this._elementRef);
+        this._overlayRef = this.calendarOverlayService.open(this._elementRef, this.options.center!);
     }
 }

--- a/projects/cashmere/src/lib/date-range/model/model.ts
+++ b/projects/cashmere/src/lib/date-range/model/model.ts
@@ -42,4 +42,6 @@ export interface DateRangeOptions {
     endDatePrefix?: string;
     /** Text label of invalid date. Default 'Please enter valid date' */
     invalidDateLabel?: string;
+    /** Centers the DateRange component to the screen instead of the target. Default 'false' */
+    center?: boolean;
 }

--- a/projects/cashmere/src/lib/date-range/services/calendar-overlay.service.ts
+++ b/projects/cashmere/src/lib/date-range/services/calendar-overlay.service.ts
@@ -9,9 +9,9 @@ export class CalendarOverlayService {
 
     constructor(private overlay: Overlay, private injector: Injector) {}
 
-    open(hostElemRef: ElementRef): OverlayRef {
+    open(hostElemRef: ElementRef, center: boolean): OverlayRef {
         this.hostElemRef = hostElemRef;
-        const overlayRef = this._createOverlay();
+        const overlayRef = this._createOverlay(center);
         const portalInjector = this._createInjector(overlayRef);
         const calendarPortal = new ComponentPortal(PickerOverlayComponent, null, portalInjector);
         overlayRef.attach(calendarPortal);
@@ -21,13 +21,22 @@ export class CalendarOverlayService {
         return overlayRef;
     }
 
-    private _createOverlay(): OverlayRef {
-        const overlayConfig = this._getOverlayConfig();
+    private _createOverlay(center): OverlayRef {
+        const overlayConfig = this._getOverlayConfig(center);
         return this.overlay.create(overlayConfig);
     }
 
-    private _getOverlayConfig(): OverlayConfig {
-        const positionStrategy = this.overlay
+    private _getOverlayConfig(center): OverlayConfig {
+        let positionStrategy;
+
+        if (center) {
+            positionStrategy = this.overlay
+            .position()
+            .global()
+            .centerHorizontally()
+            .centerVertically();
+        } else {
+            positionStrategy = this.overlay
             .position()
             .flexibleConnectedTo(this.hostElemRef)
             .withFlexibleDimensions(false)
@@ -60,6 +69,7 @@ export class CalendarOverlayService {
                     overlayY: 'bottom'
                 }
             ]);
+        }
 
         const overlayConfig = new OverlayConfig({
             hasBackdrop: true,

--- a/projects/cashmere/src/lib/date-range/services/config-store.service.ts
+++ b/projects/cashmere/src/lib/date-range/services/config-store.service.ts
@@ -17,7 +17,8 @@ export class ConfigStoreService {
         cancelLabel: 'Cancel',
         startDatePrefix: 'Start date:',
         endDatePrefix: 'End date:',
-        invalidDateLabel: 'Please enter valid date'
+        invalidDateLabel: 'Please enter valid date',
+        center: false
     };
 
     private dateRangeOptionsSubject: BehaviorSubject<DateRangeOptions> = new BehaviorSubject<DateRangeOptions>(this.defaultOptions);


### PR DESCRIPTION
date-range component can either be attached to the button or centered on the screen now. the unused
popperplacement param has been removed as well.

closes #1570