### PR TITLE
fix(code styles): refresh code block styles

### DIFF
--- a/projects/cashmere/src/lib/sass/_code-highlight.scss
+++ b/projects/cashmere/src/lib/sass/_code-highlight.scss
@@ -1,10 +1,14 @@
+@import './colors';
+@import './variables';
+@import './mixins';
+
 /** Adapted from https://github.com/atom-material/atom-material-syntax-light */
 .hljs {
     display: block;
     overflow-x: auto;
-    padding: 1em;
-    background: #fafafa;
-    color: #37474f;
+    padding: 0;
+    background: $block-text-background;
+    color: $slate-gray-500;
     -webkit-font-smoothing: antialiased;
     text-size-adjust: 100%;
     font: 300 100%/1 Roboto Mono, monospace;
@@ -13,11 +17,11 @@
 
 .hljs > *::selection,
 .hljs-section {
-    background-color: #d6edea;
+    background-color: $white;
 }
 
 .hljs-comment {
-    color: #b0bec5;
+    color: darken($slate-gray-300, 5%);
     font-style: italic;
 }
 
@@ -25,25 +29,25 @@
 .hljs-selector-tag,
 .hljs-regexp,
 .hljs-meta {
-    color: #9c27b0;
+    color: $magenta
 }
 
 .hljs-string,
 .hljs-subst {
-    color: #0d904f;
+    color: $green;
 }
 
 .hljs-number,
 .hljs-variable,
 .hljs-template-variable {
-    color: #80cbc4;
+    color: $teal;
 }
 
 .hljs-name,
 .hljs-keyword,
 .hljs-type,
 .hljs-attribute {
-    color: #3b78e7;
+    color: shade($blue, 20%);
 }
 
 .hljs-title,
@@ -53,28 +57,28 @@
 .hljs-built_in,
 .hljs-builtin-name,
 .hljs-link {
-    color: #6182b8;
+    color: $dark-blue;
 }
 
 .hljs-params {
-    color: #d81b60;
+    color: $deep-red;
 }
 
 .hljs-addition {
-    color: #3b78e7;
+    color: $azure;
     display: inline-block;
     width: 100%;
 }
 
 .hljs-deletion {
-    color: #e53935;
+    color: $red-orange;
     display: inline-block;
     width: 100%;
 }
 
 .hljs-selector-id,
 .hljs-selector-class {
-    color: #8796b0;
+    color: $slate-gray-400;
 }
 
 .hljs-emphasis {

--- a/projects/cashmere/src/lib/sass/_colors.scss
+++ b/projects/cashmere/src/lib/sass/_colors.scss
@@ -53,4 +53,4 @@ $destructive-action: $red;
 $neutral-action: $gray-500;
 $error: $deep-red;
 $text: $offblack;
-$block-text-background: $gray-100;
+$block-text-background: $slate-gray-100;

--- a/projects/cashmere/src/lib/sass/_typography.scss
+++ b/projects/cashmere/src/lib/sass/_typography.scss
@@ -2,8 +2,6 @@
 @import './variables';
 @import './mixins';
 
-$code-padding: 10px;
-
 html,
 body {
     font-family: $default-font-family;
@@ -51,7 +49,7 @@ p {
 
 // for inline code
 code {
-    color: $magenta;
+    color: $slate-gray-500;
     font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
     background-color: $block-text-background;
     border-radius: 3px;
@@ -63,8 +61,8 @@ code {
 
 // for code blocks
 pre {
-    border: 1px solid $gray-400;
-    padding: 20px;
+    border: 1px solid $slate-gray-200;
+    padding: 0;
     margin: 16px auto;
     border-radius: 5px;
     display: block;
@@ -74,7 +72,7 @@ pre {
     > span {
         @include fontSize(14px);
         line-height: 1.4;
-        padding: $code-padding 0;
+        padding: 15px 0;
         background-color: $block-text-background;
     }
 
@@ -82,12 +80,12 @@ pre {
         overflow-x: auto;
         display: block;
         @include fontSize(14px);
-        padding: $code-padding;
+        padding: 15px;
         line-height: 1.4;
         background-color: $block-text-background;
         color: $text;
         border: unset;
-        border-radius: unset;
+        border-radius: 5px;
     }
 }
 

--- a/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
+++ b/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.scss
@@ -33,6 +33,10 @@
     margin: 30px 0 5px 0;
 }
 
+p.docs-api-module-import code {
+    color: $dark-blue;
+}
+
 .docs-api-class-extends-clauses {
     @include fontSize(20px);
     font-weight: 300;
@@ -61,9 +65,7 @@
 
     code {
         @include fontSize(13px);
-        background-color: unset;
         border-radius: unset;
-        padding: unset;
         font-weight: unset;
         line-height: unset;
     }
@@ -92,11 +94,9 @@
     }
 
     code {
-        @include fontSize(13px);
-        color: $text;
-        background-color: unset;
+        @include fontSize(14px);
+        color: $dark-blue;
         border-radius: unset;
-        padding: unset;
         font-weight: unset;
         line-height: unset;
     }
@@ -116,13 +116,14 @@
     margin-top: 0;
 }
 
-.docs-api-method-parameter-type,
-.docs-api-method-returns-type {
+code.docs-api-method-parameter-type,
+code.docs-api-method-returns-type {
     font-size: 0.85714286rem !important;
+    color: $slate-gray-500;
 }
 
-.docs-api-method-returns-type {
-    padding-left: 25px !important;
+code.docs-api-method-returns-type {
+    margin-left: 25px !important;
 }
 
 .docs-api-method-name-cell {

--- a/src/app/foundations/code/code-demo.component.scss
+++ b/src/app/foundations/code/code-demo.component.scss
@@ -1,3 +1,6 @@
-.api-table li {
-    margin: 15px 0;
+.api-table {
+    td, th { padding-right: 30px; }
+    li {
+        margin: 15px 0;
+    }
 }

--- a/src/app/foundations/typography/typography-demo.component.scss
+++ b/src/app/foundations/typography/typography-demo.component.scss
@@ -1,7 +1,10 @@
 @import 'scss/colors';
 
-.api-table li {
-    margin: 15px 0;
+.api-table {
+    td, th { padding-right: 30px; }
+    li {
+        margin: 15px 0;
+    }
 }
 
 h1,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -276,9 +276,8 @@ table {
     > span {
         display: block;
         padding: 0 0.5em 0 1em;
-        border-right: 1px solid;
         margin-right: 5px;
-        color: rgba($gray-600, 0.5);
+        color: $gray-300;
         @include fontSize(14px);
         font-family: Consolas, Menlo, 'Ubuntu Mono', monospace;
     }

--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -26,7 +26,7 @@
   <thead>
     <tr class="docs-api-method-name-row">
       <th colspan="2" class="docs-api-method-name-cell">
-        {%- if method.isDeprecated -%}
+        <code>{%- if method.isDeprecated -%}</code>
           <div class="docs-api-deprecated-marker" {$ macros.deprecationTitle(method) $}>
             Deprecated
           </div>


### PR DESCRIPTION
re #956 Decided against doing a dark mode. It would've been difficult to show it without more intensive changes to the way we display markdown.

Changes are pretty minimal, but code blocks are cleaner and now use cashmere colors. Before on the left, and after on the right

![codestyles1](https://user-images.githubusercontent.com/12416432/116334644-cf4e2180-a792-11eb-986c-3daa97aabdaf.gif)


![codestyles2](https://user-images.githubusercontent.com/12416432/116334652-d117e500-a792-11eb-9d6b-be6a089d8331.gif)
