### PR TITLE
fix(modal): avoid errors when used with *ngIf

### DIFF
--- a/projects/cashmere/src/lib/modal/modal-window.component.scss
+++ b/projects/cashmere/src/lib/modal/modal-window.component.scss
@@ -8,31 +8,31 @@
     @include hc-modal();
 }
 
-.hc-modal-auto {
+.hc-modal-auto hc-modal {
     @include hc-modal-auto();
 }
 
-.hc-modal-sm {
+.hc-modal-sm hc-modal {
     @include hc-modal-sm();
 }
 
-.hc-modal-md {
+.hc-modal-md hc-modal {
     @include hc-modal-md();
 }
 
-.hc-modal-lg {
+.hc-modal-lg hc-modal {
     @include hc-modal-lg();
 }
 
-.hc-modal-xl {
+.hc-modal-xl hc-modal {
     @include hc-modal-xl();
 }
 
-.hc-modal-resizable {
+.hc-modal-resizable hc-modal {
     @include hc-modal-resizable();
 }
 
-.hc-modal-static {
+.hc-modal-static hc-modal {
     @include hc-modal-static();
 }
 

--- a/projects/cashmere/src/lib/modal/modal-window.component.ts
+++ b/projects/cashmere/src/lib/modal/modal-window.component.ts
@@ -6,10 +6,14 @@ import {DOCUMENT} from '@angular/common';
 import {Component, ElementRef, HostBinding, HostListener, Inject, Optional, ViewChild, ViewEncapsulation} from '@angular/core';
 import {ActiveModal} from './active-modal';
 
+// hcmodal[0].setAttribute('class', options.isResizable ? `hc-modal-resizable hc-modal-${options.size}` : `hc-modal-static hc-modal-${options.size}`);
+
 @Component({
     selector: 'hc-modal-window',
     template: `
-        <div #focusTrapElement class="hc-modal {{_disableFullScreen ? '' : 'hc-modal-responsive'}}" cdkDrag [cdkDragDisabled]="!_isDraggable" cdkDragBoundary=".hc-modal-window">
+        <div #focusTrapElement
+            class="hc-modal {{_disableFullScreen ? '' : 'hc-modal-responsive'}} {{_isResizable ? 'hc-modal-resizable' : 'hc-modal-static'}} hc-modal-{{_size}}"
+            cdkDrag [cdkDragDisabled]="!_isDraggable" cdkDragBoundary=".hc-modal-window">
             <div *ngIf="_isDraggable" class="hc-modal-drag-handle" cdkDragHandle>
                 <svg width="24px" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M10 9h4V6h3l-5-5-5 5h3v3zm-1 1H6V7l-5 5 5 5v-3h3v-4zm14 2l-5-5v3h-3v4h3v3l5-5zm-9 3h-4v3H7l5 5 5-5h-3v-3z"></path>
@@ -37,6 +41,8 @@ import {ActiveModal} from './active-modal';
 export class ModalWindowComponent {
     _ignoreOverlayClick = false;
     _isDraggable = false;
+    _isResizable = false;
+    _size = 'auto';
     _disableFullScreen = false;
     _restoreFocus = true;
     _autoFocus = false;

--- a/projects/cashmere/src/lib/modal/modal.service.spec.ts
+++ b/projects/cashmere/src/lib/modal/modal.service.spec.ts
@@ -48,16 +48,16 @@ describe('ModalService', () => {
             const options: ModalOptions = {size: 'lg'};
             mockModalRef = service.open( ModalOverviewExampleModalComponent, options);
 
-            const div = mockModalRef.window?.location.nativeElement.querySelector('.hc-modal');
-            expect(div.className).toContain('hc-modal-lg');
+            const size =  mockModalRef.window?.instance?._size;
+            expect(size).toBe('lg');
         });
 
         it('should open a modal with options and set to resizable', () => {
             const options: ModalOptions = {isResizable: true};
             mockModalRef = service.open( ModalOverviewExampleModalComponent, options);
 
-            const div = mockModalRef.window?.location.nativeElement.querySelector('.hc-modal');
-            expect(div.className).toContain('hc-modal-resizable');
+            const resizable =  mockModalRef.window?.instance?._isResizable;
+            expect(resizable).toBe(true);
         });
     });
 });

--- a/projects/cashmere/src/lib/modal/modal.service.spec.ts
+++ b/projects/cashmere/src/lib/modal/modal.service.spec.ts
@@ -48,7 +48,7 @@ describe('ModalService', () => {
             const options: ModalOptions = {size: 'lg'};
             mockModalRef = service.open( ModalOverviewExampleModalComponent, options);
 
-            const div = mockModalRef.window?.location.nativeElement.querySelector('hc-modal');
+            const div = mockModalRef.window?.location.nativeElement.querySelector('.hc-modal');
             expect(div.className).toContain('hc-modal-lg');
         });
 
@@ -56,7 +56,7 @@ describe('ModalService', () => {
             const options: ModalOptions = {isResizable: true};
             mockModalRef = service.open( ModalOverviewExampleModalComponent, options);
 
-            const div = mockModalRef.window?.location.nativeElement.querySelector('hc-modal');
+            const div = mockModalRef.window?.location.nativeElement.querySelector('.hc-modal');
             expect(div.className).toContain('hc-modal-resizable');
         });
     });

--- a/projects/cashmere/src/lib/modal/modal.service.ts
+++ b/projects/cashmere/src/lib/modal/modal.service.ts
@@ -124,13 +124,11 @@ export class ModalService {
         this._renderer.setStyle(window.location.nativeElement, 'z-index', this._zIndexCounter + 1);
         window.instance._ignoreOverlayClick = options.ignoreOverlayClick;
         window.instance._isDraggable = options.isDraggable;
+        window.instance._isResizable = options.isResizable;
+        window.instance._size = options.size;
         window.instance._disableFullScreen = options.disableFullScreen;
         window.instance._autoFocus = options.autoFocus;
         window.instance._restoreFocus = options.restoreFocus;
-
-        // Gives the child hc-modal component a new class of 'hc-modal-resizable' when the isResizable property is set to true
-        const hcmodal = (window.location.nativeElement as HTMLElement).getElementsByTagName('hc-modal');
-        hcmodal[0].setAttribute('class', options.isResizable ? `hc-modal-resizable hc-modal-${options.size}` : `hc-modal-static hc-modal-${options.size}`);
 
         this._applicationRef.attachView(window.hostView);
         container.appendChild(window.location.nativeElement);


### PR DESCRIPTION
fix #1913

A change to avoid querying for `hc-modal` within the modal service. Avoids a crash for cases where consuming application wraps the `hc-modal` in an *ngIf.