### PR TITLE
docs(react-cashmere): adding link to react-cashmere GH pages

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
                 <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-code"></hc-icon>
                 <span hcMenuText>Angular Components</span>
             </a>
-            <a hcMenuItem href="https://healthcatalyst.github.io/react-cashmere/">
+            <a hcMenuItem href="https://healthcatalyst.github.io/react-cashmere/" target="_blank">
                 <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-code"></hc-icon>
                 <span hcMenuText>React Components</span>
             </a>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,11 @@
         <div hcMenu>
             <a hcMenuItem routerLink="web/components">
                 <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-code"></hc-icon>
-                <span hcMenuText>Components</span>
+                <span hcMenuText>Angular Components</span>
+            </a>
+            <a hcMenuItem href="https://healthcatalyst.github.io/react-cashmere/">
+                <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-code"></hc-icon>
+                <span hcMenuText>React Components</span>
             </a>
             <a hcMenuItem routerLink="web/styles">
                 <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-paint-brush" hcIconSm></hc-icon>


### PR DESCRIPTION
Tweaking the Web Apps dropdown to have `</> Angular Components` and `</> React Components`. The react components links over to `react-cashmere` storybook.

I have also made the `react-cashmere` library public.