### PR TITLE
feat(hcmenu): submenus hover trigger

### DIFF
--- a/projects/cashmere/src/lib/pop/directives/menu-item.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/menu-item.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, HostBinding, ElementRef, HostListener} from '@angular/core';
+import {Directive, HostBinding, ElementRef, HostListener, Output, EventEmitter} from '@angular/core';
 
 /** Use `hcMenuItem` for a selectable item in an hcMenu. */
 @Directive({
@@ -8,10 +8,14 @@ export class MenuItemDirective {
     @HostBinding('class.hc-menu-item')
     _hostClass = true;
 
+    // Event fired on mouseenter (used to close submenus)
+    @Output() _itemEnter = new EventEmitter<void>();
+
     // Menu Item uses focus for hover highlighting to sync with keyboard navigation of the menu
     @HostListener('mouseenter')
     focus(): void {
         this.ref.nativeElement.focus();
+        this._itemEnter.emit();
     }
 
     @HostListener('touchend')

--- a/projects/cashmere/src/lib/pop/directives/menu.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/menu.directive.ts
@@ -3,6 +3,7 @@ import type {QueryList} from '@angular/core';
 import {HcPopoverAnchorDirective} from './popover-anchor.directive';
 import {Subject, Subscription} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+import {MenuItemDirective} from './menu-item.directive';
 
 /** The `hcMenu` directive provides a standard way of displaying a series of selectable elements in a popover. */
 @Directive({
@@ -15,23 +16,31 @@ export class MenuDirective implements AfterContentInit, OnDestroy {
     @ContentChildren(HcPopoverAnchorDirective)
     _subMenus: QueryList<HcPopoverAnchorDirective>;
 
+    @ContentChildren(MenuItemDirective)
+    _menuItems: QueryList<MenuItemDirective>;
+
     private unsubscribe$ = new Subject<void>();
 
     ngAfterContentInit(): void {
         this.updateSubMenus();
 
         // Update submenus if they are added dynamically or after check
-        this._subMenus.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.updateSubMenus());
+        this._menuItems.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.updateSubMenus());
     }
 
     /** Rechecks the content for instances of `HcPopComponent` and inits them as submenus */
     updateSubMenus(): void {
         this._subMenus.forEach((anchor: HcPopoverAnchorDirective) => {
             anchor._hasSubmenu = true;
-            // Subscribe to submenu open events so we can close any other submenus currently open
-            anchor.popoverOpened.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
+            // Force the trigger on any menu item with a submenu to a hover trigger
+            anchor.trigger = "hover";
+        });
+
+        // Subscribe to submenu mouseenter events so we can close any other submenus currently open
+        this._menuItems.forEach((item: MenuItemDirective) => {
+            item._itemEnter.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
                 this._subMenus.forEach((sub: HcPopoverAnchorDirective) => {
-                    if (sub !== anchor && sub.attachedPopover.isOpen()) {
+                    if (sub._elementRef.nativeElement !== item.ref.nativeElement && sub.attachedPopover.isOpen()) {
                         sub.attachedPopover._parentCloseBlock = true;
                         sub.attachedPopover._restoreFocusOverride = false;
                         sub.closePopover({}, true);

--- a/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
@@ -262,6 +262,8 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
         this._attachedPopover._offsetPos[0] = this._attachedPopover.horizontalAlign === 'mouse' ? $event.offsetX : 0;
         this._attachedPopover._offsetPos[1] = this._attachedPopover.verticalAlign === 'mouse' ? $event.offsetY : 0;
         this.hoverInterval = window.setTimeout(() => {
+            // Hover triggers on hcMenu sub-menus should only ever open on mouseenter
+            // Toggle would cause the menu to close unexpectedly
             if ( this._hasSubmenu ) {
                 this.openPopover();
             } else {
@@ -277,6 +279,8 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
         if (this.trigger !== 'hover') {
             return;
         }
+        // For hcMenu sub-menus, closing on mouseleave would cause the sub-menu
+        // to close when you leave the anchor and try to move your mouse to the sub-menu
         if ( !this._hasSubmenu ) {
             this.closePopover();
         }

--- a/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
@@ -262,7 +262,11 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
         this._attachedPopover._offsetPos[0] = this._attachedPopover.horizontalAlign === 'mouse' ? $event.offsetX : 0;
         this._attachedPopover._offsetPos[1] = this._attachedPopover.verticalAlign === 'mouse' ? $event.offsetY : 0;
         this.hoverInterval = window.setTimeout(() => {
-            this.togglePopover();
+            if ( this._hasSubmenu ) {
+                this.openPopover();
+            } else {
+                this.togglePopover();
+            }
         }, this.popoverDelay);
     }
 
@@ -273,7 +277,9 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
         if (this.trigger !== 'hover') {
             return;
         }
-        this.closePopover();
+        if ( !this._hasSubmenu ) {
+            this.closePopover();
+        }
     }
 
     /** Handle keyboard navigation of a hcMenu using the arrow or tab keys */

--- a/projects/cashmere/src/lib/pop/pop.md
+++ b/projects/cashmere/src/lib/pop/pop.md
@@ -101,6 +101,34 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 export class AppModule { }
 ```
 
+##### Menus
+
+One common situation where popovers can be leveraged is to create menus within the app.
+Cashmere offers a standard way to present menus from any `hcPop` anchor.
+
+`hcMenu` supports sub-menus as well as keyboard navigation.
+For sub-menus, you add another `hcPop` to a menu item.
+The trigger for sub-menus will automatically be set to hover and cannot be overriden.
+
+```html
+<hc-pop #menu [autoCloseOnContentClick]="true" [showArrow]="false" horizontalAlign="start">
+    <div hcMenu>
+        <a hcMenuItem href="http://example.com" target="_blank">
+            <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-floppy-o"></hc-icon>
+            <span hcMenuText>Save document</span>
+            <span hcMenuSubText>Ctrl + S</span>
+        </a>
+        <button hcMenuItem [hcPop]="editmenu">
+            <span hcMenuIcon></span>
+            <span hcMenuText>Edit document</span>
+            <!-- hcMenuItems with a subMenu will automatically add a caret to the right -->
+        </button>
+    </div>
+</div>
+```
+
+&nbsp;
+
 #### Modifying Animations
 
 By default, the opening and closing animations of a popover are quick with a simple easing curve.

--- a/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
+++ b/projects/cashmere/src/lib/pop/popover-anchoring.service.ts
@@ -392,7 +392,7 @@ export class HcPopoverAnchoringService implements OnDestroy {
             direction: this._getDirection(),
 
             // disable pointer events for hover popovers to avoid potential flickering issues
-            panelClass: anchor.trigger === 'hover' ? 'overlay-pointer-events' : ''
+            panelClass: anchor.trigger === 'hover' && !anchor._hasSubmenu ? 'overlay-pointer-events' : ''
         });
     }
 


### PR DESCRIPTION
I think I actually cracked this one!  As per the request from the Vitalware team, `hcMenu` items with submenus now automatically get their trigger type set to hover.  And I've built enough awareness into the menu directive to know when to close a submenu and when not to.  I think it's working as expected, but please load up this branch and test out the "Popover Menu" example in the Popover component section.  Thanks!

closes #1469