### PR TITLE
feat(table): hc-index-cell

### DIFF
--- a/projects/cashmere-examples/src/lib/table-filter/table-filter-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-filter/table-filter-example.component.html
@@ -5,8 +5,8 @@
 
     <!-- Position Column -->
     <ng-container hcColumnDef="position">
-        <th hc-header-cell *hcHeaderCellDef>No.</th>
-        <td hc-cell *hcCellDef="let element">{{element.position}}</td>
+        <th hc-index-cell *hcHeaderCellDef>#</th>
+        <td hc-index-cell *hcCellDef="let element">{{element.position}}</td>
     </ng-container>
 
     <!-- Name Column -->

--- a/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
@@ -4,8 +4,8 @@
 
     <!-- Position Column -->
     <ng-container hcColumnDef="position">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header>No.</th>
-        <td hc-cell *hcCellDef="let element">{{element.position}}</td>
+        <th hc-index-cell *hcHeaderCellDef hc-sort-header>#</th>
+        <td hc-index-cell *hcCellDef="let element">{{element.position}}</td>
     </ng-container>
 
     <!-- Name Column -->

--- a/projects/cashmere/src/lib/app-switcher/app-switcher.component.ts
+++ b/projects/cashmere/src/lib/app-switcher/app-switcher.component.ts
@@ -1,5 +1,5 @@
 import {takeUntil} from 'rxjs/operators';
-import {Component, Inject, OnDestroy, OnInit, Input, ViewEncapsulation, Output, EventEmitter} from '@angular/core';
+import {Component, Inject, OnDestroy, OnInit, Input, ViewEncapsulation, Output, EventEmitter, HostBinding} from '@angular/core';
 import {Subject, Observable} from 'rxjs';
 
 import {IAppSwitcherService, IDiscoveryApplication, APP_SWITCHER_SERVICE} from './app-switcher-interfaces';
@@ -12,10 +12,11 @@ import {WorkTrackerService} from '../shared/work-tracker.service';
     selector: 'hc-app-switcher',
     templateUrl: './app-switcher.component.html',
     styleUrls: ['./app-switcher.component.scss'],
-    host: {class: 'hc-app-switcher-container'},
     encapsulation: ViewEncapsulation.None
 })
 export class AppSwitcherComponent implements OnInit, OnDestroy {
+    @HostBinding('class.hc-app-switcher-container') _hostClass = true;
+
     /** The array of applications pulled from the Discovery Service */
     public applications: IDiscoveryApplication[];
 

--- a/projects/cashmere/src/lib/button/button.component.ts
+++ b/projects/cashmere/src/lib/button/button.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, ElementRef, Input, Renderer2, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, Renderer2, ViewEncapsulation} from '@angular/core';
 import {parseBooleanAttribute} from '../util';
 
 export const supportedStyles = ['primary', 'primary-alt', 'destructive', 'neutral', 'secondary', 'minimal', 'link', 'link-inline'];
@@ -25,9 +25,6 @@ const buttonAttributes = ['hc-icon-button', 'hc-button'];
     selector: 'button[hc-button], button[hc-icon-button]',
     template: '<ng-content></ng-content>',
     styleUrls: ['./button.component.scss'],
-    host: {
-        '[disabled]': 'disabled || null'
-    },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
@@ -73,6 +70,11 @@ export class ButtonComponent {
 
     set disabled(isDisabled: boolean) {
         this._disabled = parseBooleanAttribute(isDisabled);
+    }
+
+    @HostBinding('attr.disabled')
+    get _disabledAttr(): string | null {
+        return this.disabled ? "disabled" : null;
     }
 
     constructor(public elementRef: ElementRef, private renderer: Renderer2) {

--- a/projects/cashmere/src/lib/datepicker/calendar-body/calendar-body.component.ts
+++ b/projects/cashmere/src/lib/datepicker/calendar-body/calendar-body.component.ts
@@ -9,7 +9,8 @@ import {
     EventEmitter,
     ElementRef,
     NgZone,
-    SimpleChanges
+    SimpleChanges,
+    HostBinding
 } from '@angular/core';
 import {take} from 'rxjs/operators';
 
@@ -40,16 +41,15 @@ export class HcCalendarCell {
     selector: '[hc-calendar-body]',
     templateUrl: './calendar-body.component.html',
     styleUrls: ['calendar-body.component.scss'],
-    host: {
-        class: 'hc-calendar-body',
-        role: 'grid',
-        'aria-readonly': 'true'
-    },
     exportAs: 'hcCalendarBody',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CalendarBodyComponent implements OnChanges {
+    @HostBinding('class.hc-calendar-body') _hostClass = true;
+    @HostBinding('attr.role') _role = 'grid';
+    @HostBinding('attr.aria-readonly') _aria = true;
+
     /** The label for the table. (e.g. "Jan 2017"). */
     @Input()
     label: string;

--- a/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
+++ b/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
@@ -14,7 +14,8 @@ import {
     AfterContentInit,
     AfterViewChecked,
     OnDestroy,
-    OnChanges
+    OnChanges,
+    HostBinding
 } from '@angular/core';
 import {HcDatepickerIntl} from '../datepicker-intl';
 import {ComponentPortal, Portal, ComponentType} from '@angular/cdk/portal';
@@ -183,14 +184,13 @@ export class CalendarHeaderComponent {
     selector: 'hc-calendar',
     templateUrl: './calendar.component.html',
     styleUrls: ['calendar.component.scss'],
-    host: {
-        class: 'hc-calendar'
-    },
     exportAs: 'hcCalendar',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CalendarComponent implements AfterContentInit, AfterViewChecked, OnDestroy, OnChanges {
+    @HostBinding('class.hc-calendar') _hostClass = true;
+
     /** An input indicating the type of the header component, if set. */
     @Input()
     headerComponent: ComponentType<unknown>;

--- a/projects/cashmere/src/lib/env-switcher/env-switcher.component.ts
+++ b/projects/cashmere/src/lib/env-switcher/env-switcher.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, Input, ViewEncapsulation, Output, EventEmitter, ViewChild, forwardRef} from '@angular/core';
+import {Component, OnDestroy, Input, ViewEncapsulation, Output, EventEmitter, ViewChild, forwardRef, HostBinding} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {IMetadataEnvironment, IMetadataEnvironmentVM, badgeColorClasses} from './env-switcher-interfaces';
@@ -16,10 +16,11 @@ import {HcPopComponent} from '../pop/popover.component';
             multi: true
         }
     ],
-    host: {class: 'hc-env-switcher-container'},
     encapsulation: ViewEncapsulation.None
 })
 export class EnvSwitcherComponent implements OnDestroy, ControlValueAccessor {
+    @HostBinding('class.hc-env-switcher-container') _hostClass = true;
+
     /** The currently active metadata environments.
      * NgModel/FormValue is bound to just the environment IDs, but you can access this property for an array with the entire environment model. */
     public get selectedEnvironments(): IMetadataEnvironment[] {

--- a/projects/cashmere/src/lib/modal/modal-overlay.component.ts
+++ b/projects/cashmere/src/lib/modal/modal-overlay.component.ts
@@ -20,7 +20,6 @@ import {animate, state, style, transition, trigger} from '@angular/animations';
             }
         `
     ],
-    host: {class: 'hc-modal-overlay'},
     animations: [
         trigger('fadeInOut', [
             state('in', style({opacity: 0.5})),
@@ -36,6 +35,8 @@ import {animate, state, style, transition, trigger} from '@angular/animations';
 export class ModalOverlayComponent {
     @Input()
     _ignoreEscapeKey = false;
+
+    @HostBinding('class.hc-modal-overlay') _hostClass = true;
 
     constructor(private activeModal: ActiveModal) {}
 

--- a/projects/cashmere/src/lib/modal/modal-window.component.ts
+++ b/projects/cashmere/src/lib/modal/modal-window.component.ts
@@ -20,7 +20,6 @@ import {ActiveModal} from './active-modal';
         </div>
     `,
     encapsulation: ViewEncapsulation.None,
-    host: {class: 'hc-modal-window'},
     styleUrls: ['./modal-window.component.scss'],
     animations: [
         trigger('fadeInOut', [
@@ -42,6 +41,8 @@ export class ModalWindowComponent {
     _autoFocus = false;
     _previouslyFocusedElement: HTMLElement | null;
     _focusTrap: ConfigurableFocusTrap | undefined;
+
+    @HostBinding('class.hc-modal-window') _hostClass = true;
 
     constructor(
         private activeModal: ActiveModal,

--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -13,6 +13,14 @@
         @include hc-table-header-cell();
     }
 
+    .hc-index-cell {
+        @include hc-table-cell-justify-center();
+    }
+
+    th.hc-index-cell:not(.hc-sort-header):not(.hc-col-sortable):not(.hc-col-sortable-left) {
+        @include hc-table-index-cell();
+    }
+
     tbody {
         @include hc-table-body();
     }
@@ -21,8 +29,13 @@
         @include hc-table-body-row();
     }
 
-    td {
+    td:not(.hc-index-cell) {
         @include hc-table-body-cell();
+    }
+
+    td.hc-index-cell {
+        @include hc-table-index-cell();
+        @include hc-table-index-body-cell();
     }
 
     tfoot {
@@ -42,6 +55,10 @@
         &.hc-col-sortable,
         &.hc-col-sortable-left {
             @include hc-small-table-header-sortable();
+        }
+
+        &.hc-index-cell:not(.hc-sort-header):not(.hc-col-sortable):not(.hc-col-sortable-left) {
+            @include hc-table-index-cell();
         }
     }
 }

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -77,6 +77,16 @@ $row-selected-border-color: $white;
     vertical-align: top;
 }
 
+@mixin hc-table-index-body-cell() {
+    background-color: $slate-gray-200;
+}
+
+@mixin hc-table-index-cell() {
+    padding-right: 12px;
+    padding-left: 12px;
+    width: 0;
+}
+
 @mixin hc-table-footer() {
     font-size: $thead-font-size;
     font-weight: 600;

--- a/projects/cashmere/src/lib/sort/sort-header.ts
+++ b/projects/cashmere/src/lib/sort/sort-header.ts
@@ -18,7 +18,8 @@ import {
     OnInit,
     Optional,
     ViewEncapsulation,
-    HostBinding
+    HostBinding,
+    HostListener
 } from '@angular/core';
 import {merge, Subscription} from 'rxjs';
 import {HcSort, HcSortable} from './sort';
@@ -61,11 +62,6 @@ export interface ArrowViewStateTransition {
     exportAs: 'hcSortHeader',
     templateUrl: 'sort-header.html',
     styleUrls: ['sort-header.scss'],
-    host: {
-        '(click)': '_handleClick()',
-        '[attr.aria-sort]': '_getAriaSortAttribute()',
-        '[class.hc-sort-header-disabled]': '_isDisabled()'
-    },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     animations: [
@@ -222,6 +218,7 @@ export class HcSortHeader implements HcSortable, OnDestroy, OnInit {
     }
 
     /** Triggers the sort on this sort header and removes the indicator hint. */
+    @HostListener('click')
     _handleClick(): void {
         if (this._isDisabled()) {
             return;
@@ -274,6 +271,7 @@ export class HcSortHeader implements HcSortable, OnDestroy, OnInit {
         this._arrowDirection = this._isSorted() ? this._sort.direction : this.start || this._sort.start;
     }
 
+    @HostBinding('class.hc-sort-header-disabled')
     _isDisabled(): boolean {
         return this._sort.disabled || this.disabled;
     }
@@ -284,6 +282,7 @@ export class HcSortHeader implements HcSortable, OnDestroy, OnInit {
      * says that the aria-sort property should only be present on one header at a time, so removing
      * ensures this is true.
      */
+    @HostBinding('attr.aria-sort')
     _getAriaSortAttribute(): string | null {
         if (!this._isSorted()) {
             return null;

--- a/projects/cashmere/src/lib/table/cell.ts
+++ b/projects/cashmere/src/lib/table/cell.ts
@@ -7,7 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Input} from '@angular/core';
+import {Directive, ElementRef, HostBinding, Input} from '@angular/core';
 import {CdkCell, CdkCellDef, CdkColumnDef, CdkFooterCell, CdkFooterCellDef, CdkHeaderCell, CdkHeaderCellDef} from '@angular/cdk/table';
 
 /**
@@ -90,13 +90,12 @@ export class HcColumnDef extends CdkColumnDef {
 
 /** Header cell template container that adds the right classes and role. */
 @Directive({
-    selector: 'hc-header-cell, th[hc-header-cell]',
-    host: {
-        class: 'hc-header-cell',
-        role: 'columnheader'
-    }
+    selector: 'hc-header-cell, th[hc-header-cell]'
 })
 export class HcHeaderCell extends CdkHeaderCell {
+    @HostBinding('class.hc-header-cell') _hostClass = true;
+    @HostBinding('attr.role') _role = 'columnheader';
+
     constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
@@ -106,13 +105,12 @@ export class HcHeaderCell extends CdkHeaderCell {
 
 /** Footer cell template container that adds the right classes and role. */
 @Directive({
-    selector: 'hc-footer-cell, td[hc-footer-cell]',
-    host: {
-        class: 'hc-footer-cell',
-        role: 'gridcell'
-    }
+    selector: 'hc-footer-cell, td[hc-footer-cell]'
 })
 export class HcFooterCell extends CdkFooterCell {
+    @HostBinding('class.hc-footer-cell') _hostClass = true;
+    @HostBinding('attr.role') _role = 'gridcell';
+
     constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
@@ -122,13 +120,12 @@ export class HcFooterCell extends CdkFooterCell {
 
 /** Cell template container that adds the right classes and role. */
 @Directive({
-    selector: 'hc-cell, td[hc-cell]',
-    host: {
-        class: 'hc-cell',
-        role: 'gridcell'
-    }
+    selector: 'hc-cell, td[hc-cell]'
 })
 export class HcCell extends CdkCell {
+    @HostBinding('class.hc-cell') _hostClass = true;
+    @HostBinding('attr.role') _role = 'gridcell';
+
     constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
@@ -138,13 +135,12 @@ export class HcCell extends CdkCell {
 
 /** Row index cell template container that adds the right classes and role. */
 @Directive({
-    selector: 'hc-index-cell, td[hc-index-cell], th[hc-index-cell]',
-    host: {
-        class: 'hc-index-cell',
-        role: 'gridcell'
-    }
+    selector: 'hc-index-cell, td[hc-index-cell], th[hc-index-cell]'
 })
 export class HcIndexCell extends CdkCell {
+    @HostBinding('class.hc-index-cell') _hostClass = true;
+    @HostBinding('attr.role') _role = 'gridcell';
+
     constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);

--- a/projects/cashmere/src/lib/table/cell.ts
+++ b/projects/cashmere/src/lib/table/cell.ts
@@ -135,3 +135,19 @@ export class HcCell extends CdkCell {
         elementRef.nativeElement.classList.add(`hc-table-justify-` + columnDef.justify);
     }
 }
+
+/** Row index cell template container that adds the right classes and role. */
+@Directive({
+    selector: 'hc-index-cell, td[hc-index-cell], th[hc-index-cell]',
+    host: {
+        class: 'hc-index-cell',
+        role: 'gridcell'
+    }
+})
+export class HcIndexCell extends CdkCell {
+    constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
+        super(columnDef, elementRef);
+        elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
+        elementRef.nativeElement.classList.add(`hc-table-justify-` + columnDef.justify);
+    }
+}

--- a/projects/cashmere/src/lib/table/cell.ts
+++ b/projects/cashmere/src/lib/table/cell.ts
@@ -148,6 +148,5 @@ export class HcIndexCell extends CdkCell {
     constructor(columnDef: HcColumnDef, elementRef: ElementRef) {
         super(columnDef, elementRef);
         elementRef.nativeElement.classList.add(`hc-column-${columnDef.cssClassFriendlyName}`);
-        elementRef.nativeElement.classList.add(`hc-table-justify-` + columnDef.justify);
     }
 }

--- a/projects/cashmere/src/lib/table/index.ts
+++ b/projects/cashmere/src/lib/table/index.ts
@@ -1,5 +1,5 @@
 export {TableModule} from './table.module';
-export {HcCellDef, HcHeaderCellDef, HcFooterCellDef, HcColumnDef, HcHeaderCell, HcFooterCell, HcCell} from './cell';
+export {HcCellDef, HcHeaderCellDef, HcFooterCellDef, HcColumnDef, HcHeaderCell, HcFooterCell, HcCell, HcIndexCell} from './cell';
 export {HcHeaderRowDef, HcFooterRowDef, HcRowDef, HcHeaderRow, HcFooterRow, HcRow} from './row';
 export {HcCellResizer, CellResizeEvent} from './cell-resizer.component';
 export {HcTable} from './table.component';

--- a/projects/cashmere/src/lib/table/row.ts
+++ b/projects/cashmere/src/lib/table/row.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Directive, HostBinding, ViewEncapsulation} from '@angular/core';
 import {CDK_ROW_TEMPLATE, CdkFooterRow, CdkFooterRowDef, CdkHeaderRow, CdkHeaderRowDef, CdkRow, CdkRowDef} from '@angular/cdk/table';
 
 /**
@@ -47,43 +47,40 @@ export class HcRowDef<T> extends CdkRowDef<T> {}
 @Component({
     selector: 'hc-header-row, tr[hc-header-row]',
     template: CDK_ROW_TEMPLATE,
-    host: {
-        class: 'hc-header-row',
-        role: 'row'
-    },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     exportAs: 'hcHeaderRow',
     providers: [{provide: CdkHeaderRow, useExisting: HcHeaderRow}]
 })
-export class HcHeaderRow extends CdkHeaderRow {}
+export class HcHeaderRow extends CdkHeaderRow {
+    @HostBinding('class.hc-header-row') _hostClass = true;
+    @HostBinding('attr.role') _role = 'row';
+}
 
 /** Footer template container that contains the cell outlet. Adds the right class and role. */
 @Component({
     selector: 'hc-footer-row, tr[hc-footer-row]',
     template: CDK_ROW_TEMPLATE,
-    host: {
-        class: 'hc-footer-row',
-        role: 'row'
-    },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     exportAs: 'hcFooterRow',
     providers: [{provide: CdkFooterRow, useExisting: HcFooterRow}]
 })
-export class HcFooterRow extends CdkFooterRow {}
+export class HcFooterRow extends CdkFooterRow {
+    @HostBinding('class.hc-footer-row') _hostClass = true;
+    @HostBinding('attr.role') _role = 'row';
+}
 
 /** Data row template container that contains the cell outlet. Adds the right class and role. */
 @Component({
     selector: 'hc-row, tr[hc-row]',
     template: CDK_ROW_TEMPLATE,
-    host: {
-        class: 'hc-row',
-        role: 'row'
-    },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     exportAs: 'hcRow',
     providers: [{provide: CdkRow, useExisting: HcRow}]
 })
-export class HcRow extends CdkRow {}
+export class HcRow extends CdkRow {
+    @HostBinding('class.hc-row') _hostClass = true;
+    @HostBinding('attr.role') _role = 'row';
+}

--- a/projects/cashmere/src/lib/table/table.module.ts
+++ b/projects/cashmere/src/lib/table/table.module.ts
@@ -8,7 +8,7 @@
 
 import {NgModule} from '@angular/core';
 import {HcTable} from './table.component';
-import {HcCell, HcCellDef, HcColumnDef, HcFooterCell, HcFooterCellDef, HcHeaderCell, HcHeaderCellDef} from './cell';
+import {HcCell, HcCellDef, HcColumnDef, HcFooterCell, HcFooterCellDef, HcHeaderCell, HcHeaderCellDef, HcIndexCell} from './cell';
 import {HcFooterRow, HcFooterRowDef, HcHeaderRow, HcHeaderRowDef, HcRow, HcRowDef} from './row';
 import {HcCellResizer} from './cell-resizer.component';
 import {CdkTableModule} from '@angular/cdk/table';
@@ -31,6 +31,7 @@ const EXPORTED_DECLARATIONS = [
     HcHeaderCell,
     HcCell,
     HcFooterCell,
+    HcIndexCell,
 
     // Row directions
     HcHeaderRow,

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.ts
@@ -8,10 +8,11 @@ import {Params} from '@angular/router';
     templateUrl: './tab.component.html',
     selector: `hc-tab`,
     styleUrls: ['./tab.component.scss'],
-    host: {class: 'hc-tab'},
     encapsulation: ViewEncapsulation.None
 })
 export class TabComponent implements AfterContentInit {
+    @HostBinding('class.hc-tab') _hostClass = true;
+
     /** Plain text title of the tab; for HTML support include a `hc-tab-title` element */
     @Input()
     tabTitle = '';

--- a/projects/cashmere/src/lib/toaster/hc-toast.component.ts
+++ b/projects/cashmere/src/lib/toaster/hc-toast.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, ElementRef, ViewContainerRef, ComponentRef, ChangeDetectorRef, ViewEncapsulation} from '@angular/core';
+import {Component, EventEmitter, ElementRef, ViewContainerRef, ComponentRef, ChangeDetectorRef, ViewEncapsulation, HostBinding} from '@angular/core';
 import {trigger, state, style, transition, animate, AnimationEvent} from '@angular/animations';
 import {Portal, CdkPortalOutletAttachedRef} from '@angular/cdk/portal';
 import {BehaviorSubject} from 'rxjs';
@@ -10,7 +10,6 @@ const ANIMATION_TIMINGS = '400ms cubic-bezier(0.25, 0.8, 0.25, 1)';
     selector: 'hc-toaster',
     templateUrl: './hc-toast.component.html',
     styleUrls: ['./hc-toast.component.scss'],
-    host: {class: 'hc-toaster'},
     animations: [
         trigger('fade', [
             state('void', style({transform: 'none', opacity: 0})),
@@ -43,6 +42,8 @@ export class HcToastComponent {
     get _widthStr(): string {
         return this._width ? `${this._width}px` : 'auto';
     }
+
+    @HostBinding('class.hc-toaster') _hostClass = true;
 
     constructor(public _el: ElementRef, public _viewContainerRef: ViewContainerRef, public _changeRef: ChangeDetectorRef) {}
 

--- a/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.ts
+++ b/src/app/components/component-viewer/shared/document-viewer/document-viewer.component.ts
@@ -1,16 +1,15 @@
-import {Component, ElementRef, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+import {Component, ElementRef, EventEmitter, HostBinding, Input, Output, ViewEncapsulation} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 
 @Component({
     selector: 'hc-doc-viewer',
     template: '',
     styleUrls: ['document-viewer.component.scss'],
-    encapsulation: ViewEncapsulation.None,
-    host: {
-        '[class.hc-doc-viewer]': 'true'
-    }
+    encapsulation: ViewEncapsulation.None
 })
 export class DocumentViewerComponent {
+    @HostBinding('class.hc-doc-viewer') _hostClass = true;
+
     @Input()
     set documentUrl(docUrl: string) {
         this.fetchDocument(docUrl);

--- a/src/app/core/cashmere-components-document-items.json
+++ b/src/app/core/cashmere-components-document-items.json
@@ -129,7 +129,7 @@
     "table": {
         "name": "Table",
         "category": "table",
-        "examples": ["resizable-columns", "table-filter", "table-sort", "more-table-styles"],
+        "examples": ["table-sort", "table-filter", "resizable-columns", "more-table-styles"],
         "usageDoc": true
     },
     "tabs": {"name": "Tabs", "category": "layout", "examples": ["tabs-horizontal", "tabs-vertical"]},

--- a/src/app/styles/table/table-demo.component.html
+++ b/src/app/styles/table/table-demo.component.html
@@ -214,6 +214,55 @@
     </hc-tile>
 
     <hc-tile>
+        <h5 id="condensed-table">Indexed Table</h5>
+        <p>Add
+            <code>.hc-index-cell</code> to all <code>td</code> and <code>th</code>
+            elements in a row number/index column (usually the first).
+        </p>
+        <br>
+        <table class="hc-table hc-table-small">
+            <thead>
+                <tr>
+                    <th class="hc-index-cell">#</th>
+                    <th>Name</th>
+                    <th>Weight</th>
+                    <th>Symbol</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="hc-index-cell">1</td>
+                    <td>Hydrogen</td>
+                    <td>1.0079</td>
+                    <td>H</td>
+                </tr>
+                <tr>
+                    <td class="hc-index-cell">2</td>
+                    <td>Helium</td>
+                    <td>4.0026</td>
+                    <td>He</td>
+                </tr>
+                <tr>
+                    <td class="hc-index-cell">3</td>
+                    <td>Lithium</td>
+                    <td>6.941</td>
+                    <td>Li</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <pre>
+        <code>
+    &lt;th class=&quot;hc-index-cell&quot;&gt;#&lt;/th&gt;
+
+        ...
+
+    &lt;td class=&quot;hc-index-cell&quot;&gt;1&lt;/td&gt;
+        </code>
+        </pre>
+    </hc-tile>
+
+    <hc-tile>
         <h5 id="selected-row">Selected Row</h5>
         <p>Add
             <code>.hc-row-selected</code> to a


### PR DESCRIPTION
adds the index-cell type for row number columns

@jonest @corykon let me know what you think of this approach.  My original approach was to add a `rowNumbers` param to hc-table, and then have it automatically add a column with numbers.  But the more I thought about it, the goal with hc-table is to be as flexible as possible, and it seemed like that kind of restricted the value of this to a pretty narrow use case.

So instead I added a new cell type called `hc-index-cell` which can be added to a header or body cell.  When applied it narrows the width and padding of the cell and applies the darker background.  It still respects the padding on sort headers though, and works fine with tight tables.

I updated the first two examples to demonstrate the new cell type.

closes #1816