### PR TITLE
build(package.json): fix stackblitz examples

### DIFF
--- a/projects/cashmere/package.json
+++ b/projects/cashmere/package.json
@@ -10,10 +10,6 @@
         "type": "Git",
         "url": "https://github.com/HealthCatalyst/Fabric.Cashmere"
     },
-    "main": "./bundles/cashmere.umd.js",
-    "module": "./esm5/cashmere.js",
-    "es2015": "./esm2015/cashmere.js",
-    "jsnext": "./esm2015/cashmere.js",
     "dependencies": {
       "tslib": "^2.0.0"
     },


### PR DESCRIPTION
Remove some references in package.json that are no longer relevant and cause problems for stackblitz. When we upgraded to angular 13, it changed what gets bundled and passed into the dist folder.

My understanding of the properties I've removed in the library's package.json is pretty lacking, but I built a new library using the cli (v13) and angular (v13) and this seems to match that better, and doesn't have any references to non-existent files.

Link to the github issue where we got the tip on what to fix: https://github.com/stackblitz/core/issues/1903#issuecomment-1223762269