### PR TITLE
fix(navbar): calculate link widths after page load

### DIFF
--- a/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
+++ b/projects/cashmere/src/lib/navbar/navbar.component.spec.ts
@@ -59,15 +59,6 @@ describe('NavbarComponent', () => {
         });
     });
 
-    describe('on calling all the lifecycle hooks', () => {
-        it('should call refreshNavLinks', waitForAsync(() => {
-            spyOn(testHostComponent.navbarComponent, 'refreshNavLinks');
-            testHostComponent.navbarComponent.ngAfterViewInit();
-            testHostFixture.whenStable().then(() => {
-                expect(testHostComponent.navbarComponent.refreshNavLinks).toHaveBeenCalled();
-            });
-        }));
-    });
     describe('on calling refreshNavLinks', () => {
         describe('and adjust the elements according to the navbar size', () => {
             it('should have nothing in moreList if navbar links container > linksTotalWidth', () => {

--- a/projects/cashmere/src/lib/navbar/navbar.component.ts
+++ b/projects/cashmere/src/lib/navbar/navbar.component.ts
@@ -1,5 +1,4 @@
 import {
-    AfterViewInit,
     ChangeDetectorRef,
     Component,
     ContentChildren,
@@ -28,7 +27,7 @@ import {NavbarDropdownComponent} from './navbar-dropdown/navbar-dropdown.compone
     styleUrls: ['./navbar.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
-export class NavbarComponent implements AfterViewInit, OnDestroy {
+export class NavbarComponent implements OnDestroy {
     /** Display name of current user */
     @Input()
     user: string = '';
@@ -71,6 +70,15 @@ export class NavbarComponent implements AfterViewInit, OnDestroy {
     private _linksTotalWidth: number = 0;
     public _collapse: boolean = false;
     public _moreList: Array<MoreItem> = [];
+
+    /** Runs the initial calculation of navlink widths after the page has fully rendered */
+    @HostListener('window:load')
+    _setupNavLinks() {
+        this.refreshNavLinks();
+
+        // If links are added dynamically, recheck the navbar link sizing
+        this._navLinks.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.refreshNavLinks());
+    }
 
     /** Forces a recalculation of the navbar links to determine how many should be rolling into a More menu.
      * Call this if you've updated the contents of any navbar links. */
@@ -142,15 +150,6 @@ export class NavbarComponent implements AfterViewInit, OnDestroy {
                 t.hide();
             }
         });
-    }
-
-    ngAfterViewInit() {
-        setTimeout(() => {
-            this.refreshNavLinks();
-        }, 100);
-
-        // If links are added dynamically, recheck the navbar link sizing
-        this._navLinks.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.refreshNavLinks());
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
remove dependency on setTimeout, listen to `window:load` event

@corykon @MarielaCisneros @WistyDagel - inspiration struck today after we were talking about this, and I think I've got a fix that removes the `setTimeout` dependency.  Unfortunately, Angular's lifecycle hooks don't seem to be getting us what we want in this instance, but the standard [Window load event](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event) does.  It's fired after the page is fully rendered, which is what we need to get a proper width calculation on all the link elements.

So I _think_ this works...at least everything I could think to test seemed to check out.  Can you all give it a try as well?  And @pheebner - not sure if you can test it out before the fix is merged, but would love to hear your thoughts as well.

Note that I removed one unit test that was no longer useful since we aren't using the Angular lifecycle hook anymore.

closes #1473