### PR TITLE
Fix stackbltiz

### DIFF
--- a/projects/cashmere/package.json
+++ b/projects/cashmere/package.json
@@ -10,10 +10,6 @@
         "type": "Git",
         "url": "https://github.com/HealthCatalyst/Fabric.Cashmere"
     },
-    "main": "./bundles/cashmere.umd.js",
-    "module": "./esm5/cashmere.js",
-    "es2015": "./esm2015/cashmere.js",
-    "jsnext": "./esm2015/cashmere.js",
     "dependencies": {
       "tslib": "^2.0.0"
     },


### PR DESCRIPTION
We won't publicize this new version... more pushing it out and publishing for the sake of testing if it fixes stackblitz.

Will go back and change the stackblitz examples package.json to point to the latest cashmere version after validating that this change works. 
```
"@healthcatalyst/cashmere": "*",
```