### PR TITLE
fix(date-range): allow blank dates when to/from dates aren't required

### DIFF
--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
@@ -22,7 +22,7 @@
                 {{ range.toDate | date: 'MM/dd/yyyy' }} or earlier
             </span>
             <span *ngIf="!range.fromDate && !range.toDate">
-                Invalid state
+                No dates selected
             </span>
         </span>
         <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="icon-right" hcIconSm></hc-icon>

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.spec.ts
@@ -78,6 +78,19 @@ describe('RangeComponent', () => {
             expect(component.__invalidRangeErrorMessage).toBe("You must choose a date.");
         }));
 
+        describe('_fromDateIsRequired == false && _toDateIsRequired == false', () => {
+            beforeEach(() => {
+                component._fromDateIsRequired = false;
+                component._toDateIsRequired = false;
+            });
+
+            it('will mark the range valid if both dates are null', waitForAsync(() => {
+                component._validateRange();
+                expect(component._rangeIsInvalid).toBeFalsy();
+                expect(component.__invalidRangeErrorMessage).toBe(null);
+            }));
+        });
+
         describe('_fromDateIsRequired == false', () => {
             beforeEach(() => {
                 component._fromDateIsRequired = false;

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
@@ -163,7 +163,10 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
             endLabel = endLabel.slice(0,-1);
         }
 
-        if (!this._fromDate && !this._toDate) {
+        const bothDatesNull = !this._fromDate && !this._toDate;
+        const isDateRequired = !!this._fromDateIsRequired || !!this._toDateIsRequired
+
+        if (bothDatesNull && isDateRequired) {
             this._rangeIsInvalid = true;
             this.__invalidRangeErrorMessage = "You must choose a date.";
         } else if (!!this._fromDate && !!this._toDate) {


### PR DESCRIPTION
A date range picker where 'to date required' and 'from date required' are set to `false` should allow a completely empty range with two null values for the date to be created. This change amends the range validation function to support the aforementioned scenario and adds a test to verify it.

Closes #1833