### PR TITLE
Getting started update

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-###### Last updated January 22, 2021
+###### Last updated June 16, 2022
 
 :::
 ## Step 1: Install npm dependencies.
@@ -8,13 +8,13 @@
 ### A) Install Cashmere and the Angular CDK
 
 ```BASH
-npm install --save @healthcatalyst/cashmere @angular/cdk
+npm install --save @healthcatalyst/cashmere @angular/cdk@13.3.7
 ```
 
 ### B) *(Optional)* Install additional dependencies as needed.
 - [Font Awesome](https://fontawesome.com) - Recommended icon set. *(For healthcare-specific iconography, see step 3.)*
 - [Noto Sans](https://fonts.google.com/specimen/Noto+Sans) - Recommended font.
-- [Ng-select](https://github.com/ng-select/ng-select) - Needed only if using the multiselect/typeahead component.
+- [Ng-select](https://github.com/ng-select/ng-select) - Needed only if using the multiselect/typeahead component. Look [here](https://github.com/ng-select/ng-select) for which version of ng-select to install based on your Angular version.
 - [Ngx-slider](https://github.com/angular-slider/ngx-slider) - Needed only if using the slider component.
 
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -60,7 +60,7 @@ Anywhere you import the Shared module, Cashmere components will also be availabl
 The root Cashmere stylesheet need to be imported in your app's global style sheet (`src/styles.scss`).
 
 ```scss
-@import "~@healthcatalyst/cashmere/scss/cashmere";
+@import "node_modules/@healthcatalyst/cashmere/scss/cashmere";
 ```
 
 ### B) *(Optional)* Add Font Awesome & Noto Sans.
@@ -89,7 +89,7 @@ In `angular.json`, place references for each font in your project's build target
 If your app needs access to the [Health Catalyst icon font](/foundations/icons), add the following to your app's global style sheet (`src/styles.scss`):
 
 ```scss
-@import "~@healthcatalyst/cashmere/hcicons/hcicons";
+@import "node_modules/@healthcatalyst/cashmere/hcicons/hcicons";
 ```
 
 :::

--- a/guides/styles/login.md
+++ b/guides/styles/login.md
@@ -58,7 +58,7 @@ The following example does not use angular but a post css Preprocesser is needed
 
 -   Install and set css preprocessor like [gulp sass](https://github.com/dlmanning/gulp-sass) or [webpack with sass](https://github.com/webpack-contrib/sass-loader)
 -   Install cashmere npm package
--   Import styles `@import "~@healthcatalyst/cashmere/scss/login-page";`
+-   Import styles `@import "node_modules/@healthcatalyst/cashmere/scss/login-page";`
 -   Use html markup as needed
 
 ```html

--- a/package-lock.json
+++ b/package-lock.json
@@ -12972,15 +12972,6 @@
       "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
-    "node-sass-tilde-importer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz",
-      "integrity": "sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==",
-      "dev": true,
-      "requires": {
-        "find-parent-dir": "^0.3.0"
-      }
-    },
     "nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "lint-staged": "^7.1.2",
     "markdown-it-named-headers": "0.0.4",
     "ng-packagr": "^13.3.1",
-    "node-sass-tilde-importer": "^1.0.2",
     "path": "^0.12.7",
     "prettier": "2.1.2",
     "progress": "^2.0.3",

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.scss
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .demo-extras {
     display: flex;

--- a/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.component.scss
+++ b/projects/cashmere-examples/src/lib/drawer-basic/drawer-basic-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .hc-drawer {
     background-color: $charcoal-blue;

--- a/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.scss
+++ b/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .drawer-content {
     height: 200px; /* used to show menu scrolling effect*/

--- a/projects/cashmere-examples/src/lib/drawer-overlay/drawer-overlay-example.component.scss
+++ b/projects/cashmere-examples/src/lib/drawer-overlay/drawer-overlay-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .hc-drawer {
     background-color: $charcoal-blue;

--- a/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.component.scss
+++ b/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .hc-drawer {
     background-color: $charcoal-blue;

--- a/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.scss
+++ b/projects/cashmere-examples/src/lib/multiselect-custom-templates/multiselect-custom-templates-example.component.scss
@@ -1,5 +1,5 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
-@import "~@healthcatalyst/cashmere/scss/mixins";
+@import "@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/mixins";
 
 p {
     font-size: 14px;

--- a/projects/cashmere-examples/src/lib/progress-dots/progress-dots-example.component.scss
+++ b/projects/cashmere-examples/src/lib/progress-dots/progress-dots-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .progress-example {
     display: flex;

--- a/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.component.scss
+++ b/projects/cashmere-examples/src/lib/progress-spinner/progress-spinner-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .progress-example {
     display: flex;

--- a/projects/cashmere-examples/src/lib/subnav-overview/subnav-overview-example.component.scss
+++ b/projects/cashmere-examples/src/lib/subnav-overview/subnav-overview-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 hc-subnav {
     min-width: 625px;

--- a/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.component.scss
+++ b/projects/cashmere-examples/src/lib/tile-overview/tile-overview-example.component.scss
@@ -1,4 +1,4 @@
-@import "~@healthcatalyst/cashmere/scss/colors";
+@import "@healthcatalyst/cashmere/scss/colors";
 
 .tile-example-select {
     max-width: 350px;

--- a/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.scss
+++ b/projects/cashmere-examples/src/lib/toaster-overview/toaster-overview-example.component.scss
@@ -1,4 +1,4 @@
-@import '~@healthcatalyst/cashmere/scss/colors';
+@import '@healthcatalyst/cashmere/scss/colors';
 
 .example-column {
     display: inline-block;

--- a/projects/cashmere-examples/src/project-template/src/styles.scss
+++ b/projects/cashmere-examples/src/project-template/src/styles.scss
@@ -5,9 +5,9 @@ $notosans-fontface-path: "node_modules/notosans-fontface/fonts";
 @import "~notosans-fontface/scss/notosans-fontface-allweight";
 
 $hc-icons-font-path: 'node_modules/@healthcatalyst/cashmere/hcicons';
-@import '~@healthcatalyst/cashmere/hcicons/hcicons';
+@import 'node_modules/@healthcatalyst/cashmere/hcicons/hcicons';
 
-@import '~@healthcatalyst/cashmere/scss/cashmere';
+@import 'node_modules/@healthcatalyst/cashmere/scss/cashmere';
 
 // global styles for stackblitz examples
 .demo-button {

--- a/projects/cashmere/src/lib/multiselect/multiselect.md
+++ b/projects/cashmere/src/lib/multiselect/multiselect.md
@@ -40,7 +40,7 @@ By importing the Cashmere styles in your app's global style sheet, you'll automa
 (It's likely you completed this step when installing cashmere.)
 
 ```
-@import "~@healthcatalyst/cashmere/scss/cashmere";
+@import "node_modules/@healthcatalyst/cashmere/scss/cashmere";
 ```
 
 &nbsp;

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -3,7 +3,6 @@
 const fse = require('fs-extra');
 const path = require('path');
 const sass = require('sass');
-const tildeImporter = require('node-sass-tilde-importer');
 
 const projectName = 'cashmere';
 const libSrcDir = '../projects/cashmere';
@@ -28,8 +27,7 @@ Promise.all(copyAssets(resolveSrcDestPaths(assets)))
 sass.render(
     {
         outFile: './dist/cashmere/cashmere.css',
-        file: './projects/cashmere/src/lib/static.scss',
-        importer: tildeImporter
+        file: './projects/cashmere/src/lib/static.scss'
     },
     function(error, result) {
         if (error) {

--- a/src/app/foundations/icons/icon-guide.component.html
+++ b/src/app/foundations/icons/icon-guide.component.html
@@ -27,7 +27,7 @@
             The <strong>hc-icons</strong> font set is included with the Cashmere npm package.
             See Step 3-C in the <a routerLink="/web/guides/getting-started">getting started guide</a> for information on how to include the font in your Angular web app.
             If you're working on a project that isn't using sass, but can still pull the Cashmere npm package, a css file is also included:<br>
-            <code>~@healthcatalyst/cashmere/hcicons/css/hcicons.css</code>
+            <code>node_modules/@healthcatalyst/cashmere/hcicons/css/hcicons.css</code>
         </p>
         <p>If you'd like to install the font on your computer or add it to your project manually, you may download the font files and stylesheets below.</p>
         <br>


### PR DESCRIPTION
Some changes to the documentation, examples, and build scripts around how we use sass. There have been changes around the way SASS imports within angular.
- tilde imports are deprecated and don't work in most cases, so had to switch to relative paths or absolute paths in some places
- in examples, the node_modules paths don't compile, but `@healthcatalyst/../..` paths do


I'm not in a hurry to get this PR in, but wanted to show what I'm finding that works. I wish I could double check this in stackblitz, but Cashmere 13 still isn't coming up. 

We should probably regroup and look together at all the issues we've seen with Angular & Cashmere 13, talk about how to avoid those in the future for major releases. Maybe some more diligent testing in a few projects before announcing the update.