### PR TITLE
fix(form-field): inline/tight style collision

### DIFF
--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.html
@@ -3,7 +3,7 @@ either the <code>hcForm</code> or individual <code>hc-form-field</code> elements
 <br>
 <form hcForm tight="true">
     <div class="form-sample">
-        <hc-form-field>
+        <hc-form-field inline="true">
             <hc-label>Job name:</hc-label>
             <input hcInput required [formControl]="inputControl">
             <hc-error>A job name is required</hc-error>

--- a/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.scss
+++ b/projects/cashmere-examples/src/lib/form-field-tight/form-field-tight-example.component.scss
@@ -6,3 +6,8 @@
 .flex-column {
     flex-direction: column;
 }
+
+.hc-form-field {
+    margin-bottom: 15px;
+    display: inline-flex;
+}

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -13,7 +13,9 @@
 }
 
 .hc-form-field-wrapper-tight {
-    @include hc-form-field-wrapper-tight();
+    &:not(.hc-form-field-wrapper-inline) {
+        @include hc-form-field-wrapper-tight();
+    }
 }
 
 .hc-form-field-content-wrapper {

--- a/projects/cashmere/src/lib/form-field/hc-form.directive.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form.directive.ts
@@ -13,7 +13,7 @@ export class HcFormDirective implements AfterContentInit, OnDestroy {
     private _tight = false;
     private unsubscribe$ = new Subject<void>();
 
-    @ContentChildren(HcFormFieldComponent)
+    @ContentChildren(HcFormFieldComponent, {descendants: true})
     _formFields: QueryList<HcFormFieldComponent>;
 
     /** Set the tight parameter on all enclosed HcFormFields. *Defaults to `false`.*  */


### PR DESCRIPTION
fixes style collision and bug when tight is applied to form

@corykon - I noticed when fixing this bug that if `tight` was applied to an `hcForm`, it wasn't being applied to any descendent `hc-form-fields`.  I guess that bug probably showed up on one of our Angular upgrades but I totally missed it.  You can see it on the current Cashmere site in the last FormField example.  Anyway, the bug is fixed in this PR.

closes #1487