### PR TITLE
fix(scrollnav): remove scrollintoview usage

### DIFF
--- a/projects/cashmere/src/lib/sass/scroll-nav.scss
+++ b/projects/cashmere/src/lib/sass/scroll-nav.scss
@@ -96,6 +96,7 @@
 }
 
 @mixin hc-scroll-nav-content-container() {
+    position: relative;
     max-height: 100%;
     overflow: scroll;
     overflow-x: hidden;

--- a/projects/cashmere/src/lib/scroll-nav/content/scroll-nav-content.component.ts
+++ b/projects/cashmere/src/lib/scroll-nav/content/scroll-nav-content.component.ts
@@ -226,6 +226,10 @@ export class HcScrollNavContentComponent implements AfterViewInit, AfterViewChec
             }
         });
 
+        this.nav._scrollEvent.pipe(takeUntil(this.unsubscribe$)).subscribe( element => {
+            this._cdkScrollableElement.scrollTo({top: element.offsetTop});
+        });
+
         this.insureMinHeightForLastTarget();
     }
 

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav-link.directive.spec.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav-link.directive.spec.ts
@@ -14,7 +14,7 @@ export class AbstractHcScrollLinkComponent {
     template: `
     <hc-scroll-nav #ScrollNav>
         <ul>
-            <li hcScrollLink='a1'>
+            <li hcScrollLink='a1' (navClick)="testNavEvent($event)">
                 Test 1
             </li>
         </ul>
@@ -26,10 +26,14 @@ export class AbstractHcScrollLinkComponent {
     </hc-scroll-nav-content>`
 })
 export class ScrollNavLinkComponent extends AbstractHcScrollLinkComponent {
+    testNavEvent(event: HTMLElement): HTMLElement {
+        return event;
+    };
 }
 
 @Component({
-    template: `<hc-scroll-nav #ScrollNav>
+    template: `
+    <hc-scroll-nav #ScrollNav>
         <ul>
             <li [attr.hcScrollLink]='"a2"'>
                 Test 1
@@ -43,6 +47,9 @@ export class ScrollNavLinkComponent extends AbstractHcScrollLinkComponent {
     </hc-scroll-nav-content>`
 })
 export class ScrollNavLinkDynamicComponent extends AbstractHcScrollLinkComponent {
+    testNavEvent(event: HTMLElement): HTMLElement {
+        return event;
+    };
 }
 
 describe("ScrollNavLinkDirective", (): void => {
@@ -87,14 +94,14 @@ describe("ScrollNavLinkDirective", (): void => {
             expect(directive.nativeElement.className.includes("hc-scroll-nav-link")).toBeTruthy();
         });
 
-        it("click should call scrollIntoView", (): void => {
+        it("click should emit a navClick event", (): void => {
             const contentElement: HTMLElement = scrollNavLinkComponent.debugElement.query(By.css("#a1")).nativeElement;
             spyOn(document, "getElementById").and.returnValue(contentElement);
-            const scrollIntoViewSpy: jasmine.Spy = spyOn(contentElement, "scrollIntoView");
-
+            spyOn( scrollNavLinkComponent.componentInstance, 'testNavEvent' );
+            
             directive.nativeElement.click();
 
-            expect(scrollIntoViewSpy).toHaveBeenCalled();
+            expect(scrollNavLinkComponent.componentInstance.testNavEvent).toHaveBeenCalledWith(contentElement);
         });
     });
 
@@ -119,12 +126,14 @@ describe("ScrollNavLinkDirective", (): void => {
             expect(directive.nativeElement.className.includes("hc-scroll-nav-link")).toBeTruthy();
         });
 
-        it("click should call scrollIntoView", (): void => {
-            const scrollIntoViewSpy: jasmine.Spy = spyOn(scrollNavLinkDynamicComponent.nativeElement.querySelector(`#${directive.hcScrollLink}`), "scrollIntoView");
+        it("click should emit a navClick event", (): void => {
+            directive.navClick.subscribe( event => scrollNavLinkDynamicComponent.componentInstance.testNavEvent(event) );
 
+            spyOn( scrollNavLinkDynamicComponent.componentInstance, 'testNavEvent' );
+            
             directive.nativeElement.click();
 
-            expect(scrollIntoViewSpy).toHaveBeenCalled();
+            expect(scrollNavLinkDynamicComponent.componentInstance.testNavEvent).toHaveBeenCalled();
         });
     });
 });

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav-link.directive.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav-link.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, HostBinding, ElementRef, Input, HostListener, Renderer2} from '@angular/core';
+import {Directive, HostBinding, ElementRef, Input, HostListener, Renderer2, Output, EventEmitter} from '@angular/core';
 
 /** Marks the host element as a link within an `hc-scroll-nav`. */
 @Directive({
@@ -7,6 +7,10 @@ import {Directive, HostBinding, ElementRef, Input, HostListener, Renderer2} from
 export class ScrollNavLinkDirective {
     /** The `id` of the corresponding `hcScrollTarget` that you would like to link to. */
     @Input() public hcScrollLink: string | null;
+
+    /** Emits the associated content element when a nav link is clicked */
+    @Output() navClick = new EventEmitter<HTMLElement>();
+
     @HostBinding('class.hc-scroll-nav-link')
     _hostClass = true;
 
@@ -54,14 +58,14 @@ export class ScrollNavLinkDirective {
 
     private navigateToSection(id: string) {
         const el = document.getElementById(id);
-
+        
         if (!el) {
             throw new Error(`Failed to navigate. Could not find the element with the id: ${id}.`);
         } else {
             this.setSubsectionClass(el);
 
             if (!this.hasClickedSubsection(el)) {
-                el.scrollIntoView();
+                this.navClick.emit( el );
             }
         }
     }

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.spec.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.spec.ts
@@ -248,49 +248,8 @@ describe('HcScrollNavComponent', () => {
                 expect(scrollToSpy).toHaveBeenCalled();
             });
 
-            it('should not call scrollTo if element is under scroll view area but isScrolling is true', () => {
-                const scrollToSpy: jasmine.Spy = spyOn(testApp.linksComponent._cdkScrollableElement, "scrollTo");
-                testApp.linksComponent.scrollNavWithContent = true;
-                testApp.linksComponent.isScrolling = true;
-                testApp.linksComponent._elementRef.nativeElement.querySelector(`.${LINKS_CONTAINER_CLASS}`).style.height = '200px';
-                testApp.detectChanges();
-
-                testApp.linksComponent._setActiveSectionById('b3');
-
-                expect(scrollToSpy).not.toHaveBeenCalled();
-            });
-
-            it('should call scrollIntoView if element is above scroll view area and isScrolling is false', () => {
-                testApp.linksComponent.isScrolling = false;
-                testApp.linksComponent.scrollNavWithContent = true;
-                testApp.linksComponent._setActiveSectionById('a2');
-
-                const scrollIntoViewSpy: jasmine.Spy = spyOn(testApp.linksComponent._elementRef.nativeElement.querySelector(`[${SCROLL_LINK_ATTRIBUTE}='a1']`), "scrollIntoView");
-                testApp.linksComponent._elementRef.nativeElement.querySelector(`.${LINKS_CONTAINER_CLASS}`).style.height = '200px';
-                testApp.detectChanges();
-
-                testApp.linksComponent._setActiveSectionById('a1');
-
-                expect(scrollIntoViewSpy).toHaveBeenCalled();
-            });
-
-            it('should not call scrollIntoView if element is above scroll view area and isScrolling is true', () => {
-                const scrollIntoViewSpy: jasmine.Spy = spyOn(testApp.linksComponent._elementRef.nativeElement.querySelector(`[${SCROLL_LINK_ATTRIBUTE}='a1']`), "scrollIntoView");
-                testApp.linksComponent._elementRef.nativeElement.querySelector(`.${LINKS_CONTAINER_CLASS}`).style.height = '200px';
-                testApp.detectChanges();
-
-                spyOn(testApp.linksComponent._cdkScrollableElement, "measureScrollOffset").and.returnValue(126);
-                testApp.linksComponent.isScrolling = true;
-                testApp.linksComponent.scrollNavWithContent = true;
-
-                testApp.linksComponent._setActiveSectionById('a1');
-
-                expect(scrollIntoViewSpy).not.toHaveBeenCalled();
-            });
-
             it('should not scroll if element is in the scroll view area', () => {
                 const scrollToSpy: jasmine.Spy = spyOn(testApp.linksComponent._cdkScrollableElement, "scrollTo");
-                const scrollIntoViewSpy: jasmine.Spy = spyOn(testApp.linksComponent._elementRef.nativeElement.querySelector(`[${SCROLL_LINK_ATTRIBUTE}='a1']`), "scrollIntoView");
 
                 testApp.linksComponent._elementRef.nativeElement.querySelector(`.${LINKS_CONTAINER_CLASS}`).style.height = '200px';
                 testApp.linksComponent.scrollNavWithContent = true;
@@ -298,7 +257,6 @@ describe('HcScrollNavComponent', () => {
                 testApp.linksComponent._setActiveSectionById('a1');
 
                 expect(scrollToSpy).not.toHaveBeenCalled();
-                expect(scrollIntoViewSpy).not.toHaveBeenCalled();
             });
         });
     });

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
@@ -16,7 +16,7 @@ export class HcScrollNavComponent implements AfterViewInit, OnDestroy {
     /** Set to true to enable scrolling the nav link pane as the content pane scrolls */
     @Input() public scrollNavWithContent = false;
     /** Set to true to enable the component to change for dynamic content changes that might not be picked up by Angular */
-    @Input() public hasDynamicContent = false
+    @Input() public hasDynamicContent = false;
     @Output() _scrollEvent = new EventEmitter<HTMLElement>();
     @ViewChild('scrollContainer', {read: CdkScrollable, static: false}) public _cdkScrollableElement: CdkScrollable;
     @ContentChildren(ScrollNavLinkDirective, { descendants: true }) private linkList: QueryList<ScrollNavLinkDirective>;

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewEncapsulation, AfterViewInit, QueryList, ContentChildren, Renderer2, ViewChild, Input, OnDestroy } from '@angular/core';
+import { Component, ElementRef, ViewEncapsulation, AfterViewInit, QueryList, ContentChildren, Renderer2, ViewChild, Input, OnDestroy, Output, EventEmitter } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { some, find, map, differenceBy } from 'lodash';
@@ -16,7 +16,8 @@ export class HcScrollNavComponent implements AfterViewInit, OnDestroy {
     /** Set to true to enable scrolling the nav link pane as the content pane scrolls */
     @Input() public scrollNavWithContent = false;
     /** Set to true to enable the component to change for dynamic content changes that might not be picked up by Angular */
-    @Input() public hasDynamicContent = false;
+    @Input() public hasDynamicContent = false
+    @Output() _scrollEvent = new EventEmitter<HTMLElement>();
     @ViewChild('scrollContainer', {read: CdkScrollable, static: false}) public _cdkScrollableElement: CdkScrollable;
     @ContentChildren(ScrollNavLinkDirective, { descendants: true }) private linkList: QueryList<ScrollNavLinkDirective>;
     public get _links(): Array<HTMLElement> {
@@ -48,6 +49,8 @@ export class HcScrollNavComponent implements AfterViewInit, OnDestroy {
         if (this.dynamicInterval) {
             clearInterval(this.dynamicInterval);
         }
+        this.unsubscribe$.next();
+        this.unsubscribe$.complete();
     }
 
     public ngAfterViewInit(): void {
@@ -118,6 +121,10 @@ export class HcScrollNavComponent implements AfterViewInit, OnDestroy {
                         rtnLink = scrollNavLinkDirective;
                     }
 
+                    rtnLink.navClick.pipe(takeUntil(this.unsubscribe$)).subscribe( element => {
+                        this._scrollEvent.emit( element );
+                    })
+
                     return rtnLink;
                 }
             );
@@ -157,6 +164,12 @@ export class HcScrollNavComponent implements AfterViewInit, OnDestroy {
                     `Failed to mark active section. Could not find the element with the data target for id: ${firstScrollLink}.`
                 );
             }
+
+            this.linkList.forEach( link => {
+                link.navClick.pipe(takeUntil(this.unsubscribe$)).subscribe( element => {
+                    this._scrollEvent.emit( element );
+                });
+            });
 
             if (isInit) {
                 this._setActiveSectionById(firstScrollLink);
@@ -210,7 +223,7 @@ export class HcScrollNavComponent implements AfterViewInit, OnDestroy {
                     this._cdkScrollableElement.scrollTo({ bottom: scrollHeight - offsetTop - elementClientHeight });
                 }
             } else if (this.previousElementPosition > currentElementPosition) { // scroll up
-                element.scrollIntoView();
+                this._cdkScrollableElement.scrollTo({ bottom: scrollHeight - offsetTop - elementClientHeight });
             }
         }
 


### PR DESCRIPTION
@bskeen @corykon - I untangled the two instances of `scrollIntoView` that the scrollNav component was using.  And Ben I 100% agree that this isn't the place to use that function - the scrollNav shouldn't ever be scrolling the page it's a part of, only itself.  The component is split into multiple pieces, so it required some additional emitters and listeners to get the information to the right place, but as best as I can tell it's working as expected.  I also updated the unit tests to account for the updated approach.

closes #2145