### PR TITLE
fix(datepicker): today click selects and closes

### DIFF
--- a/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
+++ b/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
@@ -120,9 +120,9 @@ export class CalendarHeaderComponent {
     }
 
     /** Handles clicks on the jump to today button */
-
     _todayClicked(): void {
-        this.calendar.activeDate = this._dateAdapter.today();
+        this.calendar._dateSelected(this._dateAdapter.today());
+        this.calendar._userSelection.emit(true);
     }
 
     /** Whether the previous period button is enabled. */
@@ -301,9 +301,9 @@ export class CalendarComponent implements AfterContentInit, AfterViewChecked, On
     @Output()
     readonly monthSelected: EventEmitter<D> = new EventEmitter<D>();
 
-    /** Emits when any date is selected. */
+    /** Emits when any date is selected; boolean indicates if Today button was clicked */
     @Output()
-    readonly _userSelection: EventEmitter<void> = new EventEmitter<void>();
+    readonly _userSelection: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     /** Reference to the current month view component. */
     @ViewChild(MonthViewComponent)
@@ -501,7 +501,7 @@ export class CalendarComponent implements AfterContentInit, AfterViewChecked, On
     }
 
     _userSelected(): void {
-        this._userSelection.emit();
+        this._userSelection.emit(false);
     }
 
     /** Handles year/month selection in the multi-year/year views. */

--- a/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
+++ b/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
@@ -121,7 +121,17 @@ export class CalendarHeaderComponent {
 
     /** Handles clicks on the jump to today button */
     _todayClicked(): void {
-        this.calendar._dateSelected(this._dateAdapter.today());
+        const selectedYear = this._dateAdapter.getYear(this._dateAdapter.today());
+        const selectedMonth = this._dateAdapter.getMonth(this._dateAdapter.today());
+        const selectedDate = this._dateAdapter.getDate(this._dateAdapter.today());
+        const todayDate = this._dateAdapter.createDate(selectedYear, selectedMonth, selectedDate);
+
+        if ( this.calendar.mode !== 'date' ) {
+            todayDate.setHours(this._dateAdapter.today().getHours());
+            todayDate.setMinutes(this._dateAdapter.today().getMinutes());
+        }
+
+        this.calendar._dateSelected(todayDate);
         this.calendar._userSelection.emit(true);
     }
 

--- a/projects/cashmere/src/lib/datepicker/datepicker-content/datepicker-content.component.html
+++ b/projects/cashmere/src/lib/datepicker/datepicker-content/datepicker-content.component.html
@@ -15,5 +15,5 @@
     (selectedChange)="datepicker.select($event)"
     (yearSelected)="datepicker._selectYear($event)"
     (monthSelected)="datepicker._selectMonth($event)"
-    (_userSelection)="autoClose()">
+    (_userSelection)="autoClose($event)">
 </hc-calendar>

--- a/projects/cashmere/src/lib/datepicker/datepicker-content/datepicker-content.component.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker-content/datepicker-content.component.ts
@@ -38,8 +38,8 @@ export class DatepickerContentComponent implements AfterViewInit {
     }
 
     /** Close the datepicker automatically on selection only if in date mode */
-    autoClose(): void {
-        if (this.datepicker.mode === 'date') {
+    autoClose( todayClicked: boolean ): void {
+        if (this.datepicker.mode === 'date' || todayClicked ) {
             this.datepicker.close();
         }
     }


### PR DESCRIPTION
As per Vitalware's request, UX improvement to the datepicker to select and close the datepicker when the Today button is clicked (rather than just highlighting the current date but not selecting it).

closes #1962