### PR TITLE
fix(navbar): dropdown pop alignment

### DIFF
--- a/projects/cashmere/src/lib/navbar/navbar-dropdown/navbar-dropdown.component.html
+++ b/projects/cashmere/src/lib/navbar/navbar-dropdown/navbar-dropdown.component.html
@@ -11,7 +11,7 @@
     <hc-icon fontIcon="hc-navbar-ico-chevron-down" hcIconSm></hc-icon>
 </a>
 
-<hc-pop #menuPop [autoCloseOnContentClick]="true" [showArrow]="false">
+<hc-pop #menuPop [autoCloseOnContentClick]="true" [showArrow]="false" horizontalAlign="start">
     <ng-content></ng-content>
 </hc-pop>
 


### PR DESCRIPTION
set horizontal align to start rather than center on menus