### PR TITLE
fix(sort-icon): no longer shrinks

### DIFF
--- a/projects/cashmere/src/lib/sass/sort.scss
+++ b/projects/cashmere/src/lib/sass/sort.scss
@@ -63,8 +63,11 @@
     background-repeat: no-repeat;
     display: block;
     height: 13px;
-    margin-left: 15px;
     width: 13px;
+    min-width: 20px !important;
+    margin-left: 5px !important;
+    align-self: flex-end;
+    margin-bottom: 4px;
 }
 
 @mixin hc-sort-header-asc() {


### PR DESCRIPTION
The header-icon no longer shrinks depending on the size of the table. It is now at a fixed width.

closes #1635

Old version:
![image](https://user-images.githubusercontent.com/8591906/120721467-21b5e880-c48b-11eb-8ff5-30c922cf06fa.png)

New Version: 
![image](https://user-images.githubusercontent.com/8591906/120721444-1793ea00-c48b-11eb-97e0-b23bb0505916.png)
