### PR TITLE
fix(navbar): fix `active` input

### DIFF
--- a/projects/cashmere/src/lib/navbar/navbar-dropdown/navbar-dropdown.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar-dropdown/navbar-dropdown.component.html
@@ -3,7 +3,7 @@
     title="{{linkText}}"
     routerLinkActive="active"
     class="navbar-dropdown"
-    [ngClass]="{active: this.active === true, inactive: this.active === false}"
+    [ngClass]="{'force-active': this.active === true, 'force-inactive': this.active === false}"
     [hcPop]="menuPop"
     tabindex="0"
 >
@@ -14,3 +14,4 @@
 <hc-pop #menuPop [autoCloseOnContentClick]="true" [showArrow]="false">
     <ng-content></ng-content>
 </hc-pop>
+

--- a/projects/cashmere/src/lib/navbar/navbar-link/navbar-link.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar-link/navbar-link.component.html
@@ -1,5 +1,5 @@
 <a *ngIf="!_hidden" title="{{linkText}}" [routerLink]="uri" routerLinkActive="active" class="navbar-link"
-    [ngClass]="{ 'active': this.active === true, 'inactive': this.active === false }"
-    [routerLinkActiveOptions]="{exact: this.active}">
+    [ngClass]="{ 'force-active': this.active === true, 'force-inactive': this.active === false }"
+    [routerLinkActiveOptions]="{exact: this.exact}">
     {{linkText}}<ng-content></ng-content>
 </a>

--- a/projects/cashmere/src/lib/sass/navbar.scss
+++ b/projects/cashmere/src/lib/sass/navbar.scss
@@ -123,22 +123,43 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     border-bottom: 5px solid transparent;
     transition: background-color 0.25s;
     outline: none;
-    &:hover:not(.active),
-    &.inactive:hover {
-        outline: none;
-        color: $navbar-text;
-        background-color: darken($navbar-color, 5%);
-    }
     &:focus {
         outline: none;
         color: $navbar-text;
         background-color: darken($navbar-color, 8%);
     }
-    &:active:not(.inactive),
-    &.active:not(.inactive) {
+    &:hover {
+        outline: none;
+        font-weight: 400;
+        color: $navbar-text;
+        background-color: darken($navbar-color, 5%);
+    }
+    &:active,
+    &.active,
+    &.force-active {
         color: $navbar-text;
         font-weight: 600;
         border-bottom: 5px solid $navbar-brand;
+    }
+
+    &.active:hover,
+    &.force-active:hover {
+        font-weight: 600;
+    }
+
+    &:active {
+        background-color: darken($navbar-color, 8%);
+    }
+
+    &.force-inactive {
+        color: $navbar-text-inactive;
+        font-weight: 400;
+        border-bottom: 5px solid transparent;
+
+        &:hover,
+        &:focus {
+            color: $navbar-text;
+        }
     }
 
     // This piece of code allows to use the bold styling from the style guide, while
@@ -176,7 +197,7 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
     cursor: pointer;
     transition: background-color 0.25s;
     &:hover:not(.active),
-    &.inactive:hover {
+    &.force-inactive:hover {
         outline: none;
         color: $navbar-text;
         background-color: darken($navbar-color, 5%);
@@ -243,27 +264,48 @@ $navbar-fixed-shadow: 0px 2px 6px $shadow;
         font-size: 13px !important;
     }
 
-    &:hover:not(.active),
-    &.inactive:hover {
-        outline: none;
-        color: $navbar-text;
-        background-color: darken($navbar-color, 5%);
-    }
     &:focus {
         outline: none;
         color: $navbar-text;
         background-color: darken($navbar-color, 8%);
     }
-    &.active:not(.inactive) {
+    &:hover {
+        outline: none;
+        font-weight: 400;
+        color: $navbar-text;
+        background-color: darken($navbar-color, 5%);
+    }
+    &.active,
+    &.force-active {
         color: $navbar-text;
         font-weight: 600;
         border-bottom: 5px solid $navbar-brand;
+
+        &:hover {
+            font-weight: 600;
+        }
     }
 
-    &:hover:not(.active),
-    &.inactive:hover,
+    &:active {
+        background-color: darken($navbar-color, 8%);
+    }
+
+    &.force-inactive {
+        color: $navbar-text-inactive;
+        font-weight: 400;
+        border-bottom: 5px solid transparent;
+
+        &:hover,
+        &:focus {
+            color: $navbar-text;
+        }
+    }
+
+    &:hover,
+    &.force-inactive:hover,
     &:focus,
-    &.active:not(.inactive) {
+    &.active,
+    &.force-active {
         .hc-navbar-ico-chevron-down {
             background-image: url($ico-chev-down-white);
             background-repeat: no-repeat;


### PR DESCRIPTION
fix #1673

Took some battling, but eventually got it to repro and was able find a fix.

Solution was to use 'force-active' class instead of just 'active', because we were using an 'active' class for the built in route-based underlining and sometimes it was causing conflicts.