### PR TITLE
fix(form-field): error check on form reset

### DIFF
--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.component.html
@@ -1,10 +1,13 @@
-<form>
+<form [formGroup]="exampleFormGroup" #exampleForm="ngForm">
     <div class="form-container">
         <hc-form-field>
             <hc-label>Validate an email address:</hc-label>
-            <input hcInput [formControl]="formDemo" required>
+            <input hcInput formControlName="exampleInput" required>
             <hc-error>A valid email address is required</hc-error>
         </hc-form-field>
     </div>
+    <button hc-button title="Reset Form" buttonStyle="secondary" type="reset">Form Reset</button>
     <button hc-button title="Submit Form" buttonStyle="primary" type="submit">Submit</button>
 </form>
+
+<button hc-button title="NgForm Reset" buttonStyle="secondary" (click)="resetForm()">NgForm Reset</button>

--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.component.scss
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.component.scss
@@ -5,3 +5,8 @@
 .hc-form-field {
     width: 100%;
 }
+
+button {
+    margin-right: 15px;
+    margin-bottom: 20px;
+}

--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.component.ts
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.component.ts
@@ -1,5 +1,5 @@
-import {Component} from '@angular/core';
-import {FormControl, Validators} from '@angular/forms';
+import {Component, ViewChild} from '@angular/core';
+import {FormControl, FormGroup, NgForm, Validators} from '@angular/forms';
 
 /**
  * @title Required Input
@@ -10,5 +10,15 @@ import {FormControl, Validators} from '@angular/forms';
     styleUrls: ['input-required-example.component.scss']
 })
 export class InputRequiredExampleComponent {
-    formDemo = new FormControl('', [Validators.email, Validators.required]);
+    @ViewChild('exampleForm') exampleForm: NgForm;
+
+    exampleFormGroup = new FormGroup({
+        exampleInput: new FormControl('', [Validators.email, Validators.required])
+    });
+
+    // To reset the error state on a form, you must set the submitted state of the form to false
+    // resetForm on a NgForm and/or a type="reset" button in the form will accomplish that
+    resetForm(): void {
+        this.exampleForm.resetForm();
+    }
 }

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.ts
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.ts
@@ -20,7 +20,7 @@ import type {QueryList} from '@angular/core';
 import { ControlValueAccessor, NgForm, FormGroupDirective, NgControl } from '@angular/forms';
 import { HcFormControlComponent } from '../form-field/hc-form-control.component';
 import { parseBooleanAttribute } from '../util';
-import { filter, takeUntil } from 'rxjs/operators';
+import { delay, filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 let nextCheckboxId = 1;
@@ -272,13 +272,9 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
     }
 
     ngAfterViewInit(): void {
-        if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
-                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
-                setTimeout(() => {
-                    this._updateErrorState();
-                });
-            });
+        if ( this._ngControl?.statusChanges ) {
+            // delay() is necessary to make sure any form or control state changes have been applied before rechecking error states
+            this._ngControl.statusChanges.pipe(delay(0), takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.ts
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.ts
@@ -273,7 +273,12 @@ export class CheckboxComponent extends HcFormControlComponent implements Control
 
     ngAfterViewInit(): void {
         if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
+                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
+                setTimeout(() => {
+                    this._updateErrorState();
+                });
+            });
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/datepicker/datepicker.component.spec.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker.component.spec.ts
@@ -4,7 +4,7 @@ import {Overlay, OverlayContainer} from '@angular/cdk/overlay';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 
 import {Component, FactoryProvider, Type, ValueProvider, ViewChild} from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, discardPeriodicTasks, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {BrowserDynamicTestingModule} from '@angular/platform-browser-dynamic/testing';
@@ -1758,6 +1758,8 @@ describe('DatepickerComponent', () => {
 
             expect(document.querySelector('.hc-calendar-time-picker')).toBeTruthy();
             expect(document.querySelector('.hc-calendar-content')).toBeFalsy();
+
+            discardPeriodicTasks();
         }));
 
         it('should not display the AM/PM select with a 24 hour cycle', fakeAsync(() => {
@@ -1769,6 +1771,8 @@ describe('DatepickerComponent', () => {
 
             const formFields = document.querySelectorAll('hc-form-field');
             expect(formFields.length).toBe(2);
+
+            discardPeriodicTasks();
         }));
     });
 
@@ -1794,6 +1798,8 @@ describe('DatepickerComponent', () => {
 
             expect(document.querySelector('.hc-calendar-time-picker')).toBeTruthy();
             expect(document.querySelector('.hc-calendar-content')).toBeTruthy();
+
+            discardPeriodicTasks();
         }));
     });
 

--- a/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
+++ b/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, ElementRef, EventEmitter, forwardRef, HostBinding, Input, OnDestroy, Optional, Output, Self, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { delay, takeUntil } from 'rxjs/operators';
 import { HcFormControlComponent } from '../form-field/hc-form-control.component';
 import { parseBooleanAttribute } from '../util';
 
@@ -104,13 +104,9 @@ export class FileUploaderComponent extends HcFormControlComponent implements Aft
     }
 
     ngAfterViewInit(): void {
-        if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
-                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
-                setTimeout(() => {
-                    this._updateErrorState();
-                });
-            });
+        if ( this._ngControl?.statusChanges ) {
+            // delay() is necessary to make sure any form or control state changes have been applied before rechecking error states
+            this._ngControl.statusChanges.pipe(delay(0), takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
+++ b/projects/cashmere/src/lib/file-uploader/file-uploader.component.ts
@@ -105,7 +105,12 @@ export class FileUploaderComponent extends HcFormControlComponent implements Aft
 
     ngAfterViewInit(): void {
         if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
+                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
+                setTimeout(() => {
+                    this._updateErrorState();
+                });
+            });
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/input/input.directive.ts
+++ b/projects/cashmere/src/lib/input/input.directive.ts
@@ -2,7 +2,7 @@ import {Directive, ElementRef, HostBinding, HostListener, Input, Optional, Self,
 import {parseBooleanAttribute} from '../util';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {FormGroupDirective, NgControl, NgForm} from '@angular/forms';
-import {takeUntil} from 'rxjs/operators';
+import {delay, takeUntil} from 'rxjs/operators';
 import {Subject} from 'rxjs';
 
 export function getUnsupportedHCInputType(type: string): Error {
@@ -180,13 +180,9 @@ export class InputDirective extends HcFormControlComponent implements AfterViewI
     mobileChange = new EventEmitter<boolean>();
 
     ngAfterViewInit(): void {
-        if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
-                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
-                setTimeout(() => {
-                    this._updateErrorState();
-                });
-            });
+        if ( this._ngControl?.statusChanges ) {
+            // delay() is necessary to make sure any form or control state changes have been applied before rechecking error states
+            this._ngControl.statusChanges.pipe(delay(0), takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/input/input.directive.ts
+++ b/projects/cashmere/src/lib/input/input.directive.ts
@@ -181,7 +181,12 @@ export class InputDirective extends HcFormControlComponent implements AfterViewI
 
     ngAfterViewInit(): void {
         if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
+                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
+                setTimeout(() => {
+                    this._updateErrorState();
+                });
+            });
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -186,7 +186,12 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
         setTimeout(() => this._markRadiosForCheck());
 
         if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
+                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
+                setTimeout(() => {
+                    this._updateErrorState();
+                });
+            });
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/radio-button/radio.ts
+++ b/projects/cashmere/src/lib/radio-button/radio.ts
@@ -25,7 +25,7 @@ import {parseBooleanAttribute} from '../util';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {ControlValueAccessor, NgForm, FormGroupDirective, NgControl} from '@angular/forms';
 import { InputDirective } from '../input';
-import { takeUntil } from 'rxjs/operators';
+import { delay, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 let nextUniqueId = 0;
@@ -185,13 +185,9 @@ export class RadioGroupDirective extends HcFormControlComponent implements Contr
         this._initialized = true;
         setTimeout(() => this._markRadiosForCheck());
 
-        if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
-                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
-                setTimeout(() => {
-                    this._updateErrorState();
-                });
-            });
+        if ( this._ngControl?.statusChanges ) {
+            // delay() is necessary to make sure any form or control state changes have been applied before rechecking error states
+            this._ngControl.statusChanges.pipe(delay(0), takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -180,7 +180,12 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         this._applyValueToNativeControl();
 
         if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
+                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
+                setTimeout(() => {
+                    this._updateErrorState();
+                });
+            });
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -18,7 +18,7 @@ import {
 } from '@angular/core';
 import {ControlValueAccessor, NgForm, FormGroupDirective, NgControl} from '@angular/forms';
 import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
+import {delay, takeUntil} from 'rxjs/operators';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
 import {SelectService, _buildValueString} from './select.service';
@@ -179,13 +179,9 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
     ngAfterViewInit() {
         this._applyValueToNativeControl();
 
-        if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
-                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
-                setTimeout(() => {
-                    this._updateErrorState();
-                });
-            });
+        if ( this._ngControl?.statusChanges ) {
+            // delay() is necessary to make sure any form or control state changes have been applied before rechecking error states
+            this._ngControl.statusChanges.pipe(delay(0), takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
+++ b/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
@@ -123,7 +123,12 @@ export class SlideToggleComponent extends HcFormControlComponent implements Afte
 
     ngAfterViewInit(): void {
         if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
+            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
+                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
+                setTimeout(() => {
+                    this._updateErrorState();
+                });
+            });
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());

--- a/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
+++ b/projects/cashmere/src/lib/slide-toggle/slide-toggle.component.ts
@@ -1,7 +1,7 @@
 import {AfterViewInit, Component, EventEmitter, forwardRef, Input, OnDestroy, Optional, Output, Self, ViewEncapsulation} from '@angular/core';
 import {FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
+import {delay, takeUntil} from 'rxjs/operators';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
 
@@ -122,13 +122,9 @@ export class SlideToggleComponent extends HcFormControlComponent implements Afte
     @Output() buttonStateChanged = new EventEmitter<boolean>();
 
     ngAfterViewInit(): void {
-        if ( this._ngControl && this._ngControl.statusChanges ) {
-            this._ngControl.statusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
-                // setTimeout is necessary to make sure any form or control state changes have been applied before rechecking error states
-                setTimeout(() => {
-                    this._updateErrorState();
-                });
-            });
+        if ( this._ngControl?.statusChanges ) {
+            // delay() is necessary to make sure any form or control state changes have been applied before rechecking error states
+            this._ngControl.statusChanges.pipe(delay(0), takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());


### PR DESCRIPTION
make sure error states are reset have form resets

closes #2124

@guille-gomez this one was a real mind bender, notes below (I've also updated an example on the inputs page with these notes):

- The big trick here is that you have to make sure after a form submit you are resetting your form to submitted = false.  As best as I can tell, there are two ways to do that - I show both of them in the example.  You can use resetForm() on NgForm.  Or you can include a button inside your form with `type="reset"`.  The second is old school HTML, but it still does the trick and removes submitted from your form.
- That said, I did have to add a `setTimeout` to all our ngControl.statusChanges subscriptions, because we need to be sure that the error state check is happening after submitted states have been updated.  I think this was tripping us up today because our calls were happening before the submitted update had been applied.

I've been able to validate the above works on the Cashmere site, and I think it matches your use case.  Let me know what you think.