### PR TITLE
fix(popover): update after reposition

### DIFF
--- a/projects/cashmere-examples/src/lib/popover-fixed-position/popover-fixed-position-example.component.html
+++ b/projects/cashmere-examples/src/lib/popover-fixed-position/popover-fixed-position-example.component.html
@@ -1,0 +1,24 @@
+<div [hcPop]="fixedPop" trigger="none">
+
+    <p class="hc-font-sm">
+        Popovers may be set to fixed locations in the window. Set the position of the popover via the <code>open</code> function.
+        Attach the popover to <code>body</code> or any container and set the <code>trigger</code> to "none".
+    </p>
+
+    <div class="popover-fixed-inputs">
+        <hc-form-field>
+            <hc-label>Horizontal Position:</hc-label>
+            <input hcInput [formControl]="xPos" type="number"/>
+        </hc-form-field>
+
+        <hc-form-field>
+            <hc-label>Vertical Position:</hc-label>
+            <input hcInput [formControl]="yPos" type="number"/>
+        </hc-form-field>
+    </div>
+
+    <button hc-button buttonStyle="primary" (click)="fixedPop.open({ x: xPos.value, y: yPos.value })">Trigger</button>
+
+</div>
+
+<hc-pop #fixedPop [showArrow]="false">I'm a fixed position popover at location: ({{xPos.value}}px, {{yPos.value}}px).</hc-pop>

--- a/projects/cashmere-examples/src/lib/popover-fixed-position/popover-fixed-position-example.component.scss
+++ b/projects/cashmere-examples/src/lib/popover-fixed-position/popover-fixed-position-example.component.scss
@@ -1,0 +1,9 @@
+.popover-fixed-inputs {
+    display: flex;
+    margin-top: 20px;
+
+    hc-form-field {
+        max-width: 135px;
+        margin-right: 15px;
+    }
+}

--- a/projects/cashmere-examples/src/lib/popover-fixed-position/popover-fixed-position-example.component.ts
+++ b/projects/cashmere-examples/src/lib/popover-fixed-position/popover-fixed-position-example.component.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+import { FormControl } from '@angular/forms';
+
+/**
+ * @title Popover Fixed Position
+ */
+@Component({
+    selector: 'hc-popover-fixed-position-example',
+    templateUrl: 'popover-fixed-position-example.component.html',
+    styleUrls: ['./popover-fixed-position-example.component.scss']
+})
+export class PopoverFixedPositionExampleComponent {
+    xPos = new FormControl(250);
+    yPos = new FormControl(60);
+}

--- a/projects/cashmere/src/lib/pop/index.ts
+++ b/projects/cashmere/src/lib/pop/index.ts
@@ -1,6 +1,7 @@
 export {HcPopoverAnchorDirective} from './directives/popover-anchor.directive';
 export {PopModule} from './popover.module';
 export {HcPopComponent} from './popover.component';
+export {HcPopoverOpenOptions} from './types';
 export {MenuDirective} from './directives/menu.directive';
 export {MenuItemDirective} from './directives/menu-item.directive';
 export {MenuIconDirective} from './directives/menu-icon.directive';

--- a/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
@@ -252,9 +252,8 @@ export class HcPopoverAnchoringService implements OnDestroy {
                 case NotificationAction.TOGGLE:
                     this.togglePopover();
                     break;
-                case NotificationAction.REPOSITION:
-                    break;
                 // TODO: When the overlay's position can be dynamically changed, do not destroy
+                case NotificationAction.REPOSITION:
                 case NotificationAction.UPDATE_CONFIG:
                     this._destroyPopoverOnceClosed();
                     break;

--- a/projects/cashmere/src/lib/pop/types.ts
+++ b/projects/cashmere/src/lib/pop/types.ts
@@ -19,4 +19,10 @@ export interface HcPopoverOpenOptions {
 
     /** Whether the first focusable element should be focused on open. Defaults to true. */
     autoFocus?: boolean;
+
+    /** The horizontal position for a fixed position popover. Defaults to 0 if `y` is set. */
+    x?: number;
+
+    /** The vertical position for a fixed position popover. Defaults to 0 if `x` is set. */
+    y?: number;
 }

--- a/src/app/core/cashmere-components-document-items.json
+++ b/src/app/core/cashmere-components-document-items.json
@@ -90,7 +90,7 @@
     "pop": {
         "name": "Popover",
         "category": "popups",
-        "examples": ["popover-menu", "popover-overview", "popover-right-click", "popover-simple", "tooltip-overview"],
+        "examples": ["popover-simple", "popover-menu", "tooltip-overview", "popover-right-click", "popover-overview" ],
         "usageDoc": true
     },
     "progress-indicators": {

--- a/src/app/core/cashmere-components-document-items.json
+++ b/src/app/core/cashmere-components-document-items.json
@@ -90,7 +90,7 @@
     "pop": {
         "name": "Popover",
         "category": "popups",
-        "examples": ["popover-simple", "popover-menu", "tooltip-overview", "popover-right-click", "popover-overview" ],
+        "examples": ["popover-simple", "popover-menu", "tooltip-overview", "popover-right-click", "popover-fixed-position", "popover-overview" ],
         "usageDoc": true
     },
     "progress-indicators": {

--- a/src/app/foundations/foundations-routes.module.ts
+++ b/src/app/foundations/foundations-routes.module.ts
@@ -16,14 +16,14 @@ const routes: Routes = [
         component: FoundationsComponent,
         children: [
             {
-                path: 'brand-colors',
-                component: BrandColorDemoComponent,
-                data: {title: 'Brand Colors', category: 'Colors'}
-            },
-            {
                 path: 'color',
                 component: ColorDemoComponent,
                 data: {title: 'UI Colors', category: 'Colors'}
+            },
+            {
+                path: 'brand-colors',
+                component: BrandColorDemoComponent,
+                data: {title: 'Brand Colors', category: 'Colors'}
             },
             {
                 path: 'fonts',
@@ -57,7 +57,7 @@ const routes: Routes = [
             },
             {
                 path: '**',
-                redirectTo: 'brand-colors'
+                redirectTo: 'color'
             }
         ]
     }


### PR DESCRIPTION
force the popover to update after a reposition event

@corykon the issue here (which you already called out in a comment), is that the popover needs to get destroyed for overlay positioning changes to take effect.  Fortunately you already had the code in place to do that, so just needed to connect the reposition event.

I also reordered the popover examples while I was in there.

closes #1647
closes #1748
closes #1721 