### PR TITLE
fix(form-field): writevalue on remove bug

### DIFF
--- a/projects/cashmere/src/lib/button-toggle/button-toggle-group.component.ts
+++ b/projects/cashmere/src/lib/button-toggle/button-toggle-group.component.ts
@@ -138,8 +138,11 @@ export class ButtonToggleGroupComponent extends HcFormControlComponent implement
     }
 
     writeValue(value: unknown): void {
-        this._value = value;
-        this._updateButtonStateFromModel();
+        // Prevent the form control from trying to write a value when removing the control
+        if ( this.onChange.name !== 'noop' ) {
+            this._value = value;
+            this._updateButtonStateFromModel();
+        }
     }
 
     public onChange: (value: unknown) => void = () => undefined;

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.ts
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.ts
@@ -302,7 +302,10 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
     }
 
     writeValue(value: unknown): void {
-        this.checked = !!value;
+        // Prevent the form control from trying to write a value when removing the control
+        if ( this.onChange.name !== 'noop' ) {
+            this.checked = !!value;
+        }
     }
 
     public onChange: (value: unknown) => void = () => undefined;

--- a/projects/cashmere/src/lib/date-range/date-range/date-range.directive.ts
+++ b/projects/cashmere/src/lib/date-range/date-range/date-range.directive.ts
@@ -85,7 +85,10 @@ export class DateRangeDirective implements OnDestroy, OnChanges, ControlValueAcc
     }
 
     writeValue(value: number | DateRange): void {
-        this._updateSelected( value );
+        // Prevent the form control from trying to write a value when removing the control
+        if ( this.onChange.name !== 'noop' ) {
+            this._updateSelected( value );
+        }
     }
 
     _updateSelected( selectedDate: number | DateRange ): void {

--- a/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
+++ b/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
@@ -126,7 +126,10 @@ export class FileUploaderComponent extends HcFormControlComponent implements Aft
     }
 
     writeValue(value: FileList): void {
-        this._fileList = value;
+        // Prevent the form control from trying to write a value on removing the control
+        if ( this.onChange.name !== 'noop' ) {
+            this._fileList = value;
+        }
     }
 
     public onChange: (value: FileList) => void = () => undefined;

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -194,8 +194,11 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
     }
 
     writeValue(value: any): void {
-        this.value = value;
-        this._cdRef.markForCheck();
+        // Prevent the form control from trying to write a value when removing the control
+        if ( this.onChange.name !== 'noop' ) {
+            this.value = value;
+            this._cdRef.markForCheck();
+        }
     }
 
     public onChange: (value: unknown) => void = () => undefined;

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -185,8 +185,11 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
     }
 
     writeValue(value: any) {
-        this._value = value;
-        this._applyValueToNativeControl();
+        // Prevent the form control from trying to write a value when removing the control
+        if ( this.onChange.name !== 'noop' ) {
+            this._value = value;
+            this._applyValueToNativeControl();
+        }
     }
 
     _applyValueToNativeControl() {

--- a/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
+++ b/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
@@ -110,9 +110,12 @@ export class SlideToggleComponent extends HcFormControlComponent implements Afte
     }
 
     set buttonState( val: boolean | string ) {
-        this._buttonState = parseBooleanAttribute(val);
-        this.onChange(this._buttonState);
-        this.buttonStateChanged.emit(this._buttonState);
+        const tempVal = parseBooleanAttribute(val);
+        if ( tempVal !== this._buttonState ) {
+            this._buttonState = parseBooleanAttribute(val);
+            this.onChange(this._buttonState);
+            this.buttonStateChanged.emit(this._buttonState);
+        }
     }
 
     /** Event fired with boolean value when the toggle state is changed. */
@@ -141,7 +144,10 @@ export class SlideToggleComponent extends HcFormControlComponent implements Afte
     }
 
     writeValue(value: unknown): void {
-        this.buttonState = !!value;
+        // Prevent the form control from trying to write a value when removing the control
+        if ( this.onChange.name !== 'noop' ) {
+            this.buttonState = !!value;
+        }
     }
 
     public onChange: (value: unknown) => void = () => undefined;


### PR DESCRIPTION
resolves bug where writevalue is called after a form control is removed

@bskeen - this was an interesting one!  As it turns out `writeValue` on the FormControl is getting called when the previous control is being removed, but it's getting called with the value of the new control 😬 that definitely seems like an Angular bug.  I also noticed that `ngDestroy` isn't being called when the control is removed - which is concerning that there's a memory leak in Angular here too.  

It was kinda tricky to figure out how to identify when the control has actually been removed given the above, but I discovered that the registered functions like `OnChange` turn into no operation after being removed.  So that was the way I could determine if it's a legit `writeValue` call or not.

On SlideToggle and DateRange, they both call a registered form control function as a result of `writeValue`, which is why they were throwing the error and others weren't.  I guess it's mostly harmless to call a zombie writeValue, but I figured better to be safe and I put the `noop` check on all the form control Cashmere components.

Thanks very much for putting together such a thorough Stackblitz, that made debugging this WAY easier!

closes #2027