### PR TITLE
fix(datepicker): allow blank values with new datepicker option

### DIFF
--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
@@ -4,9 +4,10 @@
             <hc-label>Date:</hc-label>
             <input hcInput [hcDatepicker]="picker1" [max]="maxStr" [formControl]="dateControl1" placeholder="Select date..." />
             <hc-datepicker-toggle hcSuffix [for]="picker1"></hc-datepicker-toggle>
-            <hc-datepicker #picker1></hc-datepicker>
+            <hc-datepicker #picker1 [allows-blank-values]="allowsBlankValues"></hc-datepicker>
             <hc-error>Please enter a valid date</hc-error>
         </hc-form-field>
+        <hc-checkbox [(ngModel)]="allowsBlankValues">Allows blank values</hc-checkbox>
     </div>
 
     <div class="example-date-input">

--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.ts
@@ -14,6 +14,7 @@ export class DatepickerExampleComponent {
     });
 
     hourCycle = false;
+    allowsBlankValues = false;
 
     maxStr: string = this.dateControl2.value.toISOString();
 }

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
@@ -95,7 +95,7 @@ export class CalendarWrapperComponent implements OnChanges {
         // eslint-disable-next-line no-prototype-builtins
         if (changes.hasOwnProperty('required')) {
             const isRequired = changes.required.currentValue;
-            this.datePickerInput._allowsBlankValues = !isRequired;
+            this.datePickerInput.allowsBlankValues = !isRequired;
         }
     }
 

--- a/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
@@ -177,7 +177,14 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
     @Input() _hourCycle: number;
 
     /** When true, this allows the date picker to validate with a blank value OR a valid date value. Defaults to false. */
-    @Input() _allowsBlankValues: boolean;
+    @Input()
+    get allowsBlankValues(): boolean {
+        return this._allowsBlankValues;
+    }
+    set allowsBlankValues(value: boolean) {
+        this._allowsBlankValues = parseBooleanAttribute(value);
+    }
+    private _allowsBlankValues: boolean;
 
     /** Emits when the value changes (either due to user input or programmatic change). */
     _valueChange = new EventEmitter<D | null>();

--- a/projects/cashmere/src/lib/datepicker/datepicker.component.spec.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker.component.spec.ts
@@ -160,6 +160,18 @@ class DatepickerWithCustomIcon {}
 
 @Component({
     template: `
+        <input [hcDatepicker]="d" />
+        <hc-datepicker #d allows-blank-values="true"></hc-datepicker>
+    `
+})
+class DatepickerWithAllowsBlankValues {
+    @ViewChild('d')
+    datepicker: DatepickerComponent;
+    date: Date | null | undefined;
+}
+
+@Component({
+    template: `
         <hc-form-field>
             <input hcInput [hcDatepicker]="d" />
             <hc-datepicker #d></hc-datepicker>
@@ -1782,6 +1794,50 @@ describe('DatepickerComponent', () => {
 
             expect(document.querySelector('.hc-calendar-time-picker')).toBeTruthy();
             expect(document.querySelector('.hc-calendar-content')).toBeTruthy();
+        }));
+    });
+
+    describe('datepicker with allows blank values enabled', () => {
+        let fixture: ComponentFixture<DatepickerWithAllowsBlankValues>;
+        let testComponent: DatepickerWithAllowsBlankValues;
+
+        beforeEach(fakeAsync(() => {
+            fixture = createComponent(DatepickerWithAllowsBlankValues, [HcNativeDateModule]);
+            fixture.detectChanges();
+
+            testComponent = fixture.componentInstance;
+        }));
+
+        afterEach(fakeAsync(() => {
+            testComponent.datepicker.close();
+            fixture.detectChanges();
+        }));
+
+        it('should mark valid when value is valid', fakeAsync(() => {
+            testComponent.date = new Date(2017, JUL, 1);
+            fixture.detectChanges();
+            flush();
+            fixture.detectChanges();
+
+            expect(fixture.debugElement.query(By.css('input')).nativeElement.classList).not.toContain('ng-invalid');
+        }));
+
+        it('should mark valid when value is null', fakeAsync(() => {
+            testComponent.date = null;
+            fixture.detectChanges();
+            flush();
+            fixture.detectChanges();
+
+            expect(fixture.debugElement.query(By.css('input')).nativeElement.classList).not.toContain('ng-invalid');
+        }));
+
+        it('should mark valid when value is undefined', fakeAsync(() => {
+            testComponent.date = undefined;
+            fixture.detectChanges();
+            flush();
+            fixture.detectChanges();
+
+            expect(fixture.debugElement.query(By.css('input')).nativeElement.classList).not.toContain('ng-invalid');
         }));
     });
 });

--- a/projects/cashmere/src/lib/datepicker/datepicker.component.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker.component.ts
@@ -73,9 +73,9 @@ export class DatepickerComponent implements OnDestroy {
     get allowsBlankValues() {
         return this._datepickerInput && this._datepickerInput.allowsBlankValues;
     }
-    set allowsBlankValues(val) {
+    set allowsBlankValues(val: boolean) {
         if (this._datepickerInput) {
-            this._datepickerInput.allowsBlankValues = val;
+            this._datepickerInput.allowsBlankValues = parseBooleanAttribute(val);
         }
     }
 

--- a/projects/cashmere/src/lib/datepicker/datepicker.component.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker.component.ts
@@ -67,6 +67,19 @@ export class DatepickerComponent implements OnDestroy {
     private _scrollStrategy: () => ScrollStrategy;
 
     /**
+     * Whether the datepicker can be set to a blank value (by deleting its contents). Defaults to `false`.
+     */
+    @Input('allows-blank-values')
+    get allowsBlankValues() {
+        return this._datepickerInput && this._datepickerInput.allowsBlankValues;
+    }
+    set allowsBlankValues(val) {
+        if (this._datepickerInput) {
+            this._datepickerInput.allowsBlankValues = val;
+        }
+    }
+
+    /**
      * Whether the datepicker includes the calendar, time selector, or both. Defaults to `date`.
      */
     @Input()


### PR DESCRIPTION
Expose support for `allowBlankValues` in the DatePicker component.

fix #1984