### PR TITLE
docs(markdown): article tag wrapper for lists

### DIFF
--- a/guides/analytics/powerbi/about.md
+++ b/guides/analytics/powerbi/about.md
@@ -44,10 +44,8 @@ The Sidebar vertical text box is used on the About page for app details and shou
 The first two items in the sidebar should be the name of the accelerator and the current version number.
 You should be able to simply edit the text in the template.
 
-The remaining items in the sidebar are unique to your application. Card visuals are used to display items that rely upon data fields (such as a last refresh date). 
+The remaining items in the sidebar are unique to your application. Card visuals are used to display items that rely upon data fields (such as a last refresh date).
 Examples are included in the template, but they may be edited or removed as needed.
-
-<article>
 
 Info item formatting:
 - **Font (label)**: Segoe (Bold)
@@ -55,8 +53,6 @@ Info item formatting:
 
 - **Font (value)**: Segoe UI
 - **Font size (value)**: 10pt
-
-</article>
 
 Each info item in the sidebar is separated by `25px` of blank space.
 
@@ -68,9 +64,7 @@ Each info item in the sidebar is separated by `25px` of blank space.
 
 The Content Area has a **white** `#ffffff` background for the About Page.
 
-<article>
-
-The first item in the Content Area is the full Health Catalyst horizontal logo: 
+The first item in the Content Area is the full Health Catalyst horizontal logo:
 - **Type**: Image
 - **Position**: `x:514, y:87`
 - **Width**: 463px
@@ -83,8 +77,6 @@ The second item in the content area is a banner with the name of the accelerator
 - **Width**: 600px
 - **Height**: 30px
 
-</article>
-
 ### Tabs
 
 The next item in the content area is a horizontal slicer object.
@@ -93,19 +85,15 @@ The first tab should almost always be "About this App", where an overview of the
 
 For the remaining tabs, you may choose what is most appropriate for your application.
 
-<article>
-
-The text within each tab should be set to: 
+The text within each tab should be set to:
 - **Font**: Segoe UI
 - **Font color**: offblack `#333333`
 - **Font size**: 10pt
 
-Headers within the text should be set to 
+Headers within the text should be set to
 - **Font**: Segoe (Bold)
 - **Font color**: dark-blue `#006d9a`
 - **Font size**: 12pt
-
-</article>
 
 ### Pagination
 
@@ -118,8 +106,6 @@ The pagination controller is comprised of Page Buttons horizontally aligned with
 ![Pagination Controller](./assets/analytics/tableau/pagination.png "Pagination Controller")
 
 </div>
-
-<article>
 
 Each button should have a border with the following values:
 - **Weight**: 1px
@@ -139,7 +125,5 @@ The selected page's button is formatted as:
 De-selected page buttons are formatted as:
 - **Background**: white `#ffffff`
 - **Font color**: dark-blue `#006d9a`
- 
-</article>
 
 :::

--- a/guides/analytics/powerbi/charts.md
+++ b/guides/analytics/powerbi/charts.md
@@ -31,8 +31,6 @@ The exact size of a tile for a chart will be determined by the other content tha
 
 ##### Grid Styles
 
-<article>
-
 Axis lines in charts are set to the following values:
 - **Weight**: 1px
 - **Color**: offblack `#333333`
@@ -43,8 +41,6 @@ Gride lines are set to the following values:
 - **Weight**: 1px
 - **Style**: Dotted
 - **Color**: gray-300 `#cccccc`
-
-</article>
 
 ![Grid Lines](./assets/analytics/powerbi/pbi-grid-lines.png "Grid Lines")
 
@@ -62,7 +58,7 @@ To determine what colors should be used together in charts, you should determine
 
 </div>
 
-Charts that are dense, complex, and/or require specialized knowledge or experience to comprehend are well-suited for review by both Health Catalyst's data science team and design teams to ensure that visual elements such as color saturation, line thickness, shapes, label placements, etc., are crafted to best support the data story. 
+Charts that are dense, complex, and/or require specialized knowledge or experience to comprehend are well-suited for review by both Health Catalyst's data science team and design teams to ensure that visual elements such as color saturation, line thickness, shapes, label placements, etc., are crafted to best support the data story.
 
 :::
 
@@ -73,15 +69,11 @@ Charts that are dense, complex, and/or require specialized knowledge or experien
 The specific content of tooltips of the chart will be dictated by the data being displayed.
 But in general, they should contain a label and a value.
 
-<article>
-
 All text in the tooltip should be formatted accordingly:
 - **Font**: Segoe UI
 - **Font color**: white `#ffffff`
 - **Font size**: 10pt
 - **Background**: charcoal-blue `#384655`
-
-</article>
 
 <div style="text-align:center"><br>
 
@@ -94,13 +86,11 @@ All text in the tooltip should be formatted accordingly:
 
 ##### Visual Header Tooltips
 
-Charts should include tooltips that enable and enhance self-service analytics and data exploration. 
+Charts should include tooltips that enable and enhance self-service analytics and data exploration.
 
 ### Info Tooltip
 
-Every chart should include an info tooltip in its header. 
-
-<article>
+Every chart should include an info tooltip in its header.
 
 All text in the tooltip should be formatted as follows:
 - **Font**: Segoe UI
@@ -108,8 +98,6 @@ All text in the tooltip should be formatted as follows:
 - **Font size**: 10pt
 - **Background**: charcoal-blue `#384655`
 - **Icon color**: slate-gray-400 `#708090`
-
-</article>
 
 Refer to the [Foundations section](/analytics/powerbi-foundations) for information on how to configure it.
 The info tooltip should provide a longer description of what is being visualized on the chart, how it should read, and any considerations when evaluating it.
@@ -122,7 +110,7 @@ If additional controls are included above the chart, the info tooltip can also p
 
 ### Drill/Expand Tooltips
 
-Every chart should include at least one header hover that encourages users to explore the data within the visualization. Some hovers allow for data drilling (e.g., clicking into a single month) while others enable data expansion (e.g., viewing 12 months of data for a given year). Use your best judgement to carefully choose the most effective header icons for a chart, while weighing the potentially overwhelming effect that providing too many options brings. 
+Every chart should include at least one header hover that encourages users to explore the data within the visualization. Some hovers allow for data drilling (e.g., clicking into a single month) while others enable data expansion (e.g., viewing 12 months of data for a given year). Use your best judgement to carefully choose the most effective header icons for a chart, while weighing the potentially overwhelming effect that providing too many options brings.
 
 <div style="text-align:center"><br>
 

--- a/guides/analytics/powerbi/filters.md
+++ b/guides/analytics/powerbi/filters.md
@@ -37,11 +37,9 @@ The sliding filter pane should always be accessible to users, so that all filter
 
 ##### Color
 
-Power BI allows developers to format the Filters pane and cards. The same colors from [Cashmere Foundations](/foundations/color) are used. 
+Power BI allows developers to format the Filters pane and cards. The same colors from [Cashmere Foundations](/foundations/color) are used.
 
 ### Filter Pane
-
-<article>
 
 The Filters pane is set to the following values:
 - **Width**: 250px
@@ -53,8 +51,6 @@ The Filters pane is set to the following values:
 - **Border**: slate-gray-300 `#c0c5cc`
 - **Input box background**: charcoal-blue `#384655`
 
-</article>
-
 <div style="text-align:center">
 
 ![Filter Pane](./assets/analytics/powerbi/pbi-filter-pane.png "Filter Pane")
@@ -63,20 +59,14 @@ The Filters pane is set to the following values:
 
 ### Filter Cards: Available
 
-<article>
-
 Filter cards that are available to users are formatted as follows:
-- **Background**: charcoal-blue `#384655` 
+- **Background**: charcoal-blue `#384655`
 - **Input box background**: white `#ffffff`
 - **Border**: slate-gray-300 `#c0c5cc`
 - **Font**: Segoe UI, 9pt
 - **Font color**: white `#ffffff`
 
-</article>
-
 ### Filter Cards: Applied
-
-<article>
 
 Filters actively being used within the dashboard, page, or an object, are formatted in filter cards as follows:
 - **Background**: gray-200 `#e0e0e0`
@@ -84,8 +74,6 @@ Filters actively being used within the dashboard, page, or an object, are format
 - **Border**: slate-gray-300 `#c0c5cc`
 - **Font**: Segoe UI, 9pt
 - **Font color**: offblack `#333333`
-
-</article>
 
 ##### Filter Scope
 
@@ -96,17 +84,13 @@ These are grouped together in a section titled **Filters on all pages**.
 Other filters may only apply to the specific page the user is viewing, and will not carry over to other pages.
 These are grouped together in a section titled **Filters on this page**.
 
-<article>
-
 The section titles are formatted as:
 - **Font**: Segoe (Bold)
 - **Font size**: 10pt
 - **Font color**: white `#ffffff`
-- **Background**: charcoal-blue `#384655` 
+- **Background**: charcoal-blue `#384655`
 
-</article>
-
-Some filters may only apply to the specific visual the user is viewing. These are grouped in a section within the filters pane titled **Filters on this visual**. You may also consider placing a slicer object next to the visual. 
+Some filters may only apply to the specific visual the user is viewing. These are grouped in a section within the filters pane titled **Filters on this visual**. You may also consider placing a slicer object next to the visual.
 
 :::
 

--- a/guides/analytics/powerbi/foundations.md
+++ b/guides/analytics/powerbi/foundations.md
@@ -99,8 +99,6 @@ Detailed information on the navbar and how to configure it is included in the [n
 
 The subnav is used as an information panel to display dashboard-wide metrics, such as refresh timestamps or "stickied" metrics, such as population counts.
 
-<article>
-
 Format the subnav with the following parameters:
 - **Type**: Text object
 - **Height**: 30px
@@ -108,8 +106,6 @@ Format the subnav with the following parameters:
 - **Position**: `x:0, y:50`
 - **Background**: slate-gray-400 `#708090`
 - **Visual header toggle**: Off
- 
- </article>
 
 <div style="text-align:center"><br>
 
@@ -119,13 +115,9 @@ Format the subnav with the following parameters:
 
 ### Content Area
 
-<article>
-
 Options for a background color for the content area are:
 - **Background option**: slate-gray-100 `#f0f3f6`
 - **Background option**: white `#ffffff`
-
-</article>
 
 Objects in the content area should be placed about 30px from the outer edges.
 
@@ -140,8 +132,6 @@ Information about the dynamic filters pane is included in the [filters section](
 ##### Tiles
 
 Visualization objects such as charts, graphs, tables, and KPIs should be styled like the Cashmere [tile component](/web/components/tile) and will be referred to as tiles within this section.
-
-<article>
 
 In general, a Power BI tile is formatted accordingly:
 
@@ -160,8 +150,6 @@ Each tile should also have shadow with the following values:
 - **Angle**: 90º
 - **Distance**: 1px
 - **Transparency**: 85%
-
-</article>
 
 Layout specifics for the most common visual objects can be found in the [KPI Metrics section](/analytics/powerbi-metrics), [Charts section](/analytics/powerbi-charts), and [Tables section](/analytics/powerbi-tables). Refer to the template or these sections for working examples.
 
@@ -198,15 +186,11 @@ Utilize Power BI's alignment capabilities by selecting each object and choosing 
 
 ### Tile Title
 
-<article>
-
 Every tile should include title with the following formatting:
 - **Alignment**: left-aligned
 - **Font**: Segoe UI
 - **Font color**: offblack `#333333`
 - **Font size**: 10pt
-
-</article>
 
 ### Tile Visual Header
 
@@ -217,15 +201,11 @@ Some header elements, such as drill-down icons, are object-specific and more det
 
 ### Divider
 
-<article>
-
 A horizontal line divides the header from the content of the visual object. Leave about 2px of space on the left and right and format accordingly:
 - **Weight**: 1pt
 - **Height**: 12px
 - **Color**: slate-gray-300 `#c0c5cc`
 - **Visual header toggle**: Off
-
-</article>
 
 <div style="text-align:center"><br>
 

--- a/guides/analytics/powerbi/kpi-metrics.md
+++ b/guides/analytics/powerbi/kpi-metrics.md
@@ -26,8 +26,6 @@ It's important for us to take advantage of this convention as a way to guide use
 KPI Metrics follow all the general standards for tiles as defined in the [Foundations section](/analytics/powerbi-foundations).
 Refer to that **Tile Header** and **Divider** sections of that page for specific parameters to apply to the top of the KPI.
 
-<article>
-
 The main KPI value is formatted as:
 - **Font**: Segoe UI Light
 - **Font size**: 24px
@@ -39,8 +37,6 @@ The second line formatting values are:
 - **Font**: Segoe UI
 - **Font size**: 10px
 - **Font color**: offblack `#333333`
-
-</article>
 
 Arrows or text indicating positive trends should be set to **green** `#00a859`.
 For negative trends, use **red** `#f13c45`.

--- a/guides/analytics/powerbi/navbar.md
+++ b/guides/analytics/powerbi/navbar.md
@@ -12,8 +12,6 @@ The navbar is one of the most distinguishing elements of a Cashmere application.
 It is a hallmark of the Health Catalyst app brand on all platforms.
 For this reason, the styling of the navbar should not be altered from the template.
 
-<article>
-
 The Navbar is a horizontal text object with the following formatting:
 - **Type**: Text object
 - **Background**: charcoal-blue `#384655`
@@ -21,15 +19,11 @@ The Navbar is a horizontal text object with the following formatting:
 - **Position**: `x:0, y:0`
 - **Visual header toggle**: Off
 
-</article>
-
 :::
 
 :::
 
 ##### Brand
-
-<article>
 
 Brand is an image of the [Health Catalyst tri-flame](/foundations/logo) and formatted as follows:
 - **Type**: Image object
@@ -38,8 +32,6 @@ Brand is an image of the [Health Catalyst tri-flame](/foundations/logo) and form
 - **Background**: blue `#00aeff`
 - **Position**: `x:0, y:0`
 - **Visual header toggle**: Off
-
-</article>
 
 :::
 
@@ -53,7 +45,7 @@ To obtain a PNG for your application, contact the UX team via the `#design` Slac
 
 Edit the `AppName.png` image object and swap the image file with the one for your application.
 
-The App Name should be positioned to the right of the tri-flame logo at `x:55, y:0` and centered vertically within the Navbar. 
+The App Name should be positioned to the right of the tri-flame logo at `x:55, y:0` and centered vertically within the Navbar.
 
 **Important:** you will need to adjust the width of your app name image.
 You want the width to be just wide enough to contain the image without shrinking it.
@@ -72,8 +64,6 @@ Provide around `25px` of padding between the app name and the first button.
 
 Depending on the number of sections in your application, create additional, identically-sized Navigation Objects (buttons) with about `8px` of padding between them. The **y-position** for the button objects may need to be adjusted so the bottom of the button's text aligns with the bottom of the app name.
 
-<article>
-
 The button for the currently selected page is formatted as follows:
 - **Type**: Button
 - **Height**: 50px
@@ -90,8 +80,6 @@ Additionally, there is a floating line shape that is positioned under the select
 - **Weight**: 4px
 - **Position**: `y:50` and the **x position** must match the **x position** of the selected button item
 - **Width**: Must match the selected button item's width
- 
- </article>
 
 ![Selected Link](./assets/analytics/powerbi/pbi-selected-link.png "Selected link")
 
@@ -119,8 +107,6 @@ Contact the UX team via the `#design` Slack channel for icon png files.
 
 ##### Co-branding
 
-<article>
-
 Co-Branding is the final fixed width horizontal object formatted as follows:
 - **Type**: Image
 - **Width**: 200px
@@ -128,12 +114,10 @@ Co-Branding is the final fixed width horizontal object formatted as follows:
 
 This space allows applications to include the logo of your customer.
 Ideally you'll want the horizontal version of a customer's logo with a **white or transparent** background.
-To configure this section, you need to delete the current image object and insert the new one with the following parameters: 
+To configure this section, you need to delete the current image object and insert the new one with the following parameters:
 
 - **Position**: `x: ~1050, y:0`
 - **Height**: 50px
-
-</article>
 
 Note that this is an optional section.
 If your application does not require co-branding, click on the Co-Branding image and "Remove" or delete the object.

--- a/guides/analytics/powerbi/tables.md
+++ b/guides/analytics/powerbi/tables.md
@@ -26,32 +26,24 @@ The table should leverage the remaining content area of the tile.
 
 ### Table Header Row
 
-<article>
-
 The content in the header row of a table is formatted as:
 - **Font**: Segoe (Bold)
 - **Font color**: dark-blue `#006d9a`
 - **Font size**: 9pt
 
-</article>
-
 ### Table Cells
 
-<article>
-
-The contents of table cells should be 
+The contents of table cells should be
 - **Font**: Segoe UI
 - **Font color**: offblack `#333333`
 - **Font size**: 9pt
 
 The Shading - Row Banding on table rows should be set to a background color of `#f9fafb` for both Panes and Headers.
 
-The Border - Default formatting values on Cells and Headers should be set to 
+The Border - Default formatting values on Cells and Headers should be set to
 - **Weight**: 1px
 - **Style**: Solid
 - **Color**: `#f1f1f1`
-
-</article>
 
 This creates a minimal banding effect without being too distracting for the small font size we use on Power BI tables.
 
@@ -64,9 +56,7 @@ This creates a minimal banding effect without being too distracting for the smal
 The specific content of tooltips of the table will be dictated by the data being displayed.
 But in general, they should contain a label and a value.
 
-<article>
-
-All text in the tooltip should be 
+All text in the tooltip should be
 - **Font**: Segoe UI
 - **Font color**: white `#ffffff`
 - **Font size**: 10pt

--- a/guides/analytics/powerbi/tabs.md
+++ b/guides/analytics/powerbi/tabs.md
@@ -24,22 +24,16 @@ Each tab is a button that contains a bookmark link to another sheet.
 
 The tab set buttons should be layered on top of a blank text object that extends the entire width of the tab content.
 
-<article>
-
 Formatting of button text is as follows:
 - **Font (selected tab)**: Segoe (Bold)
 - **Font(unselected)**: Segoe UI
 - **Font size**: 11pt
 - **Font color**: offblack `#333333`
 
-</article>
-
 ### Floating Objects
 
 The positioning of the floating line objects (Tab Selected, and Tab Set Underline) must be set manually.
 The Tab Set Underline width should extend from the left edge of the first tab to the right edge of the Spacer in the Tab Set container.
-
-<article>
 
 It's formatted as
 - **Height**: 1px
@@ -51,7 +45,5 @@ The width of the Tab Selected highlight should match the width of the selected t
 - **Height**: 4px
 - **Background**: blue `#00aeff`
 For the y position, subtract 2 from the y position of the Tab Set Underline calculated above.
-
-</article>
 
 :::

--- a/guides/analytics/qlik/about.md
+++ b/guides/analytics/qlik/about.md
@@ -33,20 +33,17 @@ In general, the about page should include the following (but you may adjust base
 
 ##### Sidebar
 
-<article>
-
 The Sidebar vertical text box is used on the About page for app details and is formatted accordingly:
 - **Background**: slate-gray-100 `#f0f3f6 RGB(240,243,246)`
 - **Width**: 250px
 - **Padding**: 12px interior padding on left and right sides, 25px vertical padding between items
 - **Font(labels)**: Arial Bold, 11pt
 - **Font(content)**: Arial 10pt
-</article>
 
 The first two items in the sidebar should be the name of the accelerator and the current version number.
 You should be able to simply edit the text in the template.
 
-The remaining items in the sidebar are unique to your application. Card visuals are used to display items that rely upon data fields (such as a last refresh date). 
+The remaining items in the sidebar are unique to your application. Card visuals are used to display items that rely upon data fields (such as a last refresh date).
 Examples are included in the template, but they may be edited or removed as needed.
 
 
@@ -57,7 +54,6 @@ Examples are included in the template, but they may be edited or removed as need
 ##### Content Area
 
 The Content Area has a **white** `#ffffff RGB(255,255,255)` background for the About Page.
-<article>
 
 The first item in the Content Area is the full Health Catalyst horizontal logo:
 - **Location**: x:514, y:87
@@ -65,7 +61,6 @@ The first item in the Content Area is the full Health Catalyst horizontal logo:
 - **Width**: 463px
 - **Scale**: Normal
 - **Image stretch**: Aspect lock on
-</article>
 
 The second item in the content area is a banner with the name of the accelerator. You'll need to repoint the image file to the correct image png file that you are using for the navbar.
 
@@ -76,20 +71,19 @@ The styling and setup of the tabs follow the guidelines described in the [Tabs s
 The first tab should almost always be "About this App", where an overview of the app and usage guidelines are provided.
 
 For the remaining tabs, you may choose what is most appropriate for your application.
-<article>
+
 Format tab labels accordingly:
 
 - **Font**: Arial
 - **Font size**: 10pt
 - **Color**: off-black `#333333 RGB(51,51,51)`
 
-Headers for the text in the content area should be set to: 
+Headers for the text in the content area should be set to:
 
 - **Font**: Arial (Bold)
 - **Font size**: 12pt
 - **Color**: dark-blue `#006d9a RGB(0,109,154)`
 
-</article>
 ### Pagination
 
 If there is more text than fits onto a single page within a tab, you may incorporate pagination into your tab.
@@ -101,7 +95,6 @@ The pagination controller is comprised of Page Buttons horizontally aligned with
 ![Pagination Controller](./assets/analytics/tableau/pagination.png "Pagination Controller")
 
 </div>
-<article>
 
 Each button requires:
 - **Border**: 1px

--- a/guides/analytics/qlik/charts.md
+++ b/guides/analytics/qlik/charts.md
@@ -31,8 +31,6 @@ The exact size of a tile for a chart will be determined by the other content tha
 
 ##### Grid Styles
 
-<article>
-
 Axis lines within charts should be formatted as:
 - **Weight**: 1px
 - **Color**: off-black `#333333 RGB(51,51,51)`
@@ -45,8 +43,6 @@ Grid lines should be formatted as:
 - **Weight**: 1px
 - **Color**: gray-300 `#cccccc RGB(204,204,204)`
 - **Style**: Dotted
-
-</article>
 
 ![Grid Lines](./assets/analytics/qlik/qlik-gridlines.png "Grid Lines")
 
@@ -64,7 +60,7 @@ To determine what colors should be used together in charts, you should determine
 
 </div>
 
-Charts that are dense, complex, and/or require specialized knowledge or experience to comprehend are well-suited for review by both Health Catalyst's data science team and design teams to ensure that visual elements such as color saturation, line thickness, shapes, label placements, etc., are crafted to best support the data story. 
+Charts that are dense, complex, and/or require specialized knowledge or experience to comprehend are well-suited for review by both Health Catalyst's data science team and design teams to ensure that visual elements such as color saturation, line thickness, shapes, label placements, etc., are crafted to best support the data story.
 
 :::
 
@@ -87,7 +83,7 @@ But in general, they should contain a label and a value.
 
 ##### Visual Header Tooltips
 
-Charts should include tooltips that enable and enhance self-service analytics and data exploration. 
+Charts should include tooltips that enable and enhance self-service analytics and data exploration.
 
 ### Info Tooltip
 
@@ -104,6 +100,6 @@ If additional controls are included above the chart, the info tooltip can also p
 
 ### Data Tooltips
 
-Every chart should include the **Send to Excel** icon to enable power users who may want to explore the raw data. Some other special icons provide users with features such as the ability to easily copy the visualization as an image, to clear any filters, etc. Use your best judgement to carefully choose the most effective header icons for a chart, while weighing the potentially overwhelming effect that providing too many options brings. 
+Every chart should include the **Send to Excel** icon to enable power users who may want to explore the raw data. Some other special icons provide users with features such as the ability to easily copy the visualization as an image, to clear any filters, etc. Use your best judgement to carefully choose the most effective header icons for a chart, while weighing the potentially overwhelming effect that providing too many options brings.
 
 :::

--- a/guides/analytics/qlik/filters.md
+++ b/guides/analytics/qlik/filters.md
@@ -24,13 +24,11 @@ The sidebar is always visible, so filters being used can be easily seen.
 ##### Sidebar
 
 For consistency, filters should be displayed on the sidebar of the accelerator layout.
-<article>
 
 Format a filter sidebar accordingly:
 - **Type**: Text object
 - **Background**: slate-gray-400 `#708090 RGB(112,128,144)`
 - **Width**: 250px
-</article>
 
 There should be 10px of vertical space at the top of the sidebar before the first filter or metric.
 
@@ -43,10 +41,7 @@ As many counts may be included as needed, one on top of the other.
 
 ![Filter Counts](./assets/analytics/qlik/qlik-filter-counts.png "Filter Counts")
 
-These counts should be the first item on the sidebar, and are formatted with the following values: 
-
-
-<article>
+These counts should be the first item on the sidebar, and are formatted with the following values:
 
 Counts labels:
 - **Alignment**: left-justified
@@ -62,19 +57,15 @@ Counts values:
 - **Font color**: white `#ffffff RGB(255,255,255)`
 - **Text margin**: 6pt
 
-</article>
-
 ### Controls
 
 Controls (or filters), are usually grouped together and should be formatted with the following values:
 
 ![Filter Control](./assets/analytics/qlik/qlik-filter-control.png "Filter Control")
-<article>
 
 - **Font color**: white `#ffffff RGB(255,255,255)`
 - **Font (label)**: Arial, 11pt
 - **Font (sub-control)**: Arial, 10pt
-</article>
 
 ### Footer
 
@@ -83,14 +74,11 @@ This gives users confidence that the values in the dashboard are current and val
 
 In general, the footer should be set to:
 
-<article>
-
 - **Font color**: white `#ffffff RGB(255,255,255)`
 - **Font (label)**: Arial, 9pt
 - **Font (sub-control)**: Arial, 11pt
 - **Padding**: 4px
 - **Height**: 55px
-</article>
 
 ![Filter Footer](./assets/analytics/qlik/qlik-filter-footer.png "Filter Footer")
 

--- a/guides/analytics/qlik/foundations.md
+++ b/guides/analytics/qlik/foundations.md
@@ -104,14 +104,9 @@ Details about use of the sidebar can be found in the [filters section](/analytic
 
 ### Content Area
 
-<article>
-
 The background color for the content area can be one of the following values:
 - **Background**: slate-gray-100 `#f0f3f6 RGB(240,243,246)`
 - **Background**: white `#ffffff RGB(255,255,255)`
-
-</article>
-
 
 :::
 
@@ -121,9 +116,7 @@ The background color for the content area can be one of the following values:
 
 Visualization objects such as charts, graphs, tables, and KPIs should be styled like the Cashmere [tile component](/web/components/tile) and will be referred to as tiles within this section.
 
-<article>
-
-In general, a Qlik tile should be formatted accordingly: 
+In general, a Qlik tile should be formatted accordingly:
 - **Background**: white `#ffffff RGB(255,255,255)`
 - **Border**: white `#ffffff RGB(255,255,255)`
 - **Radius**: 5px
@@ -135,8 +128,6 @@ Each tile should also have shadow with the following values:
 - **Transparency**: 85%
 
 Tiles should have at least 10px of padding between each other (5px on either side).
-
-</article>
 
 Layout specifics for the most common visual objects can be found in the [KPI Metrics section](/analytics/qlik-metrics), [Charts section](/analytics/qlik-charts), and [Tables section](/analytics/qlik-tables). Refer to the template or these sections for working examples.
 
@@ -173,14 +164,10 @@ Utilize Qlik's alignment capabilities by selecting each object and choosing the 
 
 ### Tile Title
 
-<article>
-
 Tile tiles should be formatted accordingly:
 - **Alignment**: left
 - **Font**: Arial Bold, 10pt
 - **Color**: offblack `#333333 RGB(51,51,51)`
-
-</article>
 
 ### Tile Visual Header
 
@@ -191,15 +178,11 @@ Some header elements, such as drill-down icons, are object-specific and more det
 
 ### Divider
 
-<article>
-
 A horizontal line divides the header from the rest of the content in the object and is formatted with the following values:
 - **Weight**: 1px
 - **Padding**: 2px on left and right sides
 - **Height**: 10px
 - **Color**: slate-gray-300 `#c0c5cc RGB(192,197,204)`
-
-</article>
 
 <div style="text-align:center"><br>
 

--- a/guides/analytics/qlik/kpi-metrics.md
+++ b/guides/analytics/qlik/kpi-metrics.md
@@ -13,7 +13,7 @@ They allow users to make an immediate judgement about the state of the informati
 KPIs are so ubiquitous that they have become a established convention for data-savvy users.
 An [eye-tracking study conducted by Tableau](https://www.tableau.com/about/blog/2017/6/eye-tracking-study-5-key-learnings-data-designers-everywhere-72395) in 2017 revealed that big numbers are one of first elements of a dashboard that viewers are drawn to.
 It's important for us to take advantage of this convention as a way to guide users through the information we are presenting.
-Since Qlik users are accustomed to both traditional tiles and multi-select functionality within dynamic tiles, both types are discussed within this section. 
+Since Qlik users are accustomed to both traditional tiles and multi-select functionality within dynamic tiles, both types are discussed within this section.
 
 ![KPI Tile](./assets/analytics/qlik/qlik-tile.PNG "KPI Tile")
 
@@ -28,8 +28,6 @@ Refer to that **Tile Header** and **Divider** sections of that page for specific
 
 ### Layout
 Format the content within the tile as follows:
-
-<article>
 
 - **Text alignnment**: Centered horizontally
 - **Font color**: offblack `#333333 RGB(51,51,51)`
@@ -64,16 +62,14 @@ Refer to that **Tile Header** and **Divider** sections of that page for specific
 
 ### Layout
 
-Multi-select tile functionality should be as clear as possible to users. In the example below, the sub-header: "(select to display below)" makes it clear that each measure selection will dynamically update the following charts on the page. The checkboxes help users understand that more than one measure can be simultaneously displayed on the charts. 
+Multi-select tile functionality should be as clear as possible to users. In the example below, the sub-header: "(select to display below)" makes it clear that each measure selection will dynamically update the following charts on the page. The checkboxes help users understand that more than one measure can be simultaneously displayed on the charts.
 
-<article>
-
-The checkboxes and measure labels are within a listbox object that is 1 cell high. 
+The checkboxes and measure labels are within a listbox object that is 1 cell high.
 - **Font (label)**: Arial (Bold), 10pt
 
 The measure values are within individual transparent textboxes that are formatted as:
 
-- **Alignment**: Left-aligned to checkbox 
+- **Alignment**: Left-aligned to checkbox
 - **Font**: Arial, 24pt
 - **Text margin**: 0pt
 

--- a/guides/analytics/qlik/navbar.md
+++ b/guides/analytics/qlik/navbar.md
@@ -12,14 +12,11 @@ The navbar is one of the most distinguishing elements of a Cashmere application.
 It is a hallmark of the Health Catalyst app brand on all platforms.
 For this reason, the styling of the navbar should not be altered from the template.
 
-<article>
-
 The Navbar is formatted accordingly:
-- **Background**: charcoal-blue `#384655 RGB(56,70,85)` 
-- **Type**: horizontal text object 
+- **Background**: charcoal-blue `#384655 RGB(56,70,85)`
+- **Type**: horizontal text object
 - **Height**: `50px`
 - **Position**: x:0, y:0
-</article>
 
 :::
 
@@ -27,15 +24,12 @@ The Navbar is formatted accordingly:
 
 ##### Brand
 
-<article>
-
 Brand is an image of the [Health Catalyst tri-flame](/foundations/logo) formatted as follows:
-- **Background**: blue `#00aeff RGB(0,174,255)` 
+- **Background**: blue `#00aeff RGB(0,174,255)`
 - **Type**: image
 - **Height**: 50px
 - **Width**: 50px
 - **Position**: x:0, y:0
-</article>
 
 :::
 
@@ -44,15 +38,12 @@ Brand is an image of the [Health Catalyst tri-flame](/foundations/logo) formatte
 ##### App Name
 
 App Name is the second fixed-width image object in the navbar, also containing one PNG image, fomatted with the following values:
-<article>
 
 - **Type**: image
 - **Height**: 50px
 - **Position**: To the right of the logo (~65px) and centered vertically within the Navbar
 - **Image stretch**: Keep Aspect
 - **Text margin**: 2pt
-
-</article>
 
 The image is the name of your application in the Flexo font (so the font isn't needed).
 To obtain a PNG for your application, contact the UX team via the `#design` Slack channel.
@@ -72,8 +63,6 @@ Then continue to edit the width and reduce the size of the container until it's 
 
 Links is a flexible series of horizontal text objects that contain page navigation actions to the different sections of your application. Utilizing actions turns the text objects into button objects. These buttons have the following values:
 
-<article>
-
 - **Background**: None
 - **Border**: None
 - **Type**: text object with actions
@@ -85,21 +74,15 @@ Links is a flexible series of horizontal text objects that contain page navigati
 - **Font color**: white `#ffffff RGB(255,255,255)`
 - **Text margin**: 2pt
 
-</article>
-
 Additionally, there is a floating line item called `Selected Highlight` that should be positioned under the selected item.
 The y position of that item should always be set to the bottom of the selected item, but the x position should match the x position of the selected item.
 The width of the selected highlight item should also match the selected text object item.
 
 ![Selected Link](./assets/analytics/qlik/qlik-selected.png "Selected link")
 
-<article>
-
 Text indicating a selection has been made is formatted differently than the rest of the text within Links
 - **Font (selected)**: Arial (Bold), 10pt
 - **Font (unselected)**: Arial, 10pt
-
-</article>
 
 :::
 

--- a/guides/analytics/qlik/tables.md
+++ b/guides/analytics/qlik/tables.md
@@ -26,18 +26,13 @@ The table should leverage the remaining content area of the tile.
 
 ### Table Header Row
 
-<article>
-
 The content in the header row of a table should be:
 - **Font**: Arial(Bold), 9pt
 - **Font color**: dark-blue `#006d9a RGB(0,109,154)`
-</article>
 
 Note: The easiest way to format a table's header is to be in **design grid** mode. Then, you should be able to right-click on a header cell and choose **custom format cell**.
 
 ### Table Cells
-
-<article>
 
 The contents of table cells should be formatted as:
 - **Font**: `Arial`, 9pt
@@ -52,7 +47,6 @@ Cell and header borders
 - **Weight**: 1px
 - **Style**: Solid
 - **Color**: gray-100 `#f1f1f1 RGB(241,241,241)`
-</article>
 
 :::
 

--- a/guides/analytics/qlik/tabs.md
+++ b/guides/analytics/qlik/tabs.md
@@ -21,10 +21,8 @@ Each tab is a text object that utilizes actions to create a conditionally-shown 
 
 ##### Formatting
 
-In order to recreate the styling of the Cashmere web component in Qlik, each text object is on the same y-position and adjusted until their vertical sides touch. 
+In order to recreate the styling of the Cashmere web component in Qlik, each text object is on the same y-position and adjusted until their vertical sides touch.
 Each object follows these general guidelines:
-
-<article>
 
 Object:
 - **Height**: 35px
@@ -38,29 +36,19 @@ Object label:
 - **Font (unselected)**: Arial, 11pt
 - **Font color**: off-black `#333333 RGB(51,51,51)`
 
-</article>
-
 ### Selection Items
 
 The y position of the Tab Set Underline should be equal to the bottom of the tabs. The width should extend from the left edge of the first tab to the right edge of the page.
 Format the Tab Set Underline as follows:
 
-<article>
-
 - **Background**: Transparent
 - **Weight**: 1px
 - **Color**: slate-gray-300 `#c0c5cc RGB(192,197,204)`
 
-</article>
-
 The positioning of the Tab Selected Highlight must be set manually and must utilize conditional show-hide functionality to disappear when a tab is de-selected. The width of the Tab Selected highlight should match the width of the selected tab.
 It should be formatted as:
 
-<article>
-
 - **Background**: blue `#00aeff RGB(0,174,255)`
 - **Height**: 4px
-
-</article>
 
 :::

--- a/guides/analytics/tableau/about.md
+++ b/guides/analytics/tableau/about.md
@@ -39,8 +39,6 @@ In general, the about page should include the following (but you may adjust base
 
 Within the Body horizontal container, the Sidebar vertical container is used on the About page for app details.
 
-<article>
-
 The Sidebar should be formatted with the following values:
 - **Width**: 250px
 - **Background**: slate-gray-100 `#f0f3f6`
@@ -54,8 +52,6 @@ Examples are included in the template, but they may be edited or removed as need
 
 - **Font (label)**: Tableau Bold, 11pt
 - **Font (content)**: Tableau Regular, 10pt
-
-</article>
 
 Each info item in the Sidebar is separated by a 25px blank spacer.
 
@@ -81,8 +77,6 @@ The first tab should almost always be "About this App", where an overview of the
 
 For the remaining tabs, you may choose what is most appropriate for your application.
 
-<article>
-
 The text within each tab should be set as follows:
 
 - **Font**: Tableau Book, 10pt
@@ -91,8 +85,6 @@ The text within each tab should be set as follows:
 Headers within the text should be set as follows:
 - **Font**: Tableau Bold, 12pt
 - **Color**: dark-blue `#006d9a`
-
-</article>
 
 ### Pagination
 
@@ -105,8 +97,6 @@ The pagination horizontal container includes Page Buttons centered with a blank 
 ![Pagination Controller](./assets/analytics/tableau/pagination.png "Pagination Controller")
 
 </div>
-
-<article>
 
 Each button should be formatted as:
 
@@ -124,7 +114,5 @@ Un-selected buttons are formatted as:
 
 
 The text in each button should be `PAGE X` with page in uppercase letters.
-
-</article>
 
 :::

--- a/guides/analytics/tableau/charts.md
+++ b/guides/analytics/tableau/charts.md
@@ -30,13 +30,11 @@ The exact size of a tile for a chart will be determined by the other content tha
 
 ##### Grid Styles
 
-<article>
-
 Axis lines within charts should be formatted as:
 - **Weight**: 1px
 - **Color**: offblack `#333333`
 
-Axis text/labels should be formatted as: 
+Axis text/labels should be formatted as:
 - **Font**: Tableau Book
 - **Font size**: 9pt
 - **Color**: offblack `#333333`
@@ -45,8 +43,6 @@ Grid lines should be set to:
 - **Weight**: 1px
 - **Style**: Dotted
 - **Color**: gray-300 `cccccc`
-
-</article>
 
 ![Grid Lines](./assets/analytics/tableau/gridlines.png "Grid Lines")
 
@@ -67,16 +63,12 @@ To determine what colors should be used together in charts, you should determine
 The specific content of tooltips of the chart will be dictated by the data being displayed.
 But in general, they should contain a label and a value.
 
-<article>
-
 All text in the tooltip should be set to:
 
 - **Font**: 10pt
 - **Color**: offblack `#333333`
 - **Label font**: Tableau Book
 - **Value font**: Tableau Bold
-
-</article>
 
 ![Chart Tooltips](./assets/analytics/tableau/charttooltip.png "Chart Tooltips")
 

--- a/guides/analytics/tableau/filters.md
+++ b/guides/analytics/tableau/filters.md
@@ -25,14 +25,10 @@ The sidebar is always visible, so filters being used can be easily seen.
 
 For consistency, filters should be displayed on the sidebar of the accelerator layout.
 
-<article>
-
 A filter sidebar should be formatted as following:
-- **Background**: slate-gray-400 `#708090` 
-- **Width**: 250px 
+- **Background**: slate-gray-400 `#708090`
+- **Width**: 250px
 There should be 10px of vertical space at the top of the sidebar before the first filter or metric.
-
-</article>
 
 ### Counts
 
@@ -45,9 +41,7 @@ As many counts may be included as needed, one on top of the other.
 
 These counts should be the first item on the sidebar, and should displayed as a horizontal container with the label on the left and the value on the right.
 
-<article>
-
-Counts labels are formatted as: 
+Counts labels are formatted as:
 - **Font**: Tableau Regular, 10pt
 - **Font color**: white `#ffffff`
 - **Padding (outer)**: `6, 4, 0, 4`
@@ -58,11 +52,7 @@ Counts values are formatted as:
 - **Padding (outer)**: `0, 0, 6, 0`
 - **Alignment**: right-justified
 
-</article>
-
 ### Controls
-
-<article>
 
 Control labels are formatted as follows:
 - **Label**: Tableau Regular, 10pt
@@ -73,8 +63,6 @@ All controls, regardless of type should have the following values:
 - **Height**: 52px
 - **Padding (outer)**: `8, 2, 8, 2`
 
-</article>
-
 ![Filter Control](./assets/analytics/tableau/filtercontrol.png "Filter Control")
 
 ### Footer
@@ -82,16 +70,12 @@ All controls, regardless of type should have the following values:
 As with counts, most accelerators benefit from including a footer indicating the last refresh of the data.
 This gives users confidence that the values in the dashboard are current and valid.
 
-<article>
-
-In general, the footer should be set to 
+In general, the footer should be set to
 - **Font color**: white `#ffffff`
 - **Font (label)**: Tableau Regular, 9pt
 - **Font (value)**: Tableau Bold, 11pt
 - **Height**: 55px
 - **Padding (outer)**: `4, 4, 4, 4`
-
-</article>
 
 ![Filter Footer](./assets/analytics/tableau/filterfooter.png "Filter Footer")
 
@@ -110,17 +94,13 @@ These are referred to as **Page Filters**.
 
 To distinguish between these filter types, we use section headers on the sidebar.
 
-<article>
-
-Section headers are text items set to the following values: 
+Section headers are text items set to the following values:
 - **Font**: Tableau Bold
 - **Font size**: 10pt
 - **Font color**: white `#ffffff`
 - **Height**: 26px
 - **Background**: charcoal-blue `#384655`
 - **Padding (inner)**: `6, 5, 0, 6`
-
-</article>
 
 There should also be a 10px height spacer after the header.
 

--- a/guides/analytics/tableau/foundations.md
+++ b/guides/analytics/tableau/foundations.md
@@ -96,12 +96,9 @@ Details about use of the sidebar can be found in the [filters section](/analytic
 
 ### Content Area
 
-<article>
-
 The background color for the content area can be one of the following values:
 - **Background**: slate-gray-100 `#f0f3f6`
-- **Background**: white `#ffffff` 
-</article>
+- **Background**: white `#ffffff`
 
 The Inner Padding for the content area on dashboards should be at least `20, 20, 20, 10`.
 Note that the content area on the [About Page](/analytics/tableau-about) applies padding to the contained items instead.
@@ -116,13 +113,10 @@ As with Cashmere web applications, content is typically contained within [tiles]
 Unfortunately Tableau does not support rounded edges or drop-shadows, so tiles within Tableau apps will look slightly different than their Cashmere counterparts.
 Layout specifics for the most common tiles can be found in the [KPI Metrics section](/analytics/tableau-metrics), [Charts section](/analytics/tableau-charts), and [Tables section](/analytics/tableau-tables). Refer to the template or these sections for working examples.
 
-<article>
-
 In general, a Tableau tile is a vertical container formatted with the following values:
-- **Background**: white `#ffffff` 
+- **Background**: white `#ffffff`
 - **Border style**: solid
 - **Border**: slate-gray-300 `#c0c5cc`
-</article>
 
 Tiles should have at least 10px of padding between each other (5px on either side).
 
@@ -135,18 +129,15 @@ Tiles should have at least 10px of padding between each other (5px on either sid
 ### Tile Header
 
 Every tile should include a header horizontal container with a title, an info button, and a drill-down button (optional).
-<article>
 
-The header container is formatted as follows: 
+The header container is formatted as follows:
 - **Height**: 35px
 - **Padding (outer)**: `10, 5, 10, 0`
 
-The header text should be 
-- **Font**: Tableau Bold, 
+The header text should be
+- **Font**: Tableau Bold,
 - **Color**: offblack `#333333`
 - **Size**: 10pt
-
-</article>
 
 For the info tooltip, we leverage a worksheet with a shape.
 The shape used is included in the folder called "HealthCatalystShapes" in the template zip file.
@@ -169,8 +160,6 @@ For a navigation button, remove all outer padding, set the fixed width to 30px, 
 
 ### Divider
 
-<article>
-
 A horizontal line divides the header from the content of the tile and is formatted as follows:
 - **Weight**: 1px
 
@@ -178,8 +167,6 @@ Add a blank item to the tile vertical container and format it with the following
 - **Padding (outer)**: `10, 0, 10, 5`
 - **Height**: 6px
 - **Background**: slate-gray-300 `#c0c5cc`
-
-</article>
 
 ### Content
 

--- a/guides/analytics/tableau/kpi-metrics.md
+++ b/guides/analytics/tableau/kpi-metrics.md
@@ -27,8 +27,6 @@ Refer to that **Tile Header** and **Divider** sections of that page for specific
 
 The content of the KPI should be centered in tile.
 
-<article>
-
 The main KPI value should be formatted as:
 - **Font**: Tableau Light
 - **Font size**: 24pt
@@ -38,13 +36,11 @@ KPI metrics often leverage a second line to indicate trend or sources. A seconda
 - **Font size**: 10pt
 - **Font color**: offblack `#333333`
 
-Arrows or text colors indicating positive trends should be set to 
+Arrows or text colors indicating positive trends should be set to
 - **Color**: green `#00a859`
 
-For negative trends, use 
+For negative trends, use
 - **Color**: red `#f13c45`
-
-</article>
 
 But never rely solely on color to indicate a positive or negative trend, either text or iconography should also indicate the trend.
 

--- a/guides/analytics/tableau/navbar.md
+++ b/guides/analytics/tableau/navbar.md
@@ -23,8 +23,6 @@ Below is the hierarchy for the container (a floating item called "Selected Highl
 
 ##### Brand
 
-<article>
-
 Brand is a fixed width horizontal container.
 - **Background**: blue `#00aeff`
 - **Height**: 50px
@@ -32,8 +30,6 @@ Brand is a fixed width horizontal container.
 
 Within the container is an SVG of the Health Catalyst tri-flame.
 - **Padding (outer)**: 8px
-
-</article>
 
 :::
 
@@ -71,8 +67,6 @@ The Outer Padding on any navbar link should be set to `4, 5, 4, 3`.
 These values are important so the bottom of the navbar text aligns with the bottom of the app name.
 The background color and border on the button should be set to `None`.
 
-<article>
-
 The button for the currently selected page should be formatted as:
 
 - **Font (selected)**: Tableau Bold
@@ -85,12 +79,10 @@ Adjust the left & right Outer Padding of Selected Highlight to account for paddi
 
 ![Selected Link](./assets/analytics/tableau/selected.png "Selected link")
 
-All other buttons should be formatted as: 
+All other buttons should be formatted as:
 
 - **Font**: Tableau Regular
 - **Color**: gray-200 (the second swatch in the fourth row of the Font color picker)
-
-</article>
 
 :::
 
@@ -115,11 +107,9 @@ Contact the UX team via the `#design` Slack channel for icon svgs.
 
 ##### Co-branding
 
-<article>
 Co-Branding is the final fixed width horizontal container set to:
 - **Width**: 200px
 - **Background**: white `#ffffff`
-</article>
 
 This space allows applications to include the logo of your customer.
 Ideally you'll want the horizontal version of a customer's logo with a white or transparent background.

--- a/guides/analytics/tableau/tables.md
+++ b/guides/analytics/tableau/tables.md
@@ -26,20 +26,14 @@ The Outer Padding for the tile should be at least 10px on the right and left so 
 
 ### Table Header Row
 
-<article>
-
-The content in the header row of a table should be set to: 
+The content in the header row of a table should be set to:
 - **Color**: dark-blue `#006d9a`
 - **Font**: Tableau Bold
 - **Font size**: 9pt
 
-</article>
-
 ### Table Cells
 
-<article>
-
-The contents of table cells should be set to: 
+The contents of table cells should be set to:
 - **Color**: offblack `#333333`
 - **Font**: Tableau Regular
 - **Font size**: 9pt
@@ -55,8 +49,6 @@ The Border - Default formatting on Cells and Headers should be set to:
 - **Style**: Solid
 - **Weight**: 1px
 
-</article>
-
 This creates a minimal banding effect without being too distracting for the small font size we use on Tableau tables.
 
 :::
@@ -68,15 +60,11 @@ This creates a minimal banding effect without being too distracting for the smal
 The specific content of tooltips of the table will be dictated by the data being displayed.
 But in general, they should contain a label and a value.
 
-<article>
-
 All text in the tooltip should be set to:
 - **Font**: 10pt
 - **Color**: offblack `#333333`
 - **Label font**: Tableau Book
 - **Data font**: Tableau Bold
-
-</article>
 
 :::
 

--- a/guides/analytics/tableau/tabs.md
+++ b/guides/analytics/tableau/tabs.md
@@ -37,8 +37,6 @@ For the selected tab it should be `Tableau Bold`.
 The positioning of the floating items (Tab Selected, and Tab Set Underline) must be set manually.
 The Tab Set Underline width should extend from the left edge of the first tab to the right edge of the Spacer in the Tab Set container.
 
-<article>
-
 The Tab Set Underline is formatted as follows:
 - **Height**: 1px
 - **Background**: slate-gray-300 `#c0c5cc`
@@ -51,7 +49,5 @@ The width of the Tab Selected highlight should match the width of the selected t
 - **Background**: blue `#00aeff`
 
 For the y position, subtract 2 from the y position of the Tab Set Underline calculated above.
-
-</article>
 
 :::

--- a/guides/content/personas/active-care-management-patient.md
+++ b/guides/content/personas/active-care-management-patient.md
@@ -20,8 +20,6 @@ Individual with complex medical needs, limited medical knowledge and often high 
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -42,7 +40,5 @@ Individual with complex medical needs, limited medical knowledge and often high 
 -   Reminders of their upcoming appointments, include when, where, and how to prepare
 -   Information that they can easily access to answer questions and learn more about their conditions
 -   Care that addresses their specific social, financial, and mental health barriers
-
-</article>
 
 :::

--- a/guides/content/personas/ambulatory-clinician.md
+++ b/guides/content/personas/ambulatory-clinician.md
@@ -24,8 +24,6 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -43,7 +41,5 @@
 -   Access to review patient analytics in their EMR workflow
 -   Easy way to know if the patient has an ambulatory care team and review patient's care plan
 -   Ability to view / communicate with the patient's care team
-
-</article>
 
 :::

--- a/guides/content/personas/bi-developer.md
+++ b/guides/content/personas/bi-developer.md
@@ -20,8 +20,6 @@ Steve analyzes, designs, develops, deploys, supports, and maintains reporting an
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -42,7 +40,5 @@ Steve analyzes, designs, develops, deploys, supports, and maintains reporting an
 -   Proven and standard programming languages, tools, techniques, and technologies
 -   Tools to build, edit, and export populations, measures, terminology, etc., in collaboration with project stakeholders and sponsors
 -   Information and SMEs in multiple domains, e.g., financial, clinical, and operational
-
-</article>
 
 :::

--- a/guides/content/personas/biller-auditor.md
+++ b/guides/content/personas/biller-auditor.md
@@ -18,8 +18,6 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
@@ -43,9 +41,5 @@
 
 -   If I don't send out accurate bills, there will be a delay in the payment received and our organization will endure financial strains due to these delays.
 -   If every bill is not accurately coded correctly, I will face collection and have to rebill claims, causing many delays in receiving payment and in some cases causing our organization not to receive any payment on a claim, creating a major financial strain on the entire hospital.
-
-
-
-</article>
 
 :::

--- a/guides/content/personas/care-management-admin.md
+++ b/guides/content/personas/care-management-admin.md
@@ -20,8 +20,6 @@ Former clinician who has transitioned from patient care to a managerial role. Mu
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -53,7 +51,5 @@ Former clinician who has transitioned from patient care to a managerial role. Mu
 -   Conveniently audit the patient list to find those who care management needs have not been addressed
 -   Select from current data and export for external tools
 -   Easily trigger a refresh if application data from EDW is not current
-
-</article>
 
 :::

--- a/guides/content/personas/care-management-director.md
+++ b/guides/content/personas/care-management-director.md
@@ -20,8 +20,6 @@ Former clinician with several years of administrative experience; now responsibl
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -51,7 +49,5 @@ Former clinician with several years of administrative experience; now responsibl
 -   Configure possible reasons to decline or discharge a patient
 -   Visibility into staff performance metrics
 -   Review / compare outcomes for patients in care management
-
-</article>
 
 :::

--- a/guides/content/personas/care-team-lead.md
+++ b/guides/content/personas/care-team-lead.md
@@ -20,8 +20,6 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -52,7 +50,5 @@
 -   Messaging capability to communicate with members of the care team, including those outside of the health care system
 -   Generate patient summary reports that can be sent to clinicians providing an overview of past care and current care plan
 -   Confirm their productivity / ensure they are meeting productivity targets set by their manager
-
-</article>
 
 :::

--- a/guides/content/personas/cdm-workflow-user.md
+++ b/guides/content/personas/cdm-workflow-user.md
@@ -18,8 +18,6 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
@@ -43,8 +41,5 @@
 -   If I can't find regulatory content in one place, it takes me a long time to track it down.
 -   If I can't find my workflow tasks quickly, I might not work on the most important things.
 -   When I enter incorrect information that breaks specific rules and don't catch them right away, then costs begin to add up quickly.
-
-
-</article>
 
 :::

--- a/guides/content/personas/chief-population-health-officer.md
+++ b/guides/content/personas/chief-population-health-officer.md
@@ -20,8 +20,6 @@ Dee is a clinician with some business strategy and financial acumen; he's a stra
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -42,7 +40,5 @@ Dee is a clinician with some business strategy and financial acumen; he's a stra
 -   Surface and prioritize specific opportunities to improve value-based care performance (heavy-use at fiscal year end to decide what to prioritize for next year)
 -   Generate monthly / quarterly holistic performance reports
 -   Expose areas of interest / concern that had not previously been surfaced
-
-</article>
 
 :::

--- a/guides/content/personas/chief-quality-officer.md
+++ b/guides/content/personas/chief-quality-officer.md
@@ -27,8 +27,6 @@ Oversees overall Patient Safety and Quality efforts with the hospital.  Reviewer
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -51,7 +49,5 @@ Oversees overall Patient Safety and Quality efforts with the hospital.  Reviewer
 -   Ensures that Unit leaders are provided their Harm/Adverse Event data and tracks improvement initiatives
 -   Responsible for engaging unit leaders if safety risks aren't being met
 -   Works closely with his Risk Management counterpart
-
-</article>
 
 :::

--- a/guides/content/personas/clinical-quality-data-analyst.md
+++ b/guides/content/personas/clinical-quality-data-analyst.md
@@ -20,8 +20,6 @@ The Clinical/Quality Data Analyst has experience and expertise with domain data 
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -45,7 +43,5 @@ The Clinical/Quality Data Analyst has experience and expertise with domain data 
     -   Capture the date of intervention start—and then track different metrics from that point (e.g., antibiotic compliance, mortality, etc.)
     -   Answer: Have we decreased variation and made significant difference in a specific metric, outcome, or process aim from target?
     -   Attribute the impact to the intervention
-
-</article>
 
 :::

--- a/guides/content/personas/clinical-quality-researcher.md
+++ b/guides/content/personas/clinical-quality-researcher.md
@@ -20,8 +20,6 @@ Colin's primary go is to find insights into the healthcare system's populations 
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -51,7 +49,5 @@ Colin's primary go is to find insights into the healthcare system's populations 
     -   Capture the date of intervention start—and then track different metrics from that point (e.g., antibiotic compliance, mortality, etc.)
     -   Answer: Have we decreased variation and made significant difference in a specific metric, outcome, or process aim from target?
     -   Attribute the impact to the intervention
-
-</article>
 
 :::

--- a/guides/content/personas/cost-analyst-accountant.md
+++ b/guides/content/personas/cost-analyst-accountant.md
@@ -20,8 +20,6 @@ Aaron performs validations to resolve configuration and data quality discrepanci
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -39,7 +37,5 @@ Aaron performs validations to resolve configuration and data quality discrepanci
 -   Access to accurate and detailed cost accounting
 -   Ability to adjust expenses and allocations as needed, especially during monthly costing period
 -   Knowledge of the data available in the source marts and how the data relates
-
-</article>
 
 :::

--- a/guides/content/personas/cost-center-manager.md
+++ b/guides/content/personas/cost-center-manager.md
@@ -20,8 +20,6 @@ Paige has financial accountability for her department and reports to her manager
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -37,7 +35,5 @@ Paige has financial accountability for her department and reports to her manager
 
 -   Access to accurate and detailed cost accounting
 -   Ability to quickly identify over- or under-utilization, care gaps, areas of under-performance, etc., and to infer priorities for improvement work
-
-</article>
 
 :::

--- a/guides/content/personas/cost-management-director.md
+++ b/guides/content/personas/cost-management-director.md
@@ -20,8 +20,6 @@ Hugh leads cost management efforts in the healthcare system. He works with the s
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -39,7 +37,5 @@ Hugh leads cost management efforts in the healthcare system. He works with the s
 -   Access to accurate and detailed cost accounting
 -   Knowledge and access to internal clinical and financial SMEs
 -   Strategic guidance from organizational executive champion
-
-</article>
 
 :::

--- a/guides/content/personas/data-engineer.md
+++ b/guides/content/personas/data-engineer.md
@@ -20,8 +20,6 @@ Junior data architect at a healthcare organization. Supporting EDW operations. H
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -40,7 +38,5 @@ Junior data architect at a healthcare organization. Supporting EDW operations. H
 -   Use EDW Console to manage production of the EDW every morning
 -   Identify the ID of failed batches
 -   Identify whether a problem involves one table or many
-
-</article>
 
 :::

--- a/guides/content/personas/data-steward.md
+++ b/guides/content/personas/data-steward.md
@@ -20,8 +20,6 @@ Data stewardship is owned by content experts and supported by Information Techno
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -41,7 +39,5 @@ Data stewardship is owned by content experts and supported by Information Techno
 -   Enter, receive, and respond to support tickets (preferably through the app)
 -   Admin tab(s) with data integrity measures highlighting potential problems and with validation tracking
 -   View and edit metric, cohort, terminology, etc., definitions within the app
-
-</article>
 
 :::

--- a/guides/content/personas/director-revenue-cycle.md
+++ b/guides/content/personas/director-revenue-cycle.md
@@ -18,16 +18,12 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
 
 -   Daily User
 -   Technical Level – High
-
-
 
 ---
 
@@ -38,9 +34,6 @@
 -   Works with employees to identify workflow opportunities
 -   Work stream to ensure the executive cash flow is constant
 
-
-
-
 ---
 
 ## Pain Points
@@ -50,9 +43,5 @@
 -   When I am unable to see the levels of efficiency in our workflow process, I cannot make changes to assure revenue comes in the door as soon as possible.
 -   When I don't have a robust reporting tool, I am unable to determine if additional revenue could be obtained or whether we are out of compliance with rules and regulations.
 -   I need to affect some basic settings (workflow creation) to be able to involve others within the organization (Admin Tools) or I will have to rely on the vendor who might not make the changes in the timeline I need.
-
-
-
-</article>
 
 :::

--- a/guides/content/personas/edw-manager.md
+++ b/guides/content/personas/edw-manager.md
@@ -20,8 +20,6 @@ Data architect at a healthcare organization. Highly skilled in SQL, very knowled
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -43,7 +41,5 @@ Data architect at a healthcare organization. Highly skilled in SQL, very knowled
 -   Control the order in which tables in a batch run, taking into consideration disk space, bandwidth, table size, etc.
 -   Have everything loaded each day by 7 or 8 a.m. - real-time data is better and the pressure for this is getting stronger
 -   Customize jobs (will use SQL Agent jobs as an alternative if EDW Console doesn't allow it)
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-analytics-director.md
+++ b/guides/content/personas/health-catalyst-analytics-director.md
@@ -20,8 +20,6 @@ Victoria works with one to two clients to fill a measurable queue of opportuniti
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -45,7 +43,5 @@ Victoria works with one to two clients to fill a measurable queue of opportuniti
 -   Proven and standard programming languages, tools, techniques, and technologies
 -   Tools to build, edit, and export populations, measures, terminology, etc., in collaboration with project stakeholders and sponsors
 -   Information and SMEs in multiple domains, e.g., financial, clinical, and operational
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-analytics-engineer.md
+++ b/guides/content/personas/health-catalyst-analytics-engineer.md
@@ -22,8 +22,6 @@ Ian combines deep, analytics skills and a sound understanding of the processes a
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -60,7 +58,5 @@ Ian combines deep, analytics skills and a sound understanding of the processes a
 -   Create a web forms for users to enter data without having to build a custom web apps
 -   Access to software APIs to extend/streamline existing workflows
 -   Create a schedule for when a SAM will be updated from the EDW
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-data-engineer.md
+++ b/guides/content/personas/health-catalyst-data-engineer.md
@@ -20,8 +20,6 @@ Health Catalyst team member preparing client source marts to deploy in the Healt
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -42,7 +40,5 @@ Health Catalyst team member preparing client source marts to deploy in the Healt
 -   Troubleshoot ETL failure by checking EDWAdmin tables
 -   Jump to SSIS or create manual workarounds if a feature is missing (and seems unlikely to be added in the near future), has an architecture that is table based rather than column based, is unpredictable, or is less efficient than an external alternative (e.g., C4 queries, bulk renaming, Gap Analyzer)
 -   Directly copy software code for use with multiple tools/applications
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-developer.md
+++ b/guides/content/personas/health-catalyst-developer.md
@@ -18,17 +18,12 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
 
 -   Frequency of Use
 -   Technical Level – High
-
-
-
 
 ---
 
@@ -38,9 +33,6 @@
 -   Defines workflow within the product
 -   Performs setup of SFTP and auto file submission
 
-
-
-
 ---
 
 ## Pain Points
@@ -48,12 +40,5 @@
 -   Optimal performance of SFTP
 -   Not getting the results as promised from the API and having to adapt via workaround measures, which takes time with no guaranteed solutions.
 -   If I am unable to get adequate implementation and documentation, then major errors can occur in regard to product setup thus causing major delays in implementation.
-
-
-
-
-
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-domain-sme.md
+++ b/guides/content/personas/health-catalyst-domain-sme.md
@@ -20,8 +20,6 @@ Sean has a deep understanding of healthcare and especially of his domain area (c
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -43,7 +41,5 @@ Sean has a deep understanding of healthcare and especially of his domain area (c
 -   Process facilitations tools
 -   Outcome improvement tools
 -   Presentation tools
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-engagement-lead.md
+++ b/guides/content/personas/health-catalyst-engagement-lead.md
@@ -20,8 +20,6 @@ The EL has primary accountability for the success of our client engagements. Suc
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -48,7 +46,5 @@ The EL has primary accountability for the success of our client engagements. Suc
 -   Reminders of their upcoming appointments, include when, where, and how to prepare
 -   Information that they can easily access to answer questions and learn more about their conditions
 -   Care that addresses their specific social, financial, and mental health barriers
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-software-engineer.md
+++ b/guides/content/personas/health-catalyst-software-engineer.md
@@ -20,8 +20,6 @@ Developing modern web apps built with current frameworks and consuming data thro
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -35,7 +33,5 @@ Developing modern web apps built with current frameworks and consuming data thro
 -   Build integrations between IDEA apps and mobile apps
 -   Write on top of the IDEA API on data that is automatically integrated with the EDW
 -   Understand what's possible with the IDEA API
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-technical-director.md
+++ b/guides/content/personas/health-catalyst-technical-director.md
@@ -20,8 +20,6 @@ Kiri develops and executes strategies of implementing proprietary data warehousi
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -46,7 +44,5 @@ Kiri develops and executes strategies of implementing proprietary data warehousi
 -   Presentation and documentation tools
 -   Audit and usage dashboards (e.g., QlikView and other visualization tools)
 -   Tool for fixing coding errors (e.g., a text editor)
-
-</article>
 
 :::

--- a/guides/content/personas/health-catalyst-vitalware-user.md
+++ b/guides/content/personas/health-catalyst-vitalware-user.md
@@ -18,8 +18,6 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
@@ -27,30 +25,16 @@
 -   Internal Vitalware User
 -   Technical Level – Varies. Could be developer, client experience person, or any other person in the organization.
 
-
-
-
-
-
 ---
 
 ## Responsibilities
 
 -   To help create and support VitalWare software.
 
-
-
-
-
 ---
 
 ## Pain Points
 
 -   Some of my processes are difficult or time-consuming, so I need help.
-
-
-
-
-</article>
 
 :::

--- a/guides/content/personas/healthcare-executive.md
+++ b/guides/content/personas/healthcare-executive.md
@@ -20,8 +20,6 @@ This busy leader has historically relied on manual data capture for reporting (s
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -50,7 +48,5 @@ This busy leader has historically relied on manual data capture for reporting (s
 -   Analyze the domain area population for problems and opportunities for improvement (for example, to reduce costs, improve care, reduce utilization, etc.)
 -   Track costs trends over time and identify the root cause of changes in cost trends
 -   Review specific patients to identify gaps in care related to domain area
-
-</article>
 
 :::

--- a/guides/content/personas/inpatient-clinician.md
+++ b/guides/content/personas/inpatient-clinician.md
@@ -20,8 +20,6 @@ Primarily cares for patients by monitoring them, administering medications, cons
 
 </div>
 
-<article>
-
 ---
 
 ## Needs & Responsibilities
@@ -32,7 +30,5 @@ Primarily cares for patients by monitoring them, administering medications, cons
 -   Access to data that is refreshed e.g. every 6 hours ( e.g. timed for change of shift, sign out, and/or rounds)
 -   Have some way to report back that they have reviewed the risk for the patient
 -   Have some way to document intervention(s) for a new high-risk or increasing risk for the patient they are assigned to
-
-</article>
 
 :::

--- a/guides/content/personas/lead-physician.md
+++ b/guides/content/personas/lead-physician.md
@@ -20,8 +20,6 @@ Dr. Haugen frequently monitors data on quality, safety, appropriateness, and ove
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -48,7 +46,5 @@ Dr. Haugen frequently monitors data on quality, safety, appropriateness, and ove
 -   Ability to facilitate discussions among the multidisciplinary work group, supported by the appropriate data
 -   Investigate / validate potential opportunities for improvement delegated by a [Healthcare Executive](/content/personas/healthcare-executive).
 -   Ability to create reports that convey where and by whom processes and interventions are not being followed
-
-</article>
 
 :::

--- a/guides/content/personas/network-administrator.md
+++ b/guides/content/personas/network-administrator.md
@@ -18,17 +18,12 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
 
 -   Monthly
 -   Technical Level – High
-
-
-
 
 ---
 
@@ -38,8 +33,6 @@
 -   Several competing IT projects going on simultaneously with many ad hoc requests that arise regularly
 -   I am the only IT expert onsite at all times to handle any IT-related issues so I can't spend a lot of time on anything that is not a top priority
 
-
-
 ---
 
 ## Pain Points
@@ -47,10 +40,5 @@
 -   If I am unable to protect PHI, the hospital will be at risk for a HIPPA violation and subject to possible fines.
 -   I must have a specific set of data returned to me to update the system automatically so that I don't have to do anything manually (integration) or billings will not go out the door with the most accurate information.
 -   I need to be able to set up a job that will send data to an SFTP automatically (Automated data Transfer) or the most recent data will not be available for use leading to inaccurate reporting and delayed workflow processes.
-
-
-
-
-</article>
 
 :::

--- a/guides/content/personas/nursing-lead.md
+++ b/guides/content/personas/nursing-lead.md
@@ -20,8 +20,6 @@ Very often monitors process data for her facility and/or department. When there 
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -46,5 +44,4 @@ Very often monitors process data for her facility and/or department. When there 
 -   Timely summary of process misses to enable immediate investigation
 -   List of prioritized patients along with prior and suggested interventions
 
-</article>
 :::

--- a/guides/content/personas/patient-safety-clinical-investigator.md
+++ b/guides/content/personas/patient-safety-clinical-investigator.md
@@ -29,8 +29,6 @@ Expert Clinical Reviewer and patient safety engagement lead.  Workflow is genera
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -54,7 +52,5 @@ Expert Clinical Reviewer and patient safety engagement lead.  Workflow is genera
 -   Provide real-time feedback to the Unit leadership and Risk Management on high-harm events
 -   Facilitate and drive improvement efforts based on patient safety findings
 -   Cost and utilization analytics
-
-</article>
 
 :::

--- a/guides/content/personas/pharmacy-cdm-manager.md
+++ b/guides/content/personas/pharmacy-cdm-manager.md
@@ -18,8 +18,6 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
@@ -42,7 +40,5 @@
 -   I don't have visibility into the details of Willow, especially around billing so visibility into the formulary helps.
 -   I am responsible for managing Pharmacy, but I am not a pharmacist so some of the complicated terminology is confusing and I don't fully understand drug dosage on a pharmacist level.
 -   I am responsible for multiple parts of the CDM, so efficiency is important. I don't have time to really spend researching and need reports that are easily consumable.
-
-</article>
 
 :::

--- a/guides/content/personas/population-health-analyst.md
+++ b/guides/content/personas/population-health-analyst.md
@@ -20,8 +20,6 @@ She has experience and expertise with analytics tools and data from one or more 
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -44,7 +42,5 @@ She has experience and expertise with analytics tools and data from one or more 
     -   Capture the date of intervention start—and then track different metrics from that point
     -   Answer: Have we decreased variation and made significant difference in a specific metric, outcome, or process aim from target?
     -   Attribute the impact to the intervention
-
-</article>
 
 :::

--- a/guides/content/personas/program-director.md
+++ b/guides/content/personas/program-director.md
@@ -20,8 +20,6 @@ The program manager or director is accountable for performance and outcomes impr
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -45,7 +43,5 @@ The program manager or director is accountable for performance and outcomes impr
 -   Use multiple methods to export data for effective communication (Excel, visualizations)
 -   Share targeted feedback with frontline providers or nurses who may not be checking the app regularly (via EMR, email, or another mechanism)
     -   This includes sharing information only applicable to a specific provider (not all providers)
-
-</article>
 
 :::

--- a/guides/content/personas/revenue-integrity-analyst.md
+++ b/guides/content/personas/revenue-integrity-analyst.md
@@ -18,16 +18,12 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
 
 -   Daily User – in addition to other duties & responsibilities
 -   Technical Level – Basic
-
-
 
 ---
 
@@ -39,8 +35,6 @@
 -   Identifies and corrects root cause issues
 -   Is greatly affected by all product outages and slowdowns that have a negative impact on daily workflow will have a domino effect
 
-
-
 ---
 
 ## Pain Points
@@ -48,9 +42,5 @@
 -   If I can't find regulatory content in one place, it takes me a long time to track it down.
 -   When I have to enter duplicate information in an external workflow system and my PAS, this adds time and increases the risks associated with entering the wrong information.
 -  The more accounts I have to rebill adds time and cost.
-
-
-
-</article>
 
 :::

--- a/guides/content/personas/self-enrolled-patient.md
+++ b/guides/content/personas/self-enrolled-patient.md
@@ -20,8 +20,6 @@ Older individual with increasing medical needs, limited medical knowledge and in
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -36,7 +34,5 @@ Older individual with increasing medical needs, limited medical knowledge and in
 
 -   Ability to easily contact their providers and schedule appointments
 -   Information that they can easily access to answer questions and learn more about their conditions
-
-</article>
 
 :::

--- a/guides/content/personas/system-administrator.md
+++ b/guides/content/personas/system-administrator.md
@@ -20,8 +20,6 @@ System Administrator is responsible for installing new software releases, system
 
 </div>
 
-<article>
-
 ---
 
 ## Goals
@@ -36,7 +34,5 @@ System Administrator is responsible for installing new software releases, system
 ## Needs
 
 -   A centralized tool to grant or remove access for users and/or groups to software applications used by the hospital system
-
-</article>
 
 :::

--- a/guides/content/personas/vitalware-director-of-revenue-integrity.md
+++ b/guides/content/personas/vitalware-director-of-revenue-integrity.md
@@ -18,17 +18,12 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
 
 -   Weekly
 -   Technical Level – High
-
-
-
 
 ---
 
@@ -41,8 +36,6 @@
 -   Performs QA of analysis/rule results
 -   Creates and manages rule sets
 
-
-
 ---
 
 ## Pain Points
@@ -50,11 +43,5 @@
 -   I must perform ongoing rule inventory and management, as well as data validation.
 -   I need to ensure a consistent, comprehensive and effective client onboarding process.
 -   I identify issues affecting rule performance and need to recognize when rules are malfunctioning. If I don't catch it right away, then costs begin to add up quickly.
-
-
-
-
-
-</article>
 
 :::

--- a/guides/content/personas/vp-revenue-cycle.md
+++ b/guides/content/personas/vp-revenue-cycle.md
@@ -18,18 +18,12 @@
 
 </div>
 
-<article>
-
 ---
 
 ## Role
 
 -   Weekly Report user
 -   Technical Level – Medium
-
-
-
-
 
 ---
 
@@ -38,10 +32,6 @@
 -   Interested in ROI and resource utilization
 -   Needs succinct & precise dashboards and complete high-level reports
 -   Prefers high-level reports automated so that he does not need to log into the system
-
-
-
-
 
 ---
 
@@ -53,10 +43,5 @@
 -   If I can't understand where the company could be losing money then I won't be able to understand where exactly our financial gaps are located.
 -   If I am unable to increase productivity (do more with less FTE's) then our costs go up and become a strain on our entire organization.
 -   If I am unable to increase revenue the hospital will face financial strains that impact its entire operations and existence.
-
-
-
-
-</article>
 
 :::

--- a/guides/content/references.md
+++ b/guides/content/references.md
@@ -3,7 +3,6 @@
 ###### Last updated April 6, 2021
 
 :::
-<article>
 
 ##### When to Cite a Source
 
@@ -12,29 +11,20 @@ We **must** cite a source for any of the following appearing in a document or pr
  - Claim
  - Number
 
-</article>
-
 :::
 
 :::
-
-<article>
-
 
 ##### How to Ensure Sources are Credible
 
 It is important to gauge the credibility of any book, article, report, or website you cite as a source. Follow these guidelines to evaluate your sources:
-1. Above all, consider credibility. Cite a government website, a well-known organization, or mainstream media outlet before any other source. Be sure the information is on the main page of a current website (outdated information might live in locations other than the main, current URL). 
+1. Above all, consider credibility. Cite a government website, a well-known organization, or mainstream media outlet before any other source. Be sure the information is on the main page of a current website (outdated information might live in locations other than the main, current URL).
 2. Avoid citing Wikipedia, a dictionary, or an encyclopedia. These may be good starting places for research, but they do nothing to add credibility because they are often secondary sources of information.
 3. Do not cite other vendors.
 
-</article>
-
 :::
 
 :::
-
-<article>
 
 ##### What Style to Use
 
@@ -53,13 +43,11 @@ Examples:
 
 |          | Website Source | Article Source |
 |----------|--------------------|---------------------|
-|APA Standard Style| Ouellette, J. (2019, November 15). Physicists capture first footage of quantum knots unraveling in superfluid. *Ars Technica*. [https://arstechnica.com/science/2019/11/study-you-can-tie-a-quantum-knot-in-a-superfluid-but-it-will-soon-untie-itself/](https://arstechnica.com/science/2019/11/study-you-can-tie-a-quantum-knot-in-a-superfluid-but-it-will-soon-untie-itself/) | Grady, J. S., Her, M., Moreno, G., Perez, C., & Yelinek, J. (2019). Emotions in storybooks: A comparison of storybooks that represent ethnic and racial groups in the United States. *Psychology of Popular Media Culture, 8*(3), 207–217. [https://doi.org/10.1037/ppm0000185](https://doi.org/10.1037/ppm0000185)  | |----------------|---------------------|-------------------| 
+|APA Standard Style| Ouellette, J. (2019, November 15). Physicists capture first footage of quantum knots unraveling in superfluid. *Ars Technica*. [https://arstechnica.com/science/2019/11/study-you-can-tie-a-quantum-knot-in-a-superfluid-but-it-will-soon-untie-itself/](https://arstechnica.com/science/2019/11/study-you-can-tie-a-quantum-knot-in-a-superfluid-but-it-will-soon-untie-itself/) | Grady, J. S., Her, M., Moreno, G., Perez, C., & Yelinek, J. (2019). Emotions in storybooks: A comparison of storybooks that represent ethnic and racial groups in the United States. *Psychology of Popular Media Culture, 8*(3), 207–217. [https://doi.org/10.1037/ppm0000185](https://doi.org/10.1037/ppm0000185)  | |----------------|---------------------|-------------------|
 |HCAT Modified Style | Ouellette, J. (2019). Physicists capture first footage of quantum knots unraveling in superfluid. *Ars Technica*. Retrieved from [https://arstechnica.com/science/2019/11/study-you-can-tie-a-quantum-knot-in-a-superfluid-but-it-will-soon-untie-itself/](https://arstechnica.com/science/2019/11/study-you-can-tie-a-quantum-knot-in-a-superfluid-but-it-will-soon-untie-itself/)   | Grady, J. S., et al. (2019). Emotions in storybooks: A comparison of storybooks that represent ethnic and racial groups in the United States. *Psychology of Popular Media Culture, 8*(3), 207–217. Retrieved from [https://psycnet.apa.org/record/2018-12099-001](https://psycnet.apa.org/record/2018-12099-001) |
 
 Exceptions:
 - **For internal-only content**, you can limit the citation to just what's needed to find the source (e.g., article title and link).
-- **For web content**, hyperlink to the source. Use the name of the publication or website as the hypertext ([Insights](https://www.healthcatalyst.com/knowledge-center/insights/) on [healthcatalyst.com](healthcatalyst.com) uses this convention). 
-
-</article>
+- **For web content**, hyperlink to the source. Use the name of the publication or website as the hypertext ([Insights](https://www.healthcatalyst.com/knowledge-center/insights/) on [healthcatalyst.com](healthcatalyst.com) uses this convention).
 
 :::

--- a/src/app/shared/markdown/markdown.directive.ts
+++ b/src/app/shared/markdown/markdown.directive.ts
@@ -47,6 +47,12 @@ export class MarkdownDirective implements OnChanges {
             }
         }
 
+        // Add an article tag to all lists in markdown to include Cashmere list styling
+        const listTags: Array<HTMLElement> = this.el.nativeElement.querySelectorAll('ul,ol');
+        for (const list of listTags) {
+            list.outerHTML = '<article>' + list.outerHTML + '</article>';
+        }
+
         this.loaded.emit( true );
     }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -25,7 +25,7 @@ body {
 
     ul {
         margin: 12px 0;
-        list-style: disc inside;
+        list-style: disc;
     }
 
     :not(article) > ol {


### PR DESCRIPTION
ol and ul lists in markdown files are now wrapped in an article tag

@heathkat I had a little time this morning so I went ahead and took care of this.  Such a great suggestion - look at how much unnecessary code this removes (568 lines!).  And it really improves the formatting on many of the developer guides that had lists but weren't previously wrapped in article tags.  So a huge thank you for calling this out - and again to @cedar-ave for building these styles into the library.

@kei02003 - wanted to make sure you were aware of this fix now, because we were using `<article>` tags around all our lists in the Analytics markdown files.  But now that article tag will be automatically added, so one less thing to remember.  I took care of removing all the existing article tags.

closes #1571