### PR TITLE
build(sass): reverting change from "/" to math.div

### DIFF
--- a/projects/cashmere/src/lib/sass/_functions.scss
+++ b/projects/cashmere/src/lib/sass/_functions.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @import './variables';
 
 /// Slightly lighten a color
@@ -20,6 +19,6 @@
 /// Returns the rem value based on the px value that has been passed in
 /// @param {Size} $size - pixel based size to convert to rem
 @function calculateRem($size) {
-    $remSize: math.div($size, $default-font-size);
+    $remSize: $size / $default-font-size;
     @return #{$remSize}rem;
 }

--- a/projects/cashmere/src/lib/sass/datepicker.scss
+++ b/projects/cashmere/src/lib/sass/datepicker.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @import './colors';
 @import './typography';
 @import './functions';
@@ -286,7 +285,7 @@ $hc-calendar-body-label-padding-start: 5% !default;
 // the same amount of padding regardless of the number of columns. We align the header label with
 // the one third mark of the first cell, this was chosen somewhat arbitrarily to make it look
 // roughly like the mock. Half way is too far since the cell text is center aligned.
-$hc-calendar-body-label-side-padding: math.div(33%, 7) !default;
+$hc-calendar-body-label-side-padding: 33% / 7 !default;
 $hc-calendar-body-cell-min-size: 32px !default;
 $hc-calendar-body-cell-content-margin: 5% !default;
 $hc-calendar-body-cell-content-border-width: 1px !default;

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @import './colors';
 @import './functions';
 @import './variables';
@@ -11,8 +10,8 @@ $infix-margin-top-tight: 1.143em * $line-height * 0.93;
 $prefix-suffix-icon-font-size: 125%;
 
 $infix-padding: 0.393em;
-$infix-padding-tight: math.div($infix-padding, 2);
-$error-margin-top: math.div(0.4em, $error-font-scale);
+$infix-padding-tight: $infix-padding / 2;
+$error-margin-top: 0.4em / $error-font-scale;
 $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
 @mixin hc-form-field() {

--- a/projects/cashmere/src/lib/sass/progress-dots.scss
+++ b/projects/cashmere/src/lib/sass/progress-dots.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @import './colors';
 $animation-speed: 1.4s !default;
 $animation-delay: -0.16s !default;
@@ -14,8 +13,8 @@ $dots-diameter-mini: 4px !default;
         position: absolute;
         top: 50%;
         left: 50%;
-        margin-top: math.div($dots-diameter, -2);
-        margin-left: math.div($dots-diameter, -2);
+        margin-top: $dots-diameter / -2;
+        margin-left: $dots-diameter / -2;
     }
 }
 

--- a/projects/cashmere/src/lib/sass/progress-spinner.scss
+++ b/projects/cashmere/src/lib/sass/progress-spinner.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 // Styles forked from http://polymer.github.io
 // This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 @import './colors';
@@ -33,8 +32,8 @@ $circle-clipper-animation-timing: 1333ms;
     position: absolute;
     top: 50%;
     left: 50%;
-    margin-top: math.div($diameter, -2);
-    margin-left: math.div($diameter, -2);
+    margin-top: $diameter / -2;
+    margin-left: $diameter / -2;
 }
 
 .spinner-layer {

--- a/projects/cashmere/src/lib/sass/stepper.scss
+++ b/projects/cashmere/src/lib/sass/stepper.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 $track-space: 4rem;
 $isolated-disk-size: 2rem;
 $track-height: 0.5rem;
@@ -12,9 +10,9 @@ $track-height: 0.5rem;
     @if $right {
         border-right: $track-space * 0.05 solid $right;
     }
-    border-left: math.div($track-space, 4) solid transparent;
-    border-top: math.div($track-space, 2) solid $top-bottom;
-    border-bottom: math.div($track-space, 2) solid $top-bottom;
+    border-left: $track-space / 4 solid transparent;
+    border-top: $track-space / 2 solid $top-bottom;
+    border-bottom: $track-space / 2 solid $top-bottom;
     display: block;
     height: 0px;
     position: absolute;
@@ -49,10 +47,10 @@ $track-height: 0.5rem;
     display: block;
     height: $track-height;
     left: 0px;
-    margin-top: math.div($track-height, -2);
+    margin-top: $track-height / -2;
     position: absolute;
     right: 0px;
-    top: math.div($disk-size, 2);
+    top: $disk-size / 2;
     z-index: 1;
 }
 
@@ -158,7 +156,7 @@ $track-height: 0.5rem;
     height: $isolated-disk-size;
     left: 50%;
     line-height: $isolated-disk-size;
-    margin-left: math.div($isolated-disk-size, -2);
+    margin-left: $isolated-disk-size / -2;
     position: absolute;
     text-align: center;
     top: 0px;


### PR DESCRIPTION
I had changed us over to `math.div()` as called for by sass. https://sass-lang.com/documentation/breaking-changes/slash-div

`Math.div()` isn't playing nicely with stackblitz when imported by a library, so I switched back. We'll get warnings again with this when building... but shouldn't break anything.

fix #1757