### PR TITLE
feat(modal): add default max height on modal body

### DIFF
--- a/projects/cashmere/src/lib/sass/modal.scss
+++ b/projects/cashmere/src/lib/sass/modal.scss
@@ -156,6 +156,7 @@ $modal-border: 1px solid $gray-200;
 
 @mixin hc-modal-body() {
     overflow: auto;
+    max-height: 70vh;
     height: inherit;
     padding: $modal-padding;
     margin-bottom: 0;


### PR DESCRIPTION
New default height so that tall modals won't bleed off screen. 

re #1902

![image](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/e21661f7-d6ac-4d0e-99f7-46adfbee65d3)
