### PR TITLE
feat(drawer): animated param

### DIFF
--- a/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.html
+++ b/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.html
@@ -1,6 +1,6 @@
 <div class="drawer-container">
-    <hc-drawer-container>
-        <hc-menu-drawer align="left" menuTheme="dark-theme" [ignoreEscapeKey]="true" #leftDrawer>
+    <hc-drawer-container [animated]="isAnimated.value">
+        <hc-menu-drawer align="left" mode="push" menuTheme="dark-theme" [ignoreEscapeKey]="true" #leftDrawer>
             <div hcDrawerToolbar>Filter Sets</div>
             <hc-drawer-item>
                 <div class="drawer-label">
@@ -68,6 +68,7 @@
                 [checked]="leftDrawer.ignoreEscapeKey"
                 (change)="leftDrawer.ignoreEscapeKey = !leftDrawer.ignoreEscapeKey"
             >Ignore escape key</hc-checkbox>
+            <hc-checkbox [formControl]="isAnimated">Animated drawer</hc-checkbox>
         </div>
     </hc-drawer-container>
 </div>

--- a/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.ts
+++ b/projects/cashmere-examples/src/lib/drawer-menu/drawer-menu-example.component.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 /**
  * @title Filter menu
@@ -8,4 +9,6 @@ import {Component} from '@angular/core';
     templateUrl: 'drawer-menu-example.component.html',
     styleUrls: ['drawer-menu-example.component.scss']
 })
-export class DrawerMenuExampleComponent {}
+export class DrawerMenuExampleComponent {
+    isAnimated = new FormControl(true);
+}

--- a/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.component.html
+++ b/projects/cashmere-examples/src/lib/drawer-side/drawer-side-example.component.html
@@ -1,5 +1,5 @@
 <div class="drawer-container">
-    <hc-drawer-container>
+    <hc-drawer-container animated="false">
         <hc-drawer align="left" mode="side" opened>
             Left drawer content
         </hc-drawer>

--- a/projects/cashmere/src/lib/drawer/drawer-container.component.html
+++ b/projects/cashmere/src/lib/drawer/drawer-container.component.html
@@ -1,7 +1,10 @@
 <ng-content select="hc-drawer,hc-menu-drawer"></ng-content>
 
-<div class="hc-drawer-content"
-     [style.margin-left.px]="_contentMargins.left"
-     [style.margin-right.px]="_contentMargins.right">
+<div
+    class="hc-drawer-content"
+    [style.margin-left.px]="_contentMargins.left"
+    [style.margin-right.px]="_contentMargins.right"
+    [class.hc-drawer-animation]="animated"
+>
     <ng-content></ng-content>
 </div>

--- a/projects/cashmere/src/lib/drawer/drawer.component.scss
+++ b/projects/cashmere/src/lib/drawer/drawer.component.scss
@@ -20,4 +20,8 @@
 
 .hc-drawer-content {
     @include hc-drawer-content();
+
+    &.hc-drawer-animation {
+        @include hc-drawer-animation();
+    }
 }

--- a/projects/cashmere/src/lib/drawer/drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.ts
@@ -88,7 +88,7 @@ const closeStateAnimation = '0.7s .05s ease';
 export class Drawer implements AfterContentInit {
     private _mode = 'push';
     private _align = 'left';
-    _animated = false;
+    _animated = true;
 
     /** Defaults to false. Set to true to disable the closure of drawer by pressing the escape key. */
     @Input() ignoreEscapeKey = false;
@@ -119,7 +119,7 @@ export class Drawer implements AfterContentInit {
     @Output()
     get openStart(): Observable<void> {
         return this._animationStarted.pipe(
-            filter(event => event.fromState === 'void' && event.toState.startsWith('open-') ),
+            filter(event => (event.fromState === 'void' || event.fromState === 'close-instant') && event.toState.startsWith('open-') ),
             map(() => {
                 // do nothing.
             })
@@ -130,7 +130,7 @@ export class Drawer implements AfterContentInit {
     @Output()
     get closeStart(): Observable<void> {
         return this._animationStarted.pipe(
-            filter(event => event.fromState.startsWith('open-') && event.toState === 'void'),
+            filter(event => event.fromState.startsWith('open-') && (event.toState === 'void' || event.toState === 'close-instant')),
             map(() => {
                 // do nothing.
             })

--- a/projects/cashmere/src/lib/drawer/drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.ts
@@ -54,7 +54,7 @@ const closeStateAnimation = '0.7s .05s ease';
                 })
             ),
             state(
-                'void',
+                'void, close-instant',
                 style({
                     'box-shadow': 'none',
                     // overflow override included to prevent Safari from still showing the scrollbar when the drawer is closed
@@ -63,6 +63,9 @@ const closeStateAnimation = '0.7s .05s ease';
                 })
             ),
             transition('void => open-instant', animate('0ms')),
+            transition('open-instant => close-instant', animate('0ms')),
+            transition('open-left => close-instant', animate('0ms')),
+            transition('open-right => close-instant', animate('0ms')),
             transition('open-instant => void', animate(openStateAnimation)),
             transition('void => open-left', [
                 animate('0ms', style({ transform: 'translate3d(-100%, 0, 0)' })),
@@ -85,6 +88,7 @@ const closeStateAnimation = '0.7s .05s ease';
 export class Drawer implements AfterContentInit {
     private _mode = 'push';
     private _align = 'left';
+    _animated = false;
 
     /** Defaults to false. Set to true to disable the closure of drawer by pressing the escape key. */
     @Input() ignoreEscapeKey = false;
@@ -193,15 +197,15 @@ export class Drawer implements AfterContentInit {
     }
 
     @HostBinding('@openState')
-    get _openState(): 'void' | 'open-instant' | 'open-left' | 'open-right' {
+    get _openState(): 'void' | 'open-instant' | 'close-instant'| 'open-left' | 'open-right' {
         if (this._drawerOpened) {
-            if (this._animationDisabled) {
+            if (this._animationDisabled || !this._animated) {
                 return 'open-instant';
             }
 
             return this._align === 'right' ? 'open-right' : 'open-left';
         }
-        return 'void';
+        return this._animated ? 'void' : 'close-instant';
     }
 
     @HostListener('@openState.start', ['$event'])

--- a/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/menu-drawer/menu-drawer.component.ts
@@ -41,7 +41,7 @@ const closeStateAnimation = '0.7s .05s ease';
                 })
             ),
             state(
-                'void',
+                'void, close-instant',
                 style({
                     'box-shadow': 'none',
                     visibility: 'hidden'
@@ -49,6 +49,9 @@ const closeStateAnimation = '0.7s .05s ease';
             ),
             transition('void => open-instant', animate('0ms')),
             transition('open-instant => void', animate(openStateAnimation)),
+            transition('open-instant => close-instant', animate('0ms')),
+            transition('open-left => close-instant', animate('0ms')),
+            transition('open-right => close-instant', animate('0ms')),
             transition('void => open-left', [
                 animate('0ms', style({ transform: 'translate3d(-100%, 0, 0)' })),
                 animate(closeStateAnimation)

--- a/projects/cashmere/src/lib/sass/drawer.scss
+++ b/projects/cashmere/src/lib/sass/drawer.scss
@@ -43,7 +43,9 @@ $drawer-container-padding: 10px 20px;
     overflow: auto;
     padding: $drawer-container-padding;
     right: 0;
+}
 
+@mixin hc-drawer-animation() {
     transition: {
         duration: 0.7s;
         property: transform, margin-left, margin-right;


### PR DESCRIPTION
adds ability to turn drawer animation on or off

@robertjorg - let me know how this looks.  The only gotcha is that the animation disable will actually be on `hc-drawer-container` rather than `hc-drawer`.  The reason being there is animation on both the drawer and the content.  So the toggle needs to be on the container so it can enable/disable both.

closes #1901