### PR TITLE
fix(stackblitz): enable Ivy and fix bit module refs for stackblitz

### DIFF
--- a/projects/cashmere-examples/src/project-template/tsconfig.json
+++ b/projects/cashmere-examples/src/project-template/tsconfig.json
@@ -11,5 +11,8 @@
         "target": "es5",
         "typeRoots": ["node_modules/@types"],
         "lib": ["es2018", "dom"]
+    },
+    "angularCompilerOptions": {
+        "enableIvy": true
     }
 }

--- a/scripts/build-examples.ts
+++ b/scripts/build-examples.ts
@@ -202,7 +202,7 @@ function generateStackBlitzFiles(exampleName: string) {
     const allFiles = Object.assign({}, projectTemplateFiles, exampleFiles, {
         'src/app/app.module.ts': prettier.format(appModuleContents, {...prettierConfig, filepath: 'app.module.ts'}),
         // Bit doesn't work in StackBlitz, so have the CashmereModule reference relative path instead
-        'src/app/cashmere.module.ts': prettier.format(cashmereModule.replace(/@bit\/healthcatalyst\.cashmere\.([^']+)/g, '../bit/$1/'), {
+        'src/app/cashmere.module.ts': prettier.format(cashmereModule.replace(/@bit\/healthcatalyst\.cashmere\.([^']+)/g, '../bit/$1/$1.module'), {
             ...prettierConfig,
             filepath: 'cashmere.module.ts'
         })

--- a/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.ts
+++ b/src/app/components/component-viewer/component-examples/example-viewer/example-viewer.component.ts
@@ -143,7 +143,7 @@ export class ExampleViewerComponent implements OnInit {
             },
             {
                 openFile: `src/app/${this.example}/${this.example}-example.component.html`,
-                hideDevTools: true
+                hideDevTools: false
             }
         );
     }


### PR DESCRIPTION
Hallelujah!

Started with a working Ivy-based stackblitz example, and kept copying stuff back and forth until I tracked down the changes needed. Found that Ivy wasn't enabled in the tsconfig file, and stackblitz didn't like the way were trying to import our bit module.

Also made a change to not hide debug tools by default. I find them useful and I'm sure other devs will, too.