### PR TITLE
fix(input): mark as touched on blur

### DIFF
--- a/projects/cashmere/src/lib/input/input.directive.ts
+++ b/projects/cashmere/src/lib/input/input.directive.ts
@@ -128,6 +128,9 @@ export class InputDirective extends HcFormControlComponent implements AfterViewI
 
     @HostListener('blur')
     _onBlur(): void {
+        if ( this._ngControl && this._ngControl.control) {
+            this._ngControl.control.markAsTouched();
+        }
         this._changeFocus(false);
         this._updateErrorState();
     }


### PR DESCRIPTION
force an input element to mark its ngControl as touched on blur

@JDavidStevens @corykon  - this was an interesting one because it happens in Chrome but not Firefox.  The issue is that the `ngControl` on our inputDirective isn't being marked as `touched` on blur (or it's happening after the blur event).  And with our validation step, it won't mark the control as invalid unless it's been touched.  So what I've done here is force the control to be marked as touched on blur (which it should be doing anyway) before the validation gets called.  With that change, the test you mentioned checks out.

closes #2116