### PR TITLE
fix(examples): fix rxjs-triggered build failures

### DIFF
--- a/projects/cashmere-examples/package.json
+++ b/projects/cashmere-examples/package.json
@@ -11,6 +11,7 @@
         "@angular/core": "~12.2.13",
         "@ng-select/ng-select": "^7.4.0",
         "@angular-slider/ngx-slider": "^2.0.4",
+        "rxjs": "~6.6.0",
         "sugar": "^2.0.6",
         "change-case": "^4.1.1",
         "lodash": "^4.17.21",


### PR DESCRIPTION
We've been seeing obscure rxjs-related errors when trying to build and run cashmere-examples. It
appears that these are caused by the presence of two different versions of rxjs within our project.
This prospective fix seeks to resolve this issue by informing cashmere-examples that it should
always use the version 6 dependency. Note: this change should be removed as part of the Angular 13
upgrade, as that will bring us up to rxjs 7 across the board.