### PR TITLE
fix(drawer): prevent drawer from getting 'stuck'

### DIFF
--- a/projects/cashmere/src/lib/drawer/drawer.component.ts
+++ b/projects/cashmere/src/lib/drawer/drawer.component.ts
@@ -259,6 +259,14 @@ export class Drawer implements AfterContentInit {
 
     /** Toggles the drawer */
     toggle(isOpen = !this.opened): Promise<DrawerPromiseResult> {
+        // If the current state of the drawer matches the desired state of the drawer,
+        // then return an already-resolved Promise whose result matches the current drawer
+        // state. Ideally, we'd punt and return null here, instead, but that would break the
+        // API contract defined by the Drawer, and that would be bad.
+        if (isOpen === this._drawerOpened) {
+            return Promise.resolve(new DrawerPromiseResult(isOpen ? 'open' : 'close'));
+        }
+
         if (!this._animationPromise) {
             this._drawerOpened = isOpen;
 


### PR DESCRIPTION
Immediately return a resolved Promise from the Drawer component's `toggle()` function if the desired state of the Drawer matches the current state of the Drawer. This will prevent the Drawer from getting 'stuck' open when an open Drawer is asked to open itself.

This allows callers to request a particular state without worrying about the Drawer's current state.

fix #2005