### PR TITLE
build(ivy): setup workarounds for known build issues

### DIFF
--- a/guides/contribution-guide.md
+++ b/guides/contribution-guide.md
@@ -6,7 +6,7 @@
 
 ##### All May Contribute
 
-We would love for you to contribute to Cashmere and be part of the community making this project better! To get started, follow the [Getting Started guide](http://cashmere.healthcatalyst.net/web/guides/getting-started).
+We would love for you to contribute to Cashmere! Follow the instructions below to get started. Contributing to open source projects can be daunting at first, so we welcome questions and requests for help. Reach out on [Github](https://github.com/HealthCatalyst/Fabric.Cashmere), or if you're a Health Catalyst employee, find us on Slack in the #cashmere channel. We want to see this project and its community continue to grow!
 
 :::
 
@@ -30,8 +30,11 @@ We would love for you to contribute to Cashmere and be part of the community mak
 ### While Developing
 
 1.  You may need to run `npm run build` before you start, especially if it's your first time running Cashmere.
-2.  Run `npm start`. This will fire up the user guide website, and rebuild/reload when changes are made to the user guide site or the Cashmere library.
-3.  To run locally in BrowserStack, run `npm run start-bs` and start up your local testing in BrowserStack. Enter bs-local.com:4200 as your url.
+2.  After the initial `npm run build`, if a fresh build is needed you are not developing a new cashmere Bit component, you can run `npm run build:dev`.
+3.  Run `npm start`. This will fire up the user guide website, and rebuild/reload when changes are made to the user guide site or the Cashmere library.
+4.  To run locally in BrowserStack, run `npm run start-bs` and start up your local testing in BrowserStack. Enter bs-local.com:4200 as your url.
+
+**Note**: There is a current known [build issue](https://github.com/HealthCatalyst/Fabric.Cashmere/issues/1750). After the initial npm run build is executed, executing it a subsequent time will break. If you need to run it again, you can either delete all `node_modules` folders (at the root and the ones under `projects/cashmere-examples`, `project/cashmere-bits`), rerun `npm i` and then run `npm run build`, or, you can simply run `npm run build:dev`. Subsequent runs of the build scripts are typically needed only for refreshing some usage guides, api pages, etc.
 
 ### Code Documentation
 

--- a/guides/contribution-guide.md
+++ b/guides/contribution-guide.md
@@ -30,7 +30,7 @@ We would love for you to contribute to Cashmere! Follow the instructions below t
 ### While Developing
 
 1.  You may need to run `npm run build` before you start, especially if it's your first time running Cashmere.
-2.  After the initial `npm run build`, if a fresh build is needed you are not developing a new cashmere Bit component, you can run `npm run build:dev`.
+2.  After the initial `npm run build`, if a fresh build is needed and you are not developing a new cashmere Bit component, you can run `npm run build:dev`.
 3.  Run `npm start`. This will fire up the user guide website, and rebuild/reload when changes are made to the user guide site or the Cashmere library.
 4.  To run locally in BrowserStack, run `npm run start-bs` and start up your local testing in BrowserStack. Enter bs-local.com:4200 as your url.
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -12,10 +12,10 @@ npm install --save @healthcatalyst/cashmere
 ```
 
 ### B) Install [@angular/cdk](https://material.angular.io/cdk), a required peer dependency.
-*Note: Version 11.2.12 of the CDK, rather than the latest, is required for compatibility with Cashmere.*
+*Note: Version 12.2.13 of the CDK, rather than the latest, is required for compatibility with Cashmere.*
 
 ```BASH
-npm install --save @angular/cdk@11.2.12
+npm install --save @angular/cdk@12.2.13
 ```
 
 ### C) *(Optional)* Install additional dependencies as needed.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "prebuild:examples": "ts-node scripts/build-examples.ts",
     "build:examples": "ng build cashmere-examples --configuration production",
     "build": "npm run clean && npm run release-mode && npm run build:lib && npm run build:bit && npm run build:examples && npm run search-prep && npm run build:user",
+    "build:dev": "npx rimraf dist && npm run release-mode && npm run build:lib && npm run build:examples && npm run search-prep && npm run build:user",
+    "postbuild:dev": "npm run copy-assets",
     "postbuild": "npm run copy-assets",
     "precopy-assets": "npm run docs",
     "copy-assets": "node scripts/guide-copy-assets.js",


### PR DESCRIPTION
`npm run build` still fails the second time you run it, so this PR sets up a workaround. As needed, devs can use `npm run build:dev` while working on contributions and avoid the issues caused by the Bit build.

An issue to really fix the build issue was added here- #1750