### PR TITLE
fix(measureable): example load fix

### DIFF
--- a/projects/cashmere-examples/src/lib/measurable-overview/measurable-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/measurable-overview/measurable-overview-example.component.html
@@ -3,7 +3,7 @@
         <hc-measurable
             *ngFor="let button of buttons"
             [itemKey]="button.key">
-            <button hc-button>
+            <button hc-button buttonStyle="secondary">
                 {{button.text}}
                 <hc-icon
                     hcIconSm
@@ -14,7 +14,7 @@
             </button>
         </hc-measurable>
         <button
-            hc-button
+            hc-button buttonStyle="neutral"
             #moreButtons="hcPopAnchor"
             *ngIf="moreButtons && moreButtons.length"
             [hcPop]="popButtons">

--- a/projects/cashmere-examples/src/lib/measurable-overview/measurable-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/measurable-overview/measurable-overview-example.component.ts
@@ -65,7 +65,9 @@ export class MeasurableOverviewExampleComponent implements OnDestroy {
 
     @HostListener('window:load')
     setupButtons(): void {
-        this.refreshButtons();
+        setTimeout(() => {
+            this.refreshButtons();
+        });
 
         this.buttonComponents.changes.pipe(
             takeUntil(this.unsubscribe$)

--- a/projects/cashmere-examples/src/lib/measurable-vertical/measurable-vertical-example.component.html
+++ b/projects/cashmere-examples/src/lib/measurable-vertical/measurable-vertical-example.component.html
@@ -3,7 +3,7 @@
         <hc-measurable
             *ngFor="let button of buttons"
             [itemKey]="button.key">
-            <button hc-button>
+            <button hc-button buttonStyle="secondary">
                 {{button.text}}
                 <hc-icon
                     hcIconSm
@@ -14,7 +14,7 @@
             </button>
         </hc-measurable>
         <button
-            hc-button
+            hc-button buttonStyle="neutral"
             #moreButtons="hcPopAnchor"
             *ngIf="moreButtons && moreButtons.length"
             [hcPop]="popButtons">

--- a/projects/cashmere-examples/src/lib/measurable-vertical/measurable-vertical-example.component.ts
+++ b/projects/cashmere-examples/src/lib/measurable-vertical/measurable-vertical-example.component.ts
@@ -65,7 +65,9 @@ export class MeasurableVerticalExampleComponent {
 
     @HostListener('window:load')
     setupButtons(): void {
-        this.refreshButtons();
+        setTimeout(() => {
+            this.refreshButtons();
+        });
 
         this.buttonComponents.changes.pipe(
             takeUntil(this.unsubscribe$)


### PR DESCRIPTION
@bskeen - just a small fix here that should get rid of the inconsistent behavior on initial load.  It's annoying to have to add an empty `setTimeout` but that seems to be the silver bullet to make sure the widths get calculated only after everything is finished rendering.

I also made an adjustment to the style of the buttons in the button row so they look different from the action buttons.  Just makes the functionality of the example a little clearer.

closes #1909