### PR TITLE
docs(stackblitz): temporary stackblitz version fix

### DIFF
--- a/projects/cashmere-examples/src/project-template/package.json
+++ b/projects/cashmere-examples/src/project-template/package.json
@@ -25,7 +25,7 @@
     "core-js": "^2.5.4",
     "rxjs": "^6.6.0",
     "zone.js": "~0.11.4",
-    "@healthcatalyst/cashmere": "*",
+    "@healthcatalyst/cashmere": "^12.8.1",
     "notosans-fontface": "^1.2.4",
     "font-awesome": "4.7.0",
     "sugar": "^2.0.6",


### PR DESCRIPTION
Frustrating to have to do this - but I hate having broken Stackblitz links while we wait for a response from them.  What do you both think?