### PR TITLE
fix(form-field): remove DoCheck for validation

### DIFF
--- a/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.html
@@ -2,7 +2,7 @@
     <div class="select-sample">
         <hc-form-field tight="true">
             <hc-label>Select with tight styling:</hc-label>
-            <hc-select [formControl]="selectControl" required>
+            <hc-select [formControl]="selectControl" required (change)="resetValidate()">
                 <optgroup label="Business Intelligence Tools">
                     <option value="qlik" selected>QlikView</option>
                     <option value="tableau">Tableau</option>

--- a/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-validation/select-validation-example.component.ts
@@ -14,6 +14,10 @@ export class SelectValidationExampleComponent {
 
     selectControl = new FormControl('qlik');
 
+    resetValidate(): void {
+        this.validCheck = false;
+    }
+
     toggleValidate(): void {
         this.validCheck = !this.validCheck;
         if (this.validCheck) {

--- a/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
+++ b/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
@@ -1,5 +1,7 @@
-import { Component, DoCheck, ElementRef, EventEmitter, forwardRef, HostBinding, Input, Optional, Output, Self, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, EventEmitter, forwardRef, HostBinding, Input, OnDestroy, Optional, Output, Self, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { HcFormControlComponent } from '../form-field/hc-form-control.component';
 import { parseBooleanAttribute } from '../util';
 
@@ -13,10 +15,11 @@ let nextUploaderId = 1;
     encapsulation: ViewEncapsulation.None,
     providers: [{provide: HcFormControlComponent, useExisting: forwardRef(() => FileUploaderComponent)}]
 })
-export class FileUploaderComponent extends HcFormControlComponent implements DoCheck {
+export class FileUploaderComponent extends HcFormControlComponent implements AfterViewInit, OnDestroy {
     @ViewChild('dropZone') _dropZone!: ElementRef<HTMLElement>;
     @ViewChild('fileInput') _fileInputElement: ElementRef;
     private _form: NgForm | FormGroupDirective | null;
+    private _unsubscribe = new Subject<void>();
     private _uniqueId = `hc-file-uploader-${nextUploaderId++}`;
     _fileIcon = '';
     _fileTypes = '*';
@@ -100,6 +103,15 @@ export class FileUploaderComponent extends HcFormControlComponent implements DoC
         this._subtext = val;
     }
 
+    ngAfterViewInit(): void {
+        if ( this._ngControl && this._ngControl.statusChanges ) {
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+        }
+        if ( this._form ) {
+            this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+        }
+    }
+
     constructor(
         @Optional() _parentForm: NgForm,
         @Optional() _parentFormGroup: FormGroupDirective,
@@ -124,13 +136,6 @@ export class FileUploaderComponent extends HcFormControlComponent implements DoC
     }
     public registerOnTouched(fn: () => FileList): void {
         this.onTouch = fn;
-    }
-
-    ngDoCheck(): void {
-        // This needs to be checked every cycle because we can't subscribe to form submissions
-        if (this._ngControl) {
-            this._updateErrorState();
-        }
     }
 
     private _updateErrorState() {
@@ -168,6 +173,7 @@ export class FileUploaderComponent extends HcFormControlComponent implements DoC
 
         this._fileList = selectedFiles;
         this.onChange( this._fileList );
+        this.onTouch();
         this.filesAdded.emit( selectedFiles );
 
         this._determineFileIcon();
@@ -242,5 +248,10 @@ export class FileUploaderComponent extends HcFormControlComponent implements DoC
 
     _unhighlight(): void {
         this._dropZone?.nativeElement.classList.remove('hc-file-uploader-drag-target-over');
+    }
+
+    ngOnDestroy(): void {
+        this._unsubscribe.next();
+        this._unsubscribe.complete();
     }
 }

--- a/projects/cashmere/src/lib/select/select.component.html
+++ b/projects/cashmere/src/lib/select/select.component.html
@@ -6,7 +6,7 @@
         [disabled]="disabled"
         (change)="_change($event, selectInput.value)"
         (focus)="focus.next()"
-        (blur)="blur.next()"
+        (blur)="_onBlur()"
         [required]="required"
     >
         <option *ngIf="placeholder" value="" selected disabled hidden>{{ placeholder }}</option>

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -8,15 +8,17 @@ import {
     ViewEncapsulation,
     ElementRef,
     Optional,
-    DoCheck,
     Self,
     Output,
     EventEmitter,
     ViewChild,
     Renderer2,
-    AfterViewInit
+    AfterViewInit,
+    OnDestroy
 } from '@angular/core';
 import {ControlValueAccessor, NgForm, FormGroupDirective, NgControl} from '@angular/forms';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
 import {SelectService, _buildValueString} from './select.service';
@@ -35,9 +37,10 @@ export class SelectChangeEvent {
     encapsulation: ViewEncapsulation.None,
     providers: [SelectService, {provide: HcFormControlComponent, useExisting: forwardRef(() => SelectComponent)}]
 })
-export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck, AfterViewInit {
+export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
     private _uniqueInputId = `hc-select-${uniqueId++}`;
     private _form: NgForm | FormGroupDirective | null;
+    private _unsubscribe = new Subject<void>();
     private _value: any = '';
     get _optionMap(): Map<string, any> {
         return this.selectService._optionMap;
@@ -157,6 +160,19 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
 
     ngAfterViewInit() {
         this._applyValueToNativeControl();
+
+        if ( this._ngControl && this._ngControl.statusChanges ) {
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+        }
+        if ( this._form ) {
+            this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+        }
+    }
+
+    _onBlur(): void {
+        this.onTouch();
+        this._updateErrorState();
+        this.blur.next();
     }
 
     public onChange: (value: unknown) => void = () => undefined;
@@ -193,13 +209,6 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         this.change.emit(new SelectChangeEvent(this, this._value));
     }
 
-    ngDoCheck(): void {
-        // This needs to be checked every cycle because we can't subscribe to form submissions
-        if (this._ngControl) {
-            this._updateErrorState();
-        }
-    }
-
     _getOptionId(value: any): string | null {
         for (const id of Array.from(this._optionMap.keys())) {
             if (this._compareWith(this._optionMap.get(id), value)) {
@@ -231,5 +240,10 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         if (oldState !== newState) {
             this._errorState = newState;
         }
+    }
+
+    ngOnDestroy(): void {
+        this._unsubscribe.next();
+        this._unsubscribe.complete();
     }
 }

--- a/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.html
+++ b/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.html
@@ -19,6 +19,7 @@
         <input
             type="checkbox"
             class="hc-slide-toggle-checkbox"
+            (blur)="_onBlur()"
             [(ngModel)]="buttonState"
             [disabled]="disabled"
         />

--- a/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
+++ b/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
@@ -1,5 +1,7 @@
-import {Component, DoCheck, EventEmitter, forwardRef, Input, Optional, Output, Self, ViewEncapsulation} from '@angular/core';
+import {AfterViewInit, Component, EventEmitter, forwardRef, Input, OnDestroy, Optional, Output, Self, ViewEncapsulation} from '@angular/core';
 import {FormGroupDirective, NgControl, NgForm} from '@angular/forms';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
 
@@ -34,9 +36,10 @@ export function validateLabelType(inputStr: string): void {
     encapsulation: ViewEncapsulation.None,
     providers: [{provide: HcFormControlComponent, useExisting: forwardRef(() => SlideToggleComponent)}]
 })
-export class SlideToggleComponent extends HcFormControlComponent implements DoCheck {
+export class SlideToggleComponent extends HcFormControlComponent implements AfterViewInit, OnDestroy {
     private _uniqueId = `hc-slide-toggle-${nextToggleId++}`;
     private _form: NgForm | FormGroupDirective | null;
+    private _unsubscribe = new Subject<void>();
     _buttonState = true;
     _disabled = false;
     _insideLabel = 'on';
@@ -115,6 +118,15 @@ export class SlideToggleComponent extends HcFormControlComponent implements DoCh
     /** Event fired with boolean value when the toggle state is changed. */
     @Output() buttonStateChanged = new EventEmitter<boolean>();
 
+    ngAfterViewInit(): void {
+        if ( this._ngControl && this._ngControl.statusChanges ) {
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+        }
+        if ( this._form ) {
+            this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+        }
+    }
+
     constructor(
         @Optional() _parentForm: NgForm,
         @Optional() _parentFormGroup: FormGroupDirective,
@@ -141,11 +153,9 @@ export class SlideToggleComponent extends HcFormControlComponent implements DoCh
         this.onTouch = fn;
     }
 
-    ngDoCheck(): void {
-        // This needs to be checked every cycle because we can't subscribe to form submissions
-        if (this._ngControl) {
-            this._updateErrorState();
-        }
+    _onBlur(): void {
+        this.onTouch();
+        this._updateErrorState();
     }
 
     private _updateErrorState() {
@@ -161,5 +171,10 @@ export class SlideToggleComponent extends HcFormControlComponent implements DoCh
         if (oldState !== newState) {
             this._errorState = newState;
         }
+    }
+
+    ngOnDestroy(): void {
+        this._unsubscribe.next();
+        this._unsubscribe.complete();
     }
 }


### PR DESCRIPTION
Second run at this one.  I think this approach will could save literally thousands of function calls per minute depending on how many form fields a given page might be using.  Only downside I see is that I can't specifically observe changes to the `touched` state of a control.  So wherever I can I'm including an additional check on blur to account for that.

Would love to hear your thoughts on this approach. 

closes #1888