### PR TITLE
feat(toasts): custom image

### DIFF
--- a/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.html
@@ -69,6 +69,16 @@
         <input hcInput type="number" [formControl]="progressValue" [disabled]="toastProgress.value!='2'" />
     </hc-form-field>
 </div>
+<div class="progress-row">
+    <hc-form-field>
+        <hc-label>Custom Image:</hc-label>
+        <hc-radio-group [formControl]="customImage" inline="true">
+            <hc-radio-button [value]="null">None</hc-radio-button>
+            <hc-radio-button [value]="'./assets/avatars/avatar92.svg'">Image URL</hc-radio-button>
+            <hc-radio-button [value]="{fontSet:'fa', fontIcon:'fa-star'}">HC Icon Object</hc-radio-button>
+        </hc-radio-group>
+    </hc-form-field>
+</div>
 <div class="button-row">
     <button hc-button buttonStyle="primary" (click)="showToast(templateToast)" class="demo-button">Display Toaster Message</button>
     <button hc-button buttonStyle="secondary" (click)="closeLastToast()" class="demo-button">Close Last Toast</button>

--- a/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.ts
@@ -21,7 +21,7 @@ export class ToasterOverviewExampleComponent {
     readonly toastWidth = new FormControl(400);
     readonly toastProgress = new FormControl('0');
     readonly progressValue = new FormControl(75);
-
+    readonly customImage = new FormControl(null);
 
     constructor(private toasterService: HcToasterService) {}
 
@@ -40,7 +40,8 @@ export class ToasterOverviewExampleComponent {
             clickDismiss: this.toastClick.value,
             type: this.toastType.value,
             width: this.toastWidth.value,
-            hasProgressBar: showProgress
+            hasProgressBar: showProgress,
+            image: this.customImage.value
         };
 
         if (this.toastType.value === 'custom-template') {

--- a/projects/cashmere/src/lib/toaster/hc-toast-options.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toast-options.ts
@@ -1,3 +1,5 @@
+import { HcIcon } from "../icon/icon.component";
+
 export interface HcToastOptions {
     /** A string of header text to be included in the toast message.*/
     header?: string;
@@ -10,6 +12,9 @@ export interface HcToastOptions {
      * Options are: `top-right`, `top-center`, `top-left`, `top-full-width`,
      * `bottom-right`, `bottom-center`, `bottom-left`, `bottom-full-width`.*/
     position?: string;
+    /** A custom image for the toast that overrides the default for the type.
+     * Accepts either a URL for the image or a `HcIcon` object. */
+    image?: string | HcIcon;
     /** Timeout value in milliseconds sets the amount of time the toast is displayed.
      *  Defaults to 5000. A value of 0 means the toast will not auto-dismiss.*/
     timeout?: number;

--- a/projects/cashmere/src/lib/toaster/hc-toast.component.html
+++ b/projects/cashmere/src/lib/toaster/hc-toast.component.html
@@ -10,7 +10,13 @@
     </div>
     <div *ngIf="_styleType !== 'custom'" class="hc-toast-content" [ngClass]="{'hc-toast-progress-offset': _hasProgressBar}">
         <div class="hc-toast-icon-container">
-            <div class="hc-toast-icon"></div>
+            <div *ngIf="_customImage && _imgIsURL(_customImage)">
+                <div class="hc-toast-custom-image" [style.background-image]="'url(' + _customImage + ')'"></div>
+            </div>
+            <div *ngIf="_customImage && !_imgIsURL(_customImage)">
+                <hc-icon class="hc-toast-custom-icon" [fontSet]="_customFontSet(_customImage)" [fontIcon]="_customFontIcon(_customImage)"></hc-icon>
+            </div>
+            <div *ngIf="!_customImage" class="hc-toast-icon"></div>
         </div>
         <div>
             <div class="hc-toast-header">{{_headerText}}</div>

--- a/projects/cashmere/src/lib/toaster/hc-toast.component.scss
+++ b/projects/cashmere/src/lib/toaster/hc-toast.component.scss
@@ -83,6 +83,20 @@ $hc-header-font-size: 18px !default;
     }
 }
 
+.hc-toast-custom-image {
+    width: 60px;
+    height: 60px;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+}
+
+.hc-toast-custom-icon {
+    width: 30px !important;
+    height: 30px !important;
+    font-size: 30px !important;
+}
+
 .hc-toast-content {
     color: $white;
     display: flex;

--- a/projects/cashmere/src/lib/toaster/hc-toast.component.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toast.component.ts
@@ -2,6 +2,7 @@ import {Component, EventEmitter, ElementRef, ViewContainerRef, ComponentRef, Cha
 import {trigger, state, style, transition, animate, AnimationEvent} from '@angular/animations';
 import {Portal, CdkPortalOutletAttachedRef} from '@angular/cdk/portal';
 import {BehaviorSubject} from 'rxjs';
+import {HcIcon} from '../icon/icon.component';
 
 const ANIMATION_TIMINGS = '400ms cubic-bezier(0.25, 0.8, 0.25, 1)';
 
@@ -35,6 +36,7 @@ export class HcToastComponent {
     _hasProgressBar = false;
     _progressVal: number;
     _progressWidth = '100%';
+    _customImage: string | HcIcon;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly _componentInstance = new BehaviorSubject<any>(null);
 
@@ -64,5 +66,19 @@ export class HcToastComponent {
         if (ref instanceof ComponentRef) {
             this._componentInstance.next(ref.instance);
         }
+    }
+
+    _imgIsURL( val:string | HcIcon ): boolean {
+        return typeof val === 'string';
+    }
+
+    _customFontSet( val: string | HcIcon ): string {
+        const icon = val as HcIcon;
+        return icon.fontSet;
+    }
+
+    _customFontIcon( val: string | HcIcon ): string {
+        const icon = val as HcIcon;
+        return icon.fontIcon;
     }
 }

--- a/projects/cashmere/src/lib/toaster/hc-toaster.module.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toaster.module.ts
@@ -4,9 +4,10 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {PortalModule} from '@angular/cdk/portal';
 import {OverlayModule} from '@angular/cdk/overlay';
+import {IconModule} from '../icon/icon.module';
 
 @NgModule({
-    imports: [CommonModule, PortalModule, OverlayModule],
+    imports: [CommonModule, PortalModule, OverlayModule, IconModule],
     exports: [HcToastComponent],
     declarations: [HcToastComponent],
     providers: [HcToasterService],

--- a/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toaster.service.ts
@@ -102,6 +102,11 @@ export class HcToasterService {
             _toastRef.componentInstance._bodyText = options.body;
         }
 
+        // Set the custom image if one is defined
+        if (options.image) {
+            _toastRef.componentInstance._customImage = options.image;
+        }
+
         // Store the positioning of the toast
         _toastRef._toastPosition = String(options.position);
 


### PR DESCRIPTION
ability to set custom images / icons on standard toasts

@corykon @joeskeen - making the custom image 30 x 30px like the icons felt too small to me.  So for custom images I made it 60x60px instead.  That work?  Any real benefit to giving the dev another param to set that image size?

closes #1253