### PR TITLE
fix(tabs): deselect all tabs

### DIFF
--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.html
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.html
@@ -1,7 +1,7 @@
 <div class="tab-demo">
     <hc-tab-set direction="horizontal" (selectedTabChange)="selectionChanged($event)" #tabSet>
         <hc-tab tabTitle='Pending Tasks'>
-            <div class="tab-content">
+            <div class="example-tab-content">
                 This is where pending tasks would go.
             </div>
         </hc-tab>
@@ -9,7 +9,7 @@
             <hc-tab-title>
                 <i class="fa fa-check" style="color: #00a859; font-size: 20px;"></i>  Complete Tasks
             </hc-tab-title>
-            <div class="tab-content">
+            <div class="example-tab-content">
                 These are completed tasks
             </div>
         </hc-tab>
@@ -17,15 +17,15 @@
             <hc-tab-title>
                 <i class="fa fa-times" style="color: #f13c45; font-size: 20px;"></i> Incomplete Tasks
             </hc-tab-title>
-            <div class="tab-content">
+            <div class="example-tab-content">
                 Incomplete tasks belong here.
             </div>
         </hc-tab>
-        <hc-tab (tabClick)="addTask($event)">
+        <hc-tab (tabClick)="addTask()">
             <hc-tab-title>
                 <span style="color: #00aeff; font-weight: 600;"><i class="fa fa-plus"></i> Add Task</span>
             </hc-tab-title>
-            <div class="tab-content">
+            <div class="example-tab-content">
                 This is an example of a click handler on a tab.
             </div>
         </hc-tab>
@@ -35,4 +35,7 @@
 <button hc-button title="Set Selection" buttonStyle="primary" (click)="tabSet.selectTab(1)">
     Select Complete Tasks
 </button>
-<span class="selection-text">Currently Selected Tab Index: {{selectedIndex}}</span>
+<button hc-button title="Deselect Tabs" buttonStyle="primary" class="deselect-button" (click)="tabSet.selectTab(-1)">
+    Deselect All Tabs
+</button>
+<span class="selection-text">Selected Tab Index: {{selectedIndex}}</span>

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.scss
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.scss
@@ -1,11 +1,16 @@
-.tab-content {
+.example-tab-content {
     padding: 55px 15px;
 }
 
 .tab-demo {
     border: 1px solid #e0e0e0;
+    height: 180px;
 }
 
 .selection-text {
     margin-left: 40px;
+}
+
+.deselect-button {
+    margin-left: 10px;
 }

--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.ts
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.ts
@@ -16,8 +16,7 @@ export class TabsHorizontalExampleComponent {
         this.selectedIndex = event.index;
     }
 
-    addTask(event: MouseEvent): void {
+    addTask(): void {
         window.alert('The "Add Task" tab was clicked.');
-        console.log('Click event', event);
     }
 }

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.html
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.html
@@ -4,7 +4,9 @@
         <ng-content></ng-content>
     </div>
     <div *ngIf="_addContentContainer" class="hc-tab-content-{{direction}}">
-        <router-outlet *ngIf="_routerEnabled"></router-outlet>
-        <ng-container *ngIf="!_routerEnabled" [ngTemplateOutlet]="tabContent"></ng-container>
+        <div [hidden]="_routerDeselected">
+            <router-outlet *ngIf="_routerEnabled" ></router-outlet>
+        </div>
+        <ng-container *ngIf="!_routerEnabled && tabContent" [ngTemplateOutlet]="tabContent"></ng-container>
     </div>
 </div>

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
@@ -40,8 +40,8 @@ export function invalidDefaultTab(tabVal: string | number): void {
     encapsulation: ViewEncapsulation.None
 })
 export class TabSetComponent implements AfterContentInit {
-    private _routerEnabled = false;
-    private _routerDeselected = false;
+    _routerEnabled = false;
+    _routerDeselected = false;
     private _direction = 'vertical';
     private _defaultTab: string | number = 0;
     private _stopTabSubscriptionSubject: Subject<void> = new Subject();


### PR DESCRIPTION
Adds the ability to pass -1 to selectTab to deselect all.  

A little tricky when using tabs with routerLinks - because when deselecting I don't think we want to change the current route.  So in that instance I'm really just hiding the routerOutlet until a tab is selected again.

I also realized while I was in there that when using tabs with routerLinks, the selectTab function wasn't actually routing when called :-(  So that's been corrected here.

The first tab example has been updated to demonstrate deselecting.

closes #1870