### PR TITLE
feat(date-range): make start & end dates optional

### DIFF
--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
@@ -11,12 +11,27 @@
         #pickerOne
     >
         <span class="label">Date range:</span>
-        <span class="value">{{ range.fromDate | date: 'MM/dd/yyyy' }} - {{ range.toDate | date: 'MM/dd/yyyy' }}</span>
+        <span class="value">
+            <span *ngIf="range.fromDate && range.toDate">
+                {{ range.fromDate | date: 'MM/dd/yyyy' }} - {{ range.toDate | date: 'MM/dd/yyyy' }}
+            </span>
+            <span *ngIf="range.fromDate && !range.toDate">
+                {{ range.fromDate | date: 'MM/dd/yyyy' }} or later
+            </span>
+            <span *ngIf="!range.fromDate && range.toDate">
+                {{ range.toDate | date: 'MM/dd/yyyy' }} or earlier
+            </span>
+            <span *ngIf="!range.fromDate && !range.toDate">
+                Invalid state
+            </span>
+        </span>
         <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="icon-right" hcIconSm></hc-icon>
     </button>
 
     <div class="demo-extras">
-        <hc-checkbox [formControl]="optionsControl">Don't allow weekend dates</hc-checkbox>
+        <hc-checkbox [formControl]="optionsControlExcludeWeekends">Don't allow weekend dates</hc-checkbox>
+        <hc-checkbox [formControl]="optionsControlStartDateRequired">Start date required</hc-checkbox>
+        <hc-checkbox [formControl]="optionsControlEndDateRequired">End date required</hc-checkbox>
         <div>
             Selected preset: <strong>{{ presetSelection }}</strong>
         </div>

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.ts
@@ -11,7 +11,9 @@ export class DateRangeExampleComponent implements OnInit {
     range: DateRange = {fromDate: new Date(), toDate: new Date()};
     selected: number | DateRange = this.range;
     options: DateRangeOptions;
-    optionsControl = new FormControl(false);
+    optionsControlExcludeWeekends = new FormControl(false);
+    optionsControlStartDateRequired = new FormControl(true);
+    optionsControlEndDateRequired = new FormControl(true);
     presets: Array<PresetItem> = [];
     presetSelection = 'None';
 
@@ -28,11 +30,21 @@ export class DateRangeExampleComponent implements OnInit {
             format: 'mediumDate',
             applyLabel: 'Apply',
             fromMinMax: {fromDate: fromMin, toDate: fromMax},
-            toMinMax: {fromDate: toMin, toDate: toMax}
+            toMinMax: {fromDate: toMin, toDate: toMax},
+            startDateIsRequired: true,
+            endDateIsRequired: true
         };
 
-        this.optionsControl.valueChanges.subscribe(value => {
+        this.optionsControlExcludeWeekends.valueChanges.subscribe(value => {
             this.options.excludeWeekends = value;
+        });
+
+        this.optionsControlStartDateRequired.valueChanges.subscribe(value => {
+            this.options.startDateIsRequired = value;
+        });
+
+        this.optionsControlEndDateRequired.valueChanges.subscribe(value => {
+            this.options.endDateIsRequired = value;
         });
     }
 

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.html
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.html
@@ -5,7 +5,7 @@
             hcInput
             hcDatepicker
             [(ngModel)]="selectedDate"
-            required
+            [required]="required"
             (dateChange)="_onInputChange($event)"
             [min]="minDate"
             [max]="maxDate"

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
@@ -91,6 +91,12 @@ export class CalendarWrapperComponent implements OnChanges {
                 this.selectedDateChange.emit(date);
             }
         }
+
+        // eslint-disable-next-line no-prototype-builtins
+        if (changes.hasOwnProperty('required')) {
+            const isRequired = changes.required.currentValue;
+            this.datePickerInput._allowsBlankValues = !isRequired;
+        }
     }
 
     _onCalendarChange(date: D): void {

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
@@ -53,6 +53,10 @@ export class CalendarWrapperComponent implements OnChanges {
     @Input()
     hourCycle = 12;
 
+    /** Whether the field is required to contain a value. Defaults to `true`. */
+    @Input()
+    required = true;
+
     /** Prefix label on top of component. */
     @Input()
     prefixLabel: string;

--- a/projects/cashmere/src/lib/date-range/model/model.ts
+++ b/projects/cashmere/src/lib/date-range/model/model.ts
@@ -44,4 +44,8 @@ export interface DateRangeOptions {
     invalidDateLabel?: string;
     /** Centers the DateRange component to the screen instead of the target. Default 'false' */
     center?: boolean;
+    /** Disabling this allows an open-ended date range from the distant past to 'endDate'. Default 'true' */
+    startDateIsRequired?: boolean;
+    /** Disabling this allows an open-ended date range from 'endDate' to the distant future. Default 'true' */
+    endDateIsRequired?: boolean;
 }

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
@@ -11,6 +11,7 @@
             [invalidDateLabel]="options.invalidDateLabel"
             [mode]="options.mode"
             [hourCycle]="options.hourCycle"
+            [required]="options.startDateIsRequired"
         ></hc-calendar-wrapper>
     </div>
     <div class="hc-date-range-calendar-item hc-date-range-calendar-wrapper">
@@ -25,6 +26,7 @@
             [invalidDateLabel]="options.invalidDateLabel"
             [mode]="options.mode"
             [hourCycle]="options.hourCycle"
+            [required]="options.endDateIsRequired"
         ></hc-calendar-wrapper>
     </div>
     <div class="hc-date-range-calendar-item hc-date-range">
@@ -43,14 +45,14 @@
                     hc-button
                     buttonStyle="primary"
                     type="button"
-                    [disabled]="!(this._toDate && this._fromDate)"
+                    [disabled]="this._rangeIsInvalid"
                     (click)="_applyNewDates()"
                 >
                     {{ options.applyLabel }}
                 </button>
             </div>
             <hc-chip *ngIf="_rangeIsInvalid" color="red">
-                <span class="hc-date-range-warning-icon"></span>The start date cannot be after the end date.
+                <span class="hc-date-range-warning-icon"></span>{{ _invalidRangeErrorMessage }}
             </hc-chip>
         </div>
     </div>

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
@@ -58,22 +58,63 @@ describe('RangeComponent', () => {
     });
 
     describe('_validateRange', () => {
-        it('will not mark range invalid if one or both dates are missing', waitForAsync(() => {
+        it('will mark the range invalid if one or both dates are missing', waitForAsync(() => {
             component._updateFromDate(new Date(2010, 1, 1));
             component._updateToDate(undefined);
             component._validateRange();
-            expect(component._rangeIsInvalid).toBeFalsy();
+            expect(component._rangeIsInvalid).toBeTruthy();
+            expect(component.__invalidRangeErrorMessage).toBe("End date cannot be blank.");
 
             component._updateFromDate(undefined);
             component._updateToDate(new Date(2010, 1, 1));
             component._validateRange();
-            expect(component._rangeIsInvalid).toBeFalsy();
+            expect(component._rangeIsInvalid).toBeTruthy();
+            expect(component.__invalidRangeErrorMessage).toBe("Start date cannot be blank.");
 
             component._updateFromDate(undefined);
             component._updateToDate(undefined);
             component._validateRange();
-            expect(component._rangeIsInvalid).toBeFalsy();
+            expect(component._rangeIsInvalid).toBeTruthy();
+            expect(component.__invalidRangeErrorMessage).toBe("You must choose a date.");
         }));
+
+        describe('_fromDateIsRequired == false', () => {
+            beforeEach(() => {
+                component._fromDateIsRequired = false;
+            });
+
+            it('will mark range valid if _toDate is not null', waitForAsync(() => {
+                component._updateToDate(new Date(2010, 1, 1));
+                component._validateRange();
+                expect(component._rangeIsInvalid).toBeFalsy();
+                expect(component.__invalidRangeErrorMessage).toBe(null);
+            }));
+
+            it('will mark range invalid if _toDate is null', waitForAsync(() => {
+                component._validateRange();
+                expect(component._rangeIsInvalid).toBeTruthy();
+                expect(component.__invalidRangeErrorMessage).toBe("You must choose a date.");
+            }));
+        });
+
+        describe('_toDateIsRequired == false', () => {
+            beforeEach(() => {
+                component._toDateIsRequired = false;
+            });
+
+            it('will mark range valid if _fromDate is not null', waitForAsync(() => {
+                component._updateFromDate(new Date(2010, 1, 1));
+                component._validateRange();
+                expect(component._rangeIsInvalid).toBeFalsy();
+                expect(component.__invalidRangeErrorMessage).toBe(null);
+            }));
+
+            it('will mark range invalid if _fromDate is null', waitForAsync(() => {
+                component._validateRange();
+                expect(component._rangeIsInvalid).toBeTruthy();
+                expect(component.__invalidRangeErrorMessage).toBe("You must choose a date.");
+            }));
+        });
 
         it('will not mark range invalid if fromDate is before toDate', waitForAsync(() => {
             component._updateFromDate(new Date(2010, 1, 1));
@@ -94,6 +135,7 @@ describe('RangeComponent', () => {
             component._updateToDate(new Date(2010, 1, 1));
             component._validateRange();
             expect(component._rangeIsInvalid).toBeTruthy();
+            expect(component.__invalidRangeErrorMessage).toBe("Start date cannot be after End date.");
         }));
     });
 

--- a/projects/cashmere/src/lib/date-range/services/config-store.service.ts
+++ b/projects/cashmere/src/lib/date-range/services/config-store.service.ts
@@ -18,7 +18,9 @@ export class ConfigStoreService {
         startDatePrefix: 'Start date:',
         endDatePrefix: 'End date:',
         invalidDateLabel: 'Please enter valid date',
-        center: false
+        center: false,
+        startDateIsRequired: true,
+        endDateIsRequired: true
     };
 
     private dateRangeOptionsSubject: BehaviorSubject<DateRangeOptions> = new BehaviorSubject<DateRangeOptions>(this.defaultOptions);

--- a/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
@@ -176,6 +176,9 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
     @Input() _mode: string;
     @Input() _hourCycle: number;
 
+    /** When true, this allows the date picker to validate with a blank value OR a valid date value. Defaults to false. */
+    @Input() _allowsBlankValues: boolean;
+
     /** Emits when the value changes (either due to user input or programmatic change). */
     _valueChange = new EventEmitter<D | null>();
 
@@ -259,6 +262,8 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
             // eslint-disable-next-line no-self-assign
             this.value = this.value;
         });
+
+        this._allowsBlankValues = false;
     }
 
     ngOnDestroy(): void {
@@ -354,7 +359,12 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
             }
         }
 
-        this._lastValueValid = !date || this._dateAdapter.isValid(date);
+        if (this._allowsBlankValues && value.trim() == '') {
+            this._lastValueValid = true;
+        } else {
+            this._lastValueValid = !date || this._dateAdapter.isValid(date);
+        }
+
         date = this._getValidDateOrNull(date);
 
         if (!this._dateAdapter.sameDate(date, this._value)) {


### PR DESCRIPTION
Allows date ranges to be open-ended on either side to allow for selecting ranges like "Feb 24, 2022 or earlier" or "Feb 24, 2022 or later".

Closes #1297