### PR TITLE
Also export hcicons fonts

### DIFF
--- a/projects/cashmere/package.json
+++ b/projects/cashmere/package.json
@@ -30,6 +30,7 @@
     "exports": {
         "./css": "./cashmere.css",
         "./hcicons/hcicons": "./hcicons/hcicons.scss",
+        "./hcicons/*": "./hcicons/*",
         "./scss/*": "./scss/*.scss"
     }
 }


### PR DESCRIPTION
I encountered another situation where the `hcicons` font files needed to be exported for webpack to properly locate and bundle them.

If we don't want to keep revisiting this we may want to to think about adding a wildcard entry. 
```
"exports": {
    "./*": "./*",
...
```