### PR TITLE
fix(docs): typo error

### DIFF
--- a/src/app/content/personas/persona-org/persona-org.component.html
+++ b/src/app/content/personas/persona-org/persona-org.component.html
@@ -1,22 +1,19 @@
 <div class="demo-content">
-    <h1>Persona Organzation Chart</h1>
+    <h1>Persona Organization Chart</h1>
     <h6>Last updated Nov 30, 2020</h6>
 
     <hc-tile>
         <h5 id="overview">Overview</h5>
 
         <p>
-            Health Catalyst's customers encompass a broad range of healthcare professionals.
-            We have developed a collection of user personas that represent archetypes of these individuals.
-            These personas help us illustrate the wants, needs, and goals of groups within our customers.
-            Each of our products and services has their own primary and secondary personas, and as an organization it’s important that we understand how they all fit together.
-            The hypothetical organization chart below is one way to visualize that.
+            Health Catalyst's customers encompass a broad range of healthcare professionals. We have developed a collection of user personas that represent archetypes of these individuals. These personas help us illustrate the wants, needs, and goals of groups within
+            our customers. Each of our products and services has their own primary and secondary personas, and as an organization it’s important that we understand how they all fit together. The hypothetical organization chart below is one way to visualize
+            that.
         </p>
 
         <p>
-            Health Catalyst products and services are design to meet the needs of not only external customers, but also internal team members.
-            As a result, the chart below is divided into sections of external buyers/users and internal users.
-            A complete listing of all our available personas may be found on the <a [queryParams]="{referrer: 'chart'}" routerLink="/content/personas">Persona List</a> page.
+            Health Catalyst products and services are design to meet the needs of not only external customers, but also internal team members. As a result, the chart below is divided into sections of external buyers/users and internal users. A complete listing of
+            all our available personas may be found on the <a [queryParams]="{referrer: 'chart'}" routerLink="/content/personas">Persona List</a> page.
         </p>
     </hc-tile>
 
@@ -24,7 +21,7 @@
         <h5 id="organization-chart">Organization Chart</h5>
 
         <div class="org-container">
-            <img src="./assets/persona_org_chart.png" alt="Persona Org Chart" width="2784" height="580" usemap="#OrgChartMap"/>
+            <img src="./assets/persona_org_chart.png" alt="Persona Org Chart" width="2784" height="580" usemap="#OrgChartMap" />
         </div>
     </hc-tile>
 


### PR DESCRIPTION
adds "i" to spell Organization correctly in this headline on this page (https://cashmere.healthcatalyst.net/content/org-chart)