### PR TITLE
docs(node): specify required node version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/guides/contribution-guide.md
+++ b/guides/contribution-guide.md
@@ -1,6 +1,6 @@
 # Guidelines for Contribution
 
-###### Last updated September 21, 2019
+###### Last updated February 28, 2022
 
 :::
 
@@ -14,12 +14,14 @@ We would love for you to contribute to Cashmere! Follow the instructions below t
 
 ##### Setup Environment
 
-1.  Install the latest version of `node` with at _least_ version 8.9.
+1.  [Install Node 14 and NPM 6](https://nodejs.org/en/blog/release/v14.19.0/). You may experience some challenges getting your Cashmere development environment set up with newer versions of Node, including the latest LTS. See notes below for an alternative way to install and use Node 14.
 2.  Fork the `@healthcatalyst/cashmere` repo.
 3.  Clone your fork. Recommendation: name your git remotes `upstream` for `@healthcatalyst/cashmere`
 4.  From the root of the project, run `npm install`
 5.  Running `npm run build` will build the entire project.
 6.  `npm start` will serve the default project which is `user-guide` (the documentation site)
+
+Alternatively, you may want to consider using [Node Version Manager](https://github.com/nvm-sh/nvm) (`nvm`) to install and manage Node 14. Node 14 can be installed via `nvm` by running the command `nvm install --lts=fermium`.
 
 :::
 


### PR DESCRIPTION
Mention in the Contribution Guide that the project does not build reliably under the current Node LTS version (node 16 + npm 8), and that the previous LTS version, 14, should be use instead.

Also include link to `nvm`, which makes it easy to maintain multiple Node installations on the same machine, and add an `.nvmrc` file to make it easier to use the correct Node version when `nvm` is employed.