### PR TITLE
docs(tooltip): scroll behavior guide

### DIFF
--- a/projects/cashmere-examples/src/lib/tooltip-overview/tooltip-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/tooltip-overview/tooltip-overview-example.component.html
@@ -1,7 +1,12 @@
-This is an example of a bottom-aligned
-<u hcTooltip="I'm a tooltip" verticalAlign="below">tooltip in action</u>.
+This is an example of a bottom-aligned <u hcTooltip="I'm a tooltip" verticalAlign="below">tooltip in action</u>.
 <br><br>
 This is a <u [hcTooltip]="veryLongString" maxWidth="400px">very large tooltip</u> with a constrained width.
 <br><br>
 And this is a <u hcTooltip="">tooltip with an empty string</u> which means it won't be displayed.
-<br><br>
+<br><br><br>
+<em>
+    Note that when displaying tooltips in scrollable containers, it may be necessary to add a <code>cdkScrollable</code>
+    directive to the container to ensure that tooltips close correctly on scroll. See the
+    <a href="/web/components/pop/usage?section=scroll-behavior">usage docs</a>
+    for more information.
+</em>

--- a/projects/cashmere/src/lib/pop/pop.md
+++ b/projects/cashmere/src/lib/pop/pop.md
@@ -101,6 +101,21 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 export class AppModule { }
 ```
 
+#### Modifying Animations
+
+By default, the opening and closing animations of a popover are quick with a simple easing curve.
+You can modify these animation curves using `openTransition` and `closeTransition`. Or, you can disable animation
+altogther by setting `shouldAnimate` to false.
+
+```html
+<!-- open slowly but close quickly -->
+<hc-pop #mySlowPopover openTransition="1000ms ease-out" closeTransition="100ms ease-in">
+    <!-- ... -->
+</hc-pop>
+```
+
+&nbsp;
+
 ##### Menus
 
 One common situation where popovers can be leveraged is to create menus within the app.
@@ -129,18 +144,28 @@ The trigger for sub-menus will automatically be set to hover and cannot be overr
 
 &nbsp;
 
-#### Modifying Animations
+##### Scroll Behavior
 
-By default, the opening and closing animations of a popover are quick with a simple easing curve.
-You can modify these animation curves using `openTransition` and `closeTransition`. Or, you can disable animation
-altogther by setting `shouldAnimate` to false.
+When using `hcTooltip` or `hcPop` with a hover trigger, you may encounter some challenges with page scrolling.
+Particularly when using a mouse wheel or trackpad, the tooltip may stay open even though you have scrolled off the target.
+This can be particularly problematic with scroll containers that include tooltips or hover pops - elements with a fixed size that have `overflow: auto`.
 
-```html
-<!-- open slowly but close quickly -->
-<hc-pop #mySlowPopover openTransition="1000ms ease-out" closeTransition="100ms ease-in">
-    <!-- ... -->
-</hc-pop>
+The problem centers around the Angular CDK not having awareness of scroll events unless the app explictly defines scroll containers.
+To do so, you may add the `cdkScrollable` directive to any scrollable container that will contain tooltips or hover popovers.
+To use that directive you'll need to import the following in your module:
+
+`import {ScrollingModule} from '@angular/cdk/scrolling';`
+
+Below is an example of how to use the directive:
+
+```(html)
+<div cdkScrollable>
+    This element is a scroll container which includes
+    <u hcTooltip="I'm a tooltip">any tooltips you are using</u>.
+</div>
 ```
+
+&nbsp;
 
 ##### Mobile Development Guide
 

--- a/src/app/components/components.component.html
+++ b/src/app/components/components.component.html
@@ -1,4 +1,4 @@
-<div class="hc-components-container">
+<div class="hc-components-container" cdkScrollable>
     <hc-subnav class="responsive-subnav" fixedTop="true">
         <div class="subnav-container">
             <span class="subnav-label">

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -10,9 +10,10 @@ import {ComponentUsageComponent} from './component-viewer/component-usage/compon
 import {ComponentsComponent} from './components.component';
 import {ComponentsRouterModule} from './components-router.module';
 import {ApplicationInsightsService} from '../shared/application-insights/application-insights.service';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 
 @NgModule({
-    imports: [SharedModule, ExampleModule, ComponentsRouterModule],
+    imports: [SharedModule, ExampleModule, ComponentsRouterModule, ScrollingModule],
     providers: [ApplicationInsightsService],
     declarations: [
         ComponentsComponent,


### PR DESCRIPTION
@corykon - added guidelines around the use of `cdkScrollable` to the pop usage doc and also the tooltips example.  I also added the `cdkScrollable` directive to our components container, so it looks to me like the tooltips example behaves much better on scroll now.  I can see the change in Chrome, but interestingly this isn't an issue in Firefox.  Let me know if you're seeing the same.

closes #1371