### PR TITLE
fix(tabs): arrow overflow scrollIntoView

### DIFF
--- a/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.html
+++ b/projects/cashmere-examples/src/lib/tabs-horizontal/tabs-horizontal-example.component.html
@@ -51,8 +51,8 @@
     </hc-tab-set>
 </div>
 <br>
-<button hc-button title="Set Selection" buttonStyle="primary" (click)="tabSet.selectTab(1)">
-    Select Complete Tasks
+<button hc-button title="Set Selection" buttonStyle="primary" (click)="tabSet.selectTab(7)">
+    Select Last Tab
 </button>
 <button hc-button title="Deselect Tabs" buttonStyle="primary" class="deselect-button" (click)="tabSet.selectTab(-1)">
     Deselect All Tabs

--- a/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab-set/tab-set.component.ts
@@ -183,7 +183,7 @@ export class TabSetComponent implements AfterContentInit {
             takeUntil(this.unsubscribe)
         ).subscribe(([selectedTab, ]) => {
             setTimeout(() => {
-                this.selectTab(selectedTab, false);
+                this.selectTab(selectedTab, false, false);
                 this.changeDetector.detectChanges();
             });
         });
@@ -379,7 +379,7 @@ export class TabSetComponent implements AfterContentInit {
 
     /** Sets the currently selected tab by either its numerical index or `TabComponent` object.
      * Passing a value of -1 will deselect all tabs in the set. */
-    selectTab(tab: number | TabComponent, shouldEmit = true): void {
+    selectTab(tab: number | TabComponent, shouldEmit = true, scrollIntoView = true): void {
         this._selectedTab = tab;
         if ( tab === -1 ) {
             this.tabContent = null;
@@ -398,11 +398,11 @@ export class TabSetComponent implements AfterContentInit {
             if ( this._routerEnabled ) {
                 this.router.navigate([activeTab.routerLink], {relativeTo: this.route});
             }
-            this._setActive(activeTab, shouldEmit);
+            this._setActive(activeTab, shouldEmit, scrollIntoView);
         }
     }
 
-    _setActive(tab: TabComponent, shouldEmit = true): void {
+    _setActive(tab: TabComponent, shouldEmit = true, scrollIntoView = true): void {
         let activeIndex = 0;
         this._tabs.toArray().forEach((t, index) => {
             t._active = false;
@@ -413,6 +413,11 @@ export class TabSetComponent implements AfterContentInit {
         tab._active = true;
         this.tabContent = tab.tabContent;
         this._routerDeselected = false;
+
+        // For horizontal tabs with arrows overflow, scroll the selected tab into view if it's outside the scroll area
+        if ( this.overflowStyle === 'arrows' && this.direction === 'horizontal' && this._collapse && scrollIntoView ) {
+            tab.el.nativeElement.scrollIntoView({ block: 'nearest' });
+        }
 
         if (shouldEmit) {
             this.selectedTabChange.emit(new TabChangeEvent(activeIndex, tab));

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.ts
@@ -55,7 +55,7 @@ export class TabComponent implements AfterContentInit {
     @ContentChildren(HcTabTitleComponent)
     _tabTitle: QueryList<HcTabTitleComponent>;
 
-    constructor( private el: ElementRef ) {}
+    constructor( public el: ElementRef ) {}
 
     ngAfterContentInit(): void {
         if (this._tabTitle) {


### PR DESCRIPTION
Scrolls a tab into view when clicked or selected with selectTab

I kept the use case pretty narrow here because `scrollIntoView` can be pretty annoying if it's firing to often or in the wrong context.  So this is only triggered on horizontal tabs with arrow overflow that's active.  The developer can also elect to turn off scrollIntoView when they call the `selectTab` function.

To test, go to the Tabs page, and set the Horizontal Tabs example to "Arrows" overflow.  Then click the "Select Last Tab" button.

closes #2042