### PR TITLE
fix(env switcher): don't show info icon if no description is available

### DIFF
--- a/projects/cashmere-examples/src/lib/environment-switcher-overview/environment-switcher-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/environment-switcher-overview/environment-switcher-overview-example.component.ts
@@ -33,7 +33,7 @@ export class EnvironmentSwitcherOverviewExampleComponent {
             tenantCode: 'HCAT',
             name: 'Test',
             shortName: 'TEST',
-            description: 'Environment for integration testing.',
+            description: '',
             color: '#F13C45'
         }
     ];

--- a/projects/cashmere/src/lib/env-switcher/env-switcher.component.html
+++ b/projects/cashmere/src/lib/env-switcher/env-switcher.component.html
@@ -27,9 +27,8 @@
                             {{env.name}}
                         </hc-checkbox>
                         <span class="hc-env-row-icons">
-                            <span class="hc-env-icon-info hc-env-row-icon"
-                                hcTooltip="{{env.description || 'No description provided'}}"
-                                (click)="$event.stopPropagation();"></span>
+                            <span *ngIf="env.description" class="hc-env-icon-info hc-env-row-icon"
+                                hcTooltip="{{env.description}}" (click)="$event.stopPropagation();"></span>
                             <span *ngIf="canOpenInNewTab" class="hc-env-icon-new-tab-link hc-env-row-icon"
                                 hcTooltip="Open environment in new tab."
                                 (click)="openInNewTab.emit(env); $event.stopPropagation();"></span>


### PR DESCRIPTION
re #1695

![image](https://user-images.githubusercontent.com/12416432/143946028-08ac28ea-3fe0-45a4-98fa-495eb89418ca.png)
