### PR TITLE
fix(tooltip): disable empty tooltips

### DIFF
--- a/projects/cashmere-examples/src/lib/tooltip-overview/tooltip-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/tooltip-overview/tooltip-overview-example.component.html
@@ -1,5 +1,7 @@
 This is an example of a bottom-aligned
 <u hcTooltip="I'm a tooltip" verticalAlign="below">tooltip in action</u>.
 <br><br>
-And this is a <u [hcTooltip]="veryLongString" maxWidth="400px">very large tooltip</u> with a constrained width.
+This is a <u [hcTooltip]="veryLongString" maxWidth="400px">very large tooltip</u> with a constrained width.
+<br><br>
+And this is a <u hcTooltip="">tooltip with an empty string</u> which means it won't be displayed.
 <br><br>

--- a/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
+++ b/projects/cashmere/src/lib/pop/directives/popover-anchor.directive.ts
@@ -59,7 +59,8 @@ export class HcPopoverAnchorDirective implements OnInit, AfterContentInit, OnDes
         popover.restoreFocus = false;
         popover.maxWidth = this._maxWidth;
         this.attachedPopover = popover;
-        this.trigger = 'hover';
+        // Don't enable the tooltip if the content string is empty
+        this.trigger = value ? 'hover' : 'none';
         this.popoverDelay = 300;
     }
     private _tooltipText: string;


### PR DESCRIPTION
change trigger to none for tooltips with empty content

...and one more for you @isaaclyman - this was an easy fix but I like it a lot.  Gives the developer another option for disabling tooltips besides always having to control `trigger`.

closes #2079