### PR TITLE
fix(popover): close submenus on click

### DIFF
--- a/projects/cashmere/src/lib/pop/popover.component.ts
+++ b/projects/cashmere/src/lib/pop/popover.component.ts
@@ -242,7 +242,7 @@ export class HcPopComponent implements OnInit, OnDestroy {
         }
         this._parentMenu = val;
         if ( this._parentMenu ) {
-            this._parentClose = this._parentMenu.closed.subscribe(function() {
+            this._parentClose = this._parentMenu.closed.subscribe(() => {
                 if (this.isOpen()) {
                     this.close();
                 }


### PR DESCRIPTION
fixes bug where submenus remained open after selection in parent

closes #1774