### PR TITLE
fix(form-field): support formGroup disabled

### DIFF
--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.html
@@ -1,15 +1,15 @@
-<form>
+<form [formGroup]="exampleForm">
     <div class="form-sample">
         <hc-form-field>
             <hc-label>Job name:</hc-label>
-            <input hcInput required [formControl]="inputControl">
+            <input hcInput required formControlName="inputControl">
             <hc-error>A job name is required</hc-error>
         </hc-form-field>
     </div>
 
     <hc-form-field inline="true" class="form-padding">
         <hc-label>Data source:</hc-label>
-        <hc-radio-group [formControl]="radioControl" inline="true">
+        <hc-radio-group formControlName="radioControl" inline="true">
             <hc-radio-button value="SM">Source mart</hc-radio-button>
             <hc-radio-button value="SAM">Subject area mart</hc-radio-button>
             <hc-radio-button value="Other">Other</hc-radio-button>
@@ -19,8 +19,8 @@
 
     <div class="form-sample">
         <hc-form-field>
-            <hc-label>How long has it been since your last ER or Urgent Care visit at one of our facilities?</hc-label>
-            <hc-select placeholder="Select answer" [formControl]="selectControl">
+            <hc-label>How long has it been since your last visit?</hc-label>
+            <hc-select placeholder="Select answer" formControlName="selectControl">
                 <option value="daily">Within the last week</option>
                 <option value="weekly">Within the last month</option>
                 <option value="monthly">Within the last 6 months</option>
@@ -33,15 +33,26 @@
     <div class="form-sample flex-column">
         <hc-form-field>
             <hc-label>Requested notifications:</hc-label>
-            <hc-checkbox [formControl]="checkControl">On failure</hc-checkbox>
-            <hc-checkbox [formControl]="checkControl">On success</hc-checkbox>
-            <hc-checkbox [formControl]="checkControl">On row-count mismatch</hc-checkbox>
-            <hc-checkbox [formControl]="checkControl">On dependency-wait timeout</hc-checkbox>
+            <hc-checkbox formControlName="checkOneControl">On failure</hc-checkbox>
+            <hc-checkbox formControlName="checkTwoControl">On success</hc-checkbox>
+            <hc-checkbox formControlName="checkThreeControl">On row-count mismatch</hc-checkbox>
+            <hc-checkbox formControlName="checkFourControl">On dependency-wait timeout</hc-checkbox>
             <hc-error>At least one notification must be selected</hc-error>
+        </hc-form-field>
+    </div>
+
+    <div class="form-sample flex-column">
+        <hc-form-field>
+            <hc-label>Allow notifications:</hc-label>
+            <hc-slide-toggle formControlName="slideControl"></hc-slide-toggle>
+            <hc-error>The notifications setting is invalid</hc-error>
         </hc-form-field>
     </div>
 
     <button hc-button buttonStyle="primary" class="demo-button" (click)="invalidForm()">
         Invalidate All Fields
+    </button>
+    <button hc-button buttonStyle="primary" class="demo-button" (click)="disableToggle()">
+        Toggle Form Enabled
     </button>
 </form>

--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.scss
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.scss
@@ -10,3 +10,7 @@
 .form-padding {
     padding-bottom: 1.525em;
 }
+
+.demo-button {
+    margin-right: 10px;
+}

--- a/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/form-field-overview/form-field-overview-example.component.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {FormControl} from '@angular/forms';
+import {FormControl, FormGroup} from '@angular/forms';
 
 /**
  * @title Multiple Form Field Elements
@@ -10,15 +10,37 @@ import {FormControl} from '@angular/forms';
     styleUrls: ['form-field-overview-example.component.scss']
 })
 export class FormFieldOverviewExampleComponent {
-    selectControl = new FormControl('daily');
-    inputControl = new FormControl('');
-    radioControl = new FormControl('SM');
-    checkControl = new FormControl('');
+    enabledState = true;
+
+    exampleForm: FormGroup = new FormGroup({
+        selectControl: new FormControl('daily'),
+        inputControl: new FormControl(''),
+        radioControl: new FormControl('SM'),
+        checkOneControl: new FormControl(false),
+        checkTwoControl: new FormControl(false),
+        checkThreeControl: new FormControl(false),
+        checkFourControl: new FormControl(false),
+        slideControl: new FormControl(true)
+    });
+
+    disableToggle(): void {
+        if ( this.enabledState ) {
+            this.enabledState = false;
+            this.exampleForm.disable();
+        } else {
+            this.enabledState = true;
+            this.exampleForm.enable();
+        }
+    }
 
     invalidForm(): void {
-        this.inputControl.setErrors({incorrect: true});
-        this.selectControl.setErrors({incorrect: true});
-        this.checkControl.setErrors({incorrect: true});
-        this.radioControl.setErrors({incorrect: true});
+        this.exampleForm.controls['inputControl'].setErrors({incorrect: true});
+        this.exampleForm.controls['selectControl'].setErrors({incorrect: true});
+        this.exampleForm.controls['checkOneControl'].setErrors({incorrect: true});
+        this.exampleForm.controls['checkTwoControl'].setErrors({incorrect: true});
+        this.exampleForm.controls['checkThreeControl'].setErrors({incorrect: true});
+        this.exampleForm.controls['checkFourControl'].setErrors({incorrect: true});
+        this.exampleForm.controls['radioControl'].setErrors({incorrect: true});
+        this.exampleForm.controls['slideControl'].setErrors({incorrect: true});
     }
 }

--- a/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
+++ b/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
@@ -1,5 +1,5 @@
 import { Component, DoCheck, ElementRef, EventEmitter, forwardRef, HostBinding, Input, Optional, Output, Self, ViewChild, ViewEncapsulation } from '@angular/core';
-import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
+import { ControlValueAccessor, FormGroupDirective, NgControl, NgForm } from '@angular/forms';
 import { HcFormControlComponent } from '../form-field/hc-form-control.component';
 import { parseBooleanAttribute } from '../util';
 
@@ -13,7 +13,7 @@ let nextUploaderId = 1;
     encapsulation: ViewEncapsulation.None,
     providers: [{provide: HcFormControlComponent, useExisting: forwardRef(() => FileUploaderComponent)}]
 })
-export class FileUploaderComponent extends HcFormControlComponent implements DoCheck {
+export class FileUploaderComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck {
     @ViewChild('dropZone') _dropZone!: ElementRef<HTMLElement>;
     @ViewChild('fileInput') _fileInputElement: ElementRef;
     private _form: NgForm | FormGroupDirective | null;
@@ -124,6 +124,10 @@ export class FileUploaderComponent extends HcFormControlComponent implements DoC
     }
     public registerOnTouched(fn: () => FileList): void {
         this.onTouch = fn;
+    }
+
+    setDisabledState(disabledVal: boolean): void {
+        this.disabled = disabledVal;
     }
 
     ngDoCheck(): void {

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -200,6 +200,10 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
         this.onTouch = fn;
     }
 
+    setDisabledState(disabledVal: boolean): void {
+        this.disabled = disabledVal;
+    }
+
     _touch(): void {
         if (this.onTouch) {
             this.onTouch();

--- a/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
+++ b/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
@@ -1,5 +1,5 @@
 import {Component, DoCheck, EventEmitter, forwardRef, Input, Optional, Output, Self, ViewEncapsulation} from '@angular/core';
-import {FormGroupDirective, NgControl, NgForm} from '@angular/forms';
+import {ControlValueAccessor, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
 
@@ -34,7 +34,7 @@ export function validateLabelType(inputStr: string): void {
     encapsulation: ViewEncapsulation.None,
     providers: [{provide: HcFormControlComponent, useExisting: forwardRef(() => SlideToggleComponent)}]
 })
-export class SlideToggleComponent extends HcFormControlComponent implements DoCheck {
+export class SlideToggleComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck {
     private _uniqueId = `hc-slide-toggle-${nextToggleId++}`;
     private _form: NgForm | FormGroupDirective | null;
     _buttonState = true;
@@ -139,6 +139,10 @@ export class SlideToggleComponent extends HcFormControlComponent implements DoCh
     }
     public registerOnTouched(fn: () => unknown): void {
         this.onTouch = fn;
+    }
+
+    setDisabledState(disabledVal: boolean): void {
+        this.disabled = disabledVal;
     }
 
     ngDoCheck(): void {


### PR DESCRIPTION
Great catch on this one @bskeen - turns out that the new FileUploader component was missing the `ControlValueAccessor` function `setDisabledState`.  And actually two components were missing `ControlValueAccessor` in the `implements` block.  I'm actually not sure how they were working without that - maybe Angular just infers it 🤷‍♂️ but I'm glad it's corrected now.

closes #2026