### PR TITLE
docs(markdown): fix breadcrumbs styles

### DIFF
--- a/src/app/shared/markdown/markdown.directive.ts
+++ b/src/app/shared/markdown/markdown.directive.ts
@@ -50,7 +50,9 @@ export class MarkdownDirective implements OnChanges {
         // Add an article tag to all lists in markdown to include Cashmere list styling
         const listTags: Array<HTMLElement> = this.el.nativeElement.querySelectorAll('ul,ol');
         for (const list of listTags) {
-            list.outerHTML = '<article>' + list.outerHTML + '</article>';
+            if ( !list.classList.contains('breadcrumb') ) {
+                list.outerHTML = '<article>' + list.outerHTML + '</article>';
+            }
         }
 
         this.loaded.emit( true );


### PR DESCRIPTION
removes unintentional article tag on breadcrumb html

closes #1711