### PR TITLE
889 sticky table headers

### DIFF
--- a/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.html
@@ -1,31 +1,34 @@
 <div class="example-intro">
     <span>Example of a table with a sticky header & column.</span>
     <span class="example-checkboxes">
+        <hc-checkbox [(ngModel)]="hasGrayBg" [tight]="true">Has gray background</hc-checkbox>
         <hc-checkbox [(ngModel)]="hasBorders" [tight]="true">Has borders</hc-checkbox>
         <hc-checkbox [(ngModel)]="stickyHead" [tight]="true">Sticky header</hc-checkbox>
         <hc-checkbox [(ngModel)]="stickyCol" [tight]="true">Sticky column</hc-checkbox>
     </span>
 </div>
+<div [class.gray-example-bg]="hasGrayBg" class="example-wrapper">
 
-<!-- Scrollable table container (to define height) -->
-<div hcTableContainer tableHeight="200">
-  <table hc-table [dataSource]="dataSource" [borders]="hasBorders">
-    <!-- Sticky column [sticky]="true"-->
-    <ng-container hcColumnDef="rank" [sticky]="stickyCol">
-      <th hc-index-cell *hcHeaderCellDef>Rank</th>
-      <td hc-index-cell *hcCellDef="let element">{{ element.rank }}</td>
-    </ng-container>
+    <!-- Scrollable table container (to define height) -->
+    <div hcTableContainer tableHeight="200" [hasGrayBg]="hasGrayBg">
+    <table hc-table [dataSource]="dataSource" [borders]="hasBorders">
+        <!-- Sticky column [sticky]="true"-->
+        <ng-container hcColumnDef="rank" [sticky]="stickyCol">
+        <th hc-index-cell *hcHeaderCellDef>Rank</th>
+        <td hc-index-cell *hcCellDef="let element">{{ element.rank }}</td>
+        </ng-container>
 
-    <!-- Other columns -->
-    <ng-container *ngFor="let col of cols" [hcColumnDef]="col">
-      <th hc-header-cell *hcHeaderCellDef>{{ col }}</th>
-      <td hc-cell *hcCellDef="let element">{{ element[col] }}</td>
-    </ng-container>
+        <!-- Other columns -->
+        <ng-container *ngFor="let col of cols" [hcColumnDef]="col">
+        <th hc-header-cell *hcHeaderCellDef>{{ col }}</th>
+        <td hc-cell *hcCellDef="let element">{{ element[col] }}</td>
+        </ng-container>
 
-    <!-- Sticky headers "... sticky: true"-->
-    <tr hc-header-row *hcHeaderRowDef="allCols; sticky: stickyHead"></tr>
+        <!-- Sticky headers "... sticky: true"-->
+        <tr hc-header-row *hcHeaderRowDef="allCols; sticky: stickyHead"></tr>
 
-    <!-- Rows -->
-    <tr hc-row *hcRowDef="let row; columns: allCols"></tr>
-  </table>
+        <!-- Rows -->
+        <tr hc-row *hcRowDef="let row; columns: allCols"></tr>
+    </table>
+    </div>
 </div>

--- a/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.html
@@ -1,0 +1,31 @@
+<div class="example-intro">
+    <span>Example of a table with a sticky header & column.</span>
+    <span class="example-checkboxes">
+        <hc-checkbox [(ngModel)]="hasBorders" [tight]="true">Has borders</hc-checkbox>
+        <hc-checkbox [(ngModel)]="stickyHead" [tight]="true">Sticky header</hc-checkbox>
+        <hc-checkbox [(ngModel)]="stickyCol" [tight]="true">Sticky column</hc-checkbox>
+    </span>
+</div>
+
+<!-- Scrollable table container (to define height) -->
+<div hcTableContainer tableHeight="200">
+  <table hc-table [dataSource]="dataSource" [borders]="hasBorders">
+    <!-- Sticky column [sticky]="true"-->
+    <ng-container hcColumnDef="rank" [sticky]="stickyCol">
+      <th hc-index-cell *hcHeaderCellDef>Rank</th>
+      <td hc-index-cell *hcCellDef="let element">{{ element.rank }}</td>
+    </ng-container>
+
+    <!-- Other columns -->
+    <ng-container *ngFor="let col of cols" [hcColumnDef]="col">
+      <th hc-header-cell *hcHeaderCellDef>{{ col }}</th>
+      <td hc-cell *hcCellDef="let element">{{ element[col] }}</td>
+    </ng-container>
+
+    <!-- Sticky headers "... sticky: true"-->
+    <tr hc-header-row *hcHeaderRowDef="allCols; sticky: stickyHead"></tr>
+
+    <!-- Rows -->
+    <tr hc-row *hcRowDef="let row; columns: allCols"></tr>
+  </table>
+</div>

--- a/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.scss
+++ b/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.scss
@@ -21,3 +21,13 @@ th {
         margin-left: 8px;
     }
 }
+
+.example-wrapper {
+    padding: 24px;
+    border-radius: 4px;
+    border: 2px solid $slate-gray-100;
+}
+
+.gray-example-bg {
+    background-color: $slate-gray-100;
+}

--- a/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.scss
+++ b/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.scss
@@ -1,0 +1,23 @@
+@import "@healthcatalyst/cashmere/scss/_colors";
+
+.example-intro {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+td {
+    white-space: nowrap;
+}
+
+th {
+    text-transform: capitalize;
+}
+
+.example-checkboxes {
+    display: flex;
+
+    hc-checkbox {
+        margin-left: 8px;
+    }
+}

--- a/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.ts
+++ b/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.ts
@@ -1,0 +1,206 @@
+import {Component, OnInit} from '@angular/core';
+import {HcTableDataSource} from '@healthcatalyst/cashmere';
+
+/**
+ * @title Table sticky header
+ */
+@Component({
+    selector: 'hc-table-sticky-example',
+    templateUrl: 'table-sticky-example.component.html',
+    styleUrls: ['table-sticky-example.component.scss']
+})
+export class TableStickyExampleComponent implements OnInit {
+    cols = ['name', 'state', 'population', 'founded', 'size', 'notes'];
+    allCols = ['rank', ...this.cols];
+    dataSource: HcTableDataSource<any>;
+    hasBorders = false;
+    stickyHead = true;
+    stickyCol = true;
+
+    ngOnInit(): void {
+      this.dataSource = new HcTableDataSource(CITY_DATA);
+    }
+  }
+
+  const CITY_DATA = [
+    {
+      rank: 1,
+      name: 'New York City',
+      state: 'New York',
+      population: 7888121,
+      founded: 1624,
+      size: 302.6,
+      notes: 'Known for the Statue of Liberty, Empire State Building, Central Park, Times Square, Museums, and the Met'
+    },
+    {
+      rank: 2,
+      name: 'Los Angeles',
+      state: 'California',
+      population: 3792621,
+      founded: 1781,
+      size: 468.7,
+      notes: 'Known for Hollywood, Entertainment, Celebrities, and the Beach'
+    },
+    {
+      rank: 3,
+      name: 'Chicago',
+      state: 'Illinois',
+      population: 2695598,
+      founded: 1837,
+      size: 227.6,
+      notes: 'Known for the Sears (Willis) Tower, the Magnificent Mile, Deep Dish Pizza, and the Cubs'
+    },
+    {
+      rank: 4,
+      name: 'Houston',
+      state: 'Texas',
+      population: 2100263,
+      founded: 1837,
+      size: 599.6,
+      notes: 'Known for NASA, the Astros, and the Rockets'
+    },
+    {
+      rank: 5,
+      name: 'Philadelphia',
+      state: 'Pennsylvania',
+      population: 1526006,
+      founded: 1682,
+      size: 134.1,
+      notes: 'Known for the Liberty Bell, Independence Hall, and the Philly Cheesesteak'
+    },
+    {
+      rank: 6,
+      name: 'Phoenix',
+      state: 'Arizona',
+      population: 1445632,
+      founded: 1881,
+      size: 516.7,
+      notes: 'Known for the Heat, the Suns, and the Grand Canyon'
+    },
+    {
+      rank: 7,
+      name: 'San Antonio',
+      state: 'Texas',
+      population: 1327407,
+      founded: 1718,
+      size: 460.9,
+      notes: 'Known for the Alamo, the River Walk, and the Spurs'
+    },
+    {
+      rank: 8,
+      name: 'San Diego',
+      state: 'California',
+      population: 1307402,
+      founded: 1769,
+      size: 325.2,
+      notes: 'Known for the Zoo, Sea World, and the Beach'
+    },
+    {
+      rank: 9,
+      name: 'Dallas',
+      state: 'Texas',
+      population: 1197816,
+      founded: 1841,
+      size: 340.9,
+      notes: 'Known for the Cowboys, the Mavericks, and the Rangers'
+    },
+    {
+      rank: 10,
+      name: 'San Jose',
+      state: 'California',
+      population: 945942,
+      founded: 1777,
+      size: 176.5,
+      notes: 'Known for Silicon Valley, Tech Companies, and the Sharks'
+    },
+    {
+      rank: 11,
+      name: 'Austin',
+      state: 'Texas',
+      population: 790390,
+      founded: 1839,
+      size: 322.48,
+      notes: 'Known for the Longhorns, the State Capital, and the Music Scene'
+    },
+    {
+      rank: 12,
+      name: 'Indianapolis',
+      state: 'Indiana',
+      population: 843393,
+      founded: 1821,
+      size: 361.5,
+      notes: 'Known for the Indy 500, the Colts, and the Pacers'
+    },
+    {
+      rank: 13,
+      name: 'Jacksonville',
+      state: 'Florida',
+      population: 842583,
+      founded: 1822,
+      size: 747.0,
+      notes: 'Known for the Jaguars, the Beaches, and the Navy'
+    },
+    {
+      rank: 14,
+      name: 'San Francisco',
+      state: 'California',
+      population: 837442,
+      founded: 1776,
+      size: 231.9,
+      notes: 'Known for the Golden Gate Bridge, Alcatraz, and the Cable Cars'
+    },
+    {
+      rank: 15,
+      name: 'Columbus',
+      state: 'Ohio',
+      population: 822553,
+      founded: 1812,
+      size: 210.3,
+      notes: 'Has the largest university in the United States'
+    },
+    {
+      rank: 16,
+      name: 'Charlotte',
+      state: 'North Carolina',
+      population: 792862,
+      founded: 1768,
+      size: 297.7,
+      notes: 'Known for NASCAR, the Hornets, and the Panthers'
+    },
+    {
+      rank: 17,
+      name: 'Fort Worth',
+      state: 'Texas',
+      population: 792727,
+      founded: 1849,
+      size: 339.8,
+      notes: 'Known for the Stockyards, the Cowboys, and the Rangers'
+    },
+    {
+      rank: 18,
+      name: 'Detroit',
+      state: 'Michigan',
+      population: 688701,
+      founded: 1701,
+      size: 138.8,
+      notes: 'Home of the Big Three Automakers'
+    },
+    {
+      rank: 19,
+      name: 'El Paso',
+      state: 'Texas',
+      population: 674433,
+      founded: 1850,
+      size: 256.8,
+      notes: 'Home to the University of Texas at El Paso'
+    },
+    {
+      rank: 20,
+      name: 'Memphis',
+      state: 'Tennessee',
+      population: 653450,
+      founded: 1819,
+      size: 315.1,
+      notes: 'Famous for Elvis Presley, Graceland, and the Blues'
+    },
+  ];

--- a/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.ts
+++ b/projects/cashmere-examples/src/lib/table-sticky/table-sticky-example.component.ts
@@ -16,6 +16,7 @@ export class TableStickyExampleComponent implements OnInit {
     hasBorders = false;
     stickyHead = true;
     stickyCol = true;
+    hasGrayBg = false;
 
     ngOnInit(): void {
       this.dataSource = new HcTableDataSource(CITY_DATA);

--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -275,6 +275,10 @@ tr:hover .hc-table-actions .hc-action-ico,
 // sticky no borders
 th.hc-table-sticky.hc-table-sticky-border-elem-top, .hc-sticky-header th{
     @include th-header-sticky();
+
+    &:first-child {
+        @include th-header-sticky-first-child();
+    }
 }
 
 td, th:first-child {

--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -1,6 +1,10 @@
 @import './table';
 @import './icons';
 
+.hc-table-container {
+    @include hc-table-container();
+}
+
 .hc-table {
     @include hc-table();
 
@@ -264,5 +268,40 @@ tr:hover .hc-table-actions .hc-action-ico,
 
     button {
         @include hc-empty-table-block-button();
+    }
+}
+
+
+// sticky no borders
+th.hc-table-sticky.hc-table-sticky-border-elem-top, .hc-sticky-header th{
+    @include th-header-sticky();
+}
+
+td, th:first-child {
+    &.hc-table-sticky.hc-table-sticky-border-elem-left, &.hc-sticky-col {
+        @include th-col-sticky();
+     }
+}
+
+th.hc-table-sticky-border-elem-left.hc-table-sticky-border-elem-top, tr.hc-sticky-header th.hc-sticky-col:first-child {
+    @include th-sticky-row-and-col();
+}
+
+// sticky w borders
+.hc-table-borders {
+    th.hc-table-sticky, .hc-sticky-header th {
+        @include th-border-header-sticky();
+
+        &.hc-table-sticky-border-elem-left {
+            @include th-sticky-row-and-col-borders();
+        }
+    }
+
+    td.hc-table-sticky, td.hc-sticky-col, th.hc-sticky-col{
+        @include th-border-col-sticky();
+    }
+
+    .hc-sticky-header th.hc-sticky-col {
+        @include th-sticky-row-and-col-borders();
     }
 }

--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -287,8 +287,20 @@ td, th:first-child {
      }
 }
 
-th.hc-table-sticky-border-elem-left.hc-table-sticky-border-elem-top, tr.hc-sticky-header th.hc-sticky-col:first-child {
-    @include th-sticky-row-and-col();
+.hc-table-container-gray {
+    th.hc-table-sticky.hc-table-sticky-border-elem-top, .hc-sticky-header th{
+        @include th-header-sticky-gray();
+
+        &:first-child {
+            @include th-header-sticky-first-child-gray();
+        }
+    }
+}
+
+.hc-table-container-gray, :not(.hc-table-container-gray) {
+    th.hc-table-sticky-border-elem-left.hc-table-sticky-border-elem-top, tr.hc-sticky-header th.hc-sticky-col:first-child {
+        @include th-sticky-row-and-col();
+    }
 }
 
 // sticky w borders

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -395,10 +395,20 @@ $row-selected-border-color: $white;
     background-color: $white;
     top: -1px !important;
     box-shadow: 1px 0 2px $shadow;
+}
 
-    &.hc-sticky-col:first-child {
-        z-index: 101;
-        border-left: 1px solid $slate-gray-300;
+@mixin th-header-sticky-first-child() {
+    z-index: 101;
+
+    &:before {
+        content: ' ';
+        height: 100%;
+        width: 2px;
+        background-color: $white;
+        display: inline-block;
+        position: absolute;
+        left: -1px;
+        top: 0;
     }
 }
 
@@ -415,6 +425,10 @@ $row-selected-border-color: $white;
     border-left: 1px solid $slate-gray-300;
     background-color: $slate-gray-200;
     box-shadow: inset 1px 0 0 $slate-gray-300, inset -1px 0 0 $slate-gray-300;
+
+    &:first-child:before {
+        content: none;
+    }
 }
 
 // sticky w borders
@@ -423,6 +437,9 @@ $row-selected-border-color: $white;
     box-shadow: inset 0 1px 0 $slate-gray-300, inset 0 -1px 0 $slate-gray-300;
     border: 1px solid $slate-gray-300;
     border-bottom: none;
+    &:first-child:before {
+        content: none;
+    }
 }
 
 @mixin th-sticky-row-and-col-borders() {

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -23,6 +23,16 @@ $row-color-selected-hover: tint($azure, 20%) !default;
 $row-selected-font-color: $white;
 $row-selected-border-color: $white;
 
+@mixin hc-table-container {
+    position: relative;
+    overflow: auto;
+    border: none;
+    height: auto;
+    animation: FadeIn 0.3s;
+    max-height: 100vh;
+    border-bottom: 1px solid $slate-gray-200;
+}
+
 @mixin hc-table-element() {
     display: block;
 }
@@ -374,4 +384,53 @@ $row-selected-border-color: $white;
 @mixin hc-empty-table-block-button() {
     margin-top: 10px;
     font-style: normal;
+}
+
+
+
+// sticky no borders
+@mixin th-header-sticky() {
+    z-index: 100;
+    position: sticky;
+    background-color: $white;
+    top: -1px !important;
+    box-shadow: 1px 0 2px $shadow;
+
+    &.hc-sticky-col:first-child {
+        z-index: 101;
+        border-left: 1px solid $slate-gray-300;
+    }
+}
+
+@mixin th-sticky-row-and-col() {
+    z-index: 101;
+    background-color: $slate-gray-200;
+    border-left: 1px solid $slate-gray-300;
+}
+
+@mixin th-col-sticky() {
+    z-index: 99;
+    position: sticky;
+    left: -1px !important;
+    border-left: 1px solid $slate-gray-300;
+    background-color: $slate-gray-200;
+    box-shadow: inset 1px 0 0 $slate-gray-300, inset -1px 0 0 $slate-gray-300;
+}
+
+// sticky w borders
+@mixin th-border-header-sticky() {
+    background-color: $slate-gray-100;
+    box-shadow: inset 0 1px 0 $slate-gray-300, inset 0 -1px 0 $slate-gray-300;
+    border: 1px solid $slate-gray-300;
+    border-bottom: none;
+}
+
+@mixin th-sticky-row-and-col-borders() {
+    box-shadow: inset 0 1px 0 $slate-gray-300, inset 0 -1px 0 $slate-gray-300,
+        inset 1px 0 0 $slate-gray-300, inset -1px 0 0 $slate-gray-300;
+}
+
+@mixin th-border-col-sticky() {
+    border-right: none !important;
+    box-shadow: inset 1px 0 0 $slate-gray-300, inset -1px 0 0 $slate-gray-300;
 }

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -397,6 +397,10 @@ $row-selected-border-color: $white;
     box-shadow: 1px 0 2px $shadow;
 }
 
+@mixin th-header-sticky-gray() {
+    background-color: $slate-gray-100;
+}
+
 @mixin th-header-sticky-first-child() {
     z-index: 101;
 
@@ -409,6 +413,12 @@ $row-selected-border-color: $white;
         position: absolute;
         left: -1px;
         top: 0;
+    }
+}
+
+@mixin th-header-sticky-first-child-gray() {
+    &:before {
+        background-color: $slate-gray-100;
     }
 }
 

--- a/projects/cashmere/src/lib/table/index.ts
+++ b/projects/cashmere/src/lib/table/index.ts
@@ -4,3 +4,4 @@ export {HcHeaderRowDef, HcFooterRowDef, HcRowDef, HcHeaderRow, HcFooterRow, HcRo
 export {HcCellResizer, CellResizeEvent} from './cell-resizer.component';
 export {HcTable} from './table.component';
 export {HcTableDataSource} from './table-data-source';
+export {TableContainerDirective} from './table-container.directive';

--- a/projects/cashmere/src/lib/table/table-container.directive.ts
+++ b/projects/cashmere/src/lib/table/table-container.directive.ts
@@ -9,15 +9,25 @@ export class TableContainerDirective {
     @HostBinding('class.hc-table-container')
     _hostClass = true;
 
+    @HostBinding('class.hc-table-container-gray')
+    _hasGrayBg = false;
+
     @Input() set tableHeight(height: number | string) {
         this._height = height;
         const isHeightJustNumbers = this.onlyNumbersRegex.test(height.toString());
         this.elRef.nativeElement.style.height = isHeightJustNumbers ? `${height}px` : height;
     }
-    get tableHeight(): number | string {
+    get tableHeight(): string | number{
         return this._height;
     }
     private _height: string | number;
+
+    @Input() set hasGrayBg(hasGrayBg: boolean) {
+        this._hasGrayBg = hasGrayBg;
+    }
+    get hasGrayBg(): boolean {
+        return this._hasGrayBg;
+    }
 
     constructor(private elRef: ElementRef) {}
 }

--- a/projects/cashmere/src/lib/table/table-container.directive.ts
+++ b/projects/cashmere/src/lib/table/table-container.directive.ts
@@ -1,0 +1,23 @@
+import {Directive, ElementRef, HostBinding, Input} from '@angular/core';
+
+/** Use `hcTableContainer` to wrap around tables that have sticky headers/columns or other advanced use cases. */
+@Directive({
+    selector: '[hcTableContainer]'
+})
+export class TableContainerDirective {
+    private readonly onlyNumbersRegex = /^\d+$/;
+    @HostBinding('class.hc-table-container')
+    _hostClass = true;
+
+    @Input() set tableHeight(height: number | string) {
+        this._height = height;
+        const isHeightJustNumbers = this.onlyNumbersRegex.test(height.toString());
+        this.elRef.nativeElement.style.height = isHeightJustNumbers ? `${height}px` : height;
+    }
+    get tableHeight(): number | string {
+        return this._height;
+    }
+    private _height: string | number;
+
+    constructor(private elRef: ElementRef) {}
+}

--- a/projects/cashmere/src/lib/table/table.module.ts
+++ b/projects/cashmere/src/lib/table/table.module.ts
@@ -13,6 +13,7 @@ import {HcFooterRow, HcFooterRowDef, HcHeaderRow, HcHeaderRowDef, HcRow, HcRowDe
 import {HcCellResizer} from './cell-resizer.component';
 import {CdkTableModule} from '@angular/cdk/table';
 import {CommonModule} from '@angular/common';
+import { TableContainerDirective } from './table-container.directive';
 
 const EXPORTED_DECLARATIONS = [
     // HcTable
@@ -37,6 +38,9 @@ const EXPORTED_DECLARATIONS = [
     HcHeaderRow,
     HcRow,
     HcFooterRow,
+
+    // table directive
+    TableContainerDirective,
 
     // Cell resizer
     HcCellResizer

--- a/src/app/core/cashmere-components-document-items.json
+++ b/src/app/core/cashmere-components-document-items.json
@@ -132,7 +132,7 @@
     "table": {
         "name": "Table",
         "category": "table",
-        "examples": ["table-sort", "table-filter", "resizable-columns", "more-table-styles"],
+        "examples": ["table-sort", "table-filter", "resizable-columns", "table-sticky", "more-table-styles"],
         "usageDoc": true
     },
     "tabs": {"name": "Tabs", "category": "layout", "examples": ["tabs-horizontal", "tabs-vertical", "selected-tab-input"]},

--- a/src/app/styles/table/table-demo.component.html
+++ b/src/app/styles/table/table-demo.component.html
@@ -383,12 +383,17 @@
             For a sticky header, you'll apply<code>.hc-sticky-header</code> to the row.
             For a sticky column, apply <code>.hc-sticky-col</code> to each cell in the column.
         </p>
+        <span class="example-checkboxes">
+            <hc-checkbox [(ngModel)]="hasBorders" [tight]="true">Has borders</hc-checkbox>
+            <hc-checkbox [(ngModel)]="stickyHead" [tight]="true">Sticky header</hc-checkbox>
+            <hc-checkbox [(ngModel)]="stickyCol" [tight]="true">Sticky column</hc-checkbox>
+        </span>
         <br>
-        <div class="hc-table-container" style="height: 200px;">
+        <div class="hc-table-container" [class.hc-table-borders]="hasBorders" style="height: 200px;">
             <table class="hc-table">
                 <thead>
-                    <tr class="hc-sticky-header">
-                        <th class="hc-sticky-col">Rank</th>
+                    <tr [class.hc-sticky-header]="stickyHead">
+                        <th [class.hc-sticky-col]="stickyCol">Rank</th>
                         <th>City</th>
                         <th>State</th>
                         <th>Population</th>
@@ -399,7 +404,7 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="hc-sticky-col">1</td>
+                        <td [class.hc-sticky-col]="stickyCol">1</td>
                         <td>New York City</td>
                         <td>New York</td>
                         <td>7,888,121</td>
@@ -408,7 +413,7 @@
                         <td>Known for the Statue of Liberty, Empire State Building, Central Park, Times Square, Museums, and the Met</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">2</td>
+                    <td [class.hc-sticky-col]="stickyCol">2</td>
                     <td>Los Angeles</td>
                     <td>California</td>
                     <td>3,792,621</td>
@@ -417,7 +422,7 @@
                     <td>Known for Hollywood, Entertainment, Celebrities, and the Beach</td>
                     </tr>
                     <tr>
-                        <td class="hc-sticky-col">3</td>
+                        <td [class.hc-sticky-col]="stickyCol">3</td>
                         <td>Chicago</td>
                         <td>Illinois</td>
                         <td>2,695,598</td>
@@ -426,7 +431,7 @@
                         <td>Known for the Sears (Willis) Tower, the Magnificent Mile, Deep Dish Pizza, and the Cubs</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">4</td>
+                    <td [class.hc-sticky-col]="stickyCol">4</td>
                     <td>Houston</td>
                     <td>Texas</td>
                     <td>2,100,263</td>
@@ -435,7 +440,7 @@
                     <td>Known for NASA, the Astros, and the Rockets</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">5</td>
+                    <td [class.hc-sticky-col]="stickyCol">5</td>
                     <td>Philadelphia</td>
                     <td>Pennsylvania</td>
                     <td>1,526,006</td>
@@ -444,7 +449,7 @@
                     <td>Known for the Liberty Bell, Independence Hall, and the Philly Cheesesteak</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">6</td>
+                    <td [class.hc-sticky-col]="stickyCol">6</td>
                     <td>Phoenix</td>
                     <td>Arizona</td>
                     <td>1,445,632</td>
@@ -453,7 +458,7 @@
                     <td>Known for the Heat, the Suns, and the Grand Canyon</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">7</td>
+                    <td [class.hc-sticky-col]="stickyCol">7</td>
                     <td>San Antonio</td>
                     <td>Texas</td>
                     <td>1,327,407</td>
@@ -462,7 +467,7 @@
                     <td>Known for the Alamo, the River Walk, and the Spurs</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">8</td>
+                    <td [class.hc-sticky-col]="stickyCol">8</td>
                     <td>San Diego</td>
                     <td>California</td>
                     <td>1,307,402</td>
@@ -471,7 +476,7 @@
                     <td>Known for the Zoo, Sea World, and the Beach</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">9</td>
+                    <td [class.hc-sticky-col]="stickyCol">9</td>
                     <td>Dallas</td>
                     <td>Texas</td>
                     <td>1,197,816</td>
@@ -480,7 +485,7 @@
                     <td>Known for the Cowboys, the Mavericks, and the Rangers</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">10</td>
+                    <td [class.hc-sticky-col]="stickyCol">10</td>
                     <td>San Jose</td>
                     <td>California</td>
                     <td>945,942</td>
@@ -489,7 +494,7 @@
                     <td>Known for Silicon Valley, Tech Companies, and the Sharks</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">11</td>
+                    <td [class.hc-sticky-col]="stickyCol">11</td>
                     <td>Austin</td>
                     <td>Texas</td>
                     <td>790,390</td>
@@ -498,7 +503,7 @@
                     <td>Known for the Longhorns, the State Capital, and the Music Scene</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">12</td>
+                    <td [class.hc-sticky-col]="stickyCol">12</td>
                     <td>Indianapolis</td>
                     <td>Indiana</td>
                     <td>843,393</td>
@@ -507,7 +512,7 @@
                     <td>Known for the Indy 500, the Colts, and the Pacers</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">13</td>
+                    <td [class.hc-sticky-col]="stickyCol">13</td>
                     <td>Jacksonville</td>
                     <td>Florida</td>
                     <td>842,583</td>
@@ -516,7 +521,7 @@
                     <td>Known for the Jaguars, the Beaches, and the Navy</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">14</td>
+                    <td [class.hc-sticky-col]="stickyCol">14</td>
                     <td>San Francisco</td>
                     <td>California</td>
                     <td>837,442</td>
@@ -525,7 +530,7 @@
                     <td>Known for the Golden Gate Bridge, Alcatraz, and the Cable Cars</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">15</td>
+                    <td [class.hc-sticky-col]="stickyCol">15</td>
                     <td>Columbus</td>
                     <td>Ohio</td>
                     <td>822553</td>
@@ -534,7 +539,7 @@
                     <td>Has the largest university in the United States</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">16</td>
+                    <td [class.hc-sticky-col]="stickyCol">16</td>
                     <td>Charlotte</td>
                     <td>North Carolina</td>
                     <td>792,862</td>
@@ -543,7 +548,7 @@
                     <td>Known for NASCAR, the Hornets, and the Panthers</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">17</td>
+                    <td [class.hc-sticky-col]="stickyCol">17</td>
                     <td>Fort Worth</td>
                     <td>Texas</td>
                     <td>792,727</td>
@@ -552,7 +557,7 @@
                     <td>Known for the Stockyards, the Cowboys, and the Rangers</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">18</td>
+                    <td [class.hc-sticky-col]="stickyCol">18</td>
                     <td>Detroit</td>
                     <td>Michigan</td>
                     <td>688,701</td>
@@ -561,7 +566,7 @@
                     <td>Home of the Big Three Automakers</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">19</td>
+                    <td [class.hc-sticky-col]="stickyCol">19</td>
                     <td>El Paso</td>
                     <td>Texas</td>
                     <td>674,433</td>
@@ -570,7 +575,7 @@
                     <td>Home to the University of Texas at El Paso</td>
                     </tr>
                     <tr>
-                    <td class="hc-sticky-col">20</td>
+                    <td [class.hc-sticky-col]="stickyCol">20</td>
                     <td>Memphis</td>
                     <td>Tennessee</td>
                     <td>653,450</td>

--- a/src/app/styles/table/table-demo.component.html
+++ b/src/app/styles/table/table-demo.component.html
@@ -379,9 +379,12 @@
             That element will be scrollable when the table extends beyond it's height. The element needs to have a height
             constraint applied. This can be done with the "max-height" or "height" css properties, or by other methods, like a flexbox layout.
         </p>
-        <p>
-            For a sticky header, you'll apply<code>.hc-sticky-header</code> to the row.
-            For a sticky column, apply <code>.hc-sticky-col</code> to each cell in the column.
+        <ul>
+            <li>For a sticky header, you'll apply<code>.hc-sticky-header</code> to the row.</li>
+            <li>For a sticky column, apply <code>.hc-sticky-col</code> to each cell in the column.</li>
+        </ul>
+        <p>By default, these table styles are meant for tables on a white background, but you can use <code>.hc-table-container-gray</code> for a <code>$slate-gray-100</code>
+            background, or override the colors as needed.
         </p>
         <span class="example-checkboxes">
             <hc-checkbox [(ngModel)]="hasBorders" [tight]="true">Has borders</hc-checkbox>

--- a/src/app/styles/table/table-demo.component.html
+++ b/src/app/styles/table/table-demo.component.html
@@ -374,6 +374,242 @@
     </hc-tile>
 
     <hc-tile>
+        <h5 id="table-action-icons">Sticky Headers & Columns</h5>
+        <p>For sticky headers or columns, first wrap the table in a div with <code>.hc-table-container</code>.
+            That element will be scrollable when the table extends beyond it's height. The element needs to have a height
+            constraint applied. This can be done with the "max-height" or "height" css properties, or by other methods, like a flexbox layout.
+        </p>
+        <p>
+            For a sticky header, you'll apply<code>.hc-sticky-header</code> to the row.
+            For a sticky column, apply <code>.hc-sticky-col</code> to each cell in the column.
+        </p>
+        <br>
+        <div class="hc-table-container" style="height: 200px;">
+            <table class="hc-table">
+                <thead>
+                    <tr class="hc-sticky-header">
+                        <th class="hc-sticky-col">Rank</th>
+                        <th>City</th>
+                        <th>State</th>
+                        <th>Population</th>
+                        <th>Founded</th>
+                        <th>Size</th>
+                        <th>Notes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="hc-sticky-col">1</td>
+                        <td>New York City</td>
+                        <td>New York</td>
+                        <td>7,888,121</td>
+                        <td>1624</td>
+                        <td>302.6</td>
+                        <td>Known for the Statue of Liberty, Empire State Building, Central Park, Times Square, Museums, and the Met</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">2</td>
+                    <td>Los Angeles</td>
+                    <td>California</td>
+                    <td>3,792,621</td>
+                    <td>1781</td>
+                    <td>468.7</td>
+                    <td>Known for Hollywood, Entertainment, Celebrities, and the Beach</td>
+                    </tr>
+                    <tr>
+                        <td class="hc-sticky-col">3</td>
+                        <td>Chicago</td>
+                        <td>Illinois</td>
+                        <td>2,695,598</td>
+                        <td>1837</td>
+                        <td>227.6</td>
+                        <td>Known for the Sears (Willis) Tower, the Magnificent Mile, Deep Dish Pizza, and the Cubs</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">4</td>
+                    <td>Houston</td>
+                    <td>Texas</td>
+                    <td>2,100,263</td>
+                    <td>1837</td>
+                    <td>599.6</td>
+                    <td>Known for NASA, the Astros, and the Rockets</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">5</td>
+                    <td>Philadelphia</td>
+                    <td>Pennsylvania</td>
+                    <td>1,526,006</td>
+                    <td>1682</td>
+                    <td>134.1</td>
+                    <td>Known for the Liberty Bell, Independence Hall, and the Philly Cheesesteak</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">6</td>
+                    <td>Phoenix</td>
+                    <td>Arizona</td>
+                    <td>1,445,632</td>
+                    <td>1881</td>
+                    <td>516.7</td>
+                    <td>Known for the Heat, the Suns, and the Grand Canyon</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">7</td>
+                    <td>San Antonio</td>
+                    <td>Texas</td>
+                    <td>1,327,407</td>
+                    <td>1718</td>
+                    <td>460.9</td>
+                    <td>Known for the Alamo, the River Walk, and the Spurs</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">8</td>
+                    <td>San Diego</td>
+                    <td>California</td>
+                    <td>1,307,402</td>
+                    <td>1769</td>
+                    <td>325.2</td>
+                    <td>Known for the Zoo, Sea World, and the Beach</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">9</td>
+                    <td>Dallas</td>
+                    <td>Texas</td>
+                    <td>1,197,816</td>
+                    <td>1841</td>
+                    <td>340.9</td>
+                    <td>Known for the Cowboys, the Mavericks, and the Rangers</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">10</td>
+                    <td>San Jose</td>
+                    <td>California</td>
+                    <td>945,942</td>
+                    <td>1777</td>
+                    <td>176.5</td>
+                    <td>Known for Silicon Valley, Tech Companies, and the Sharks</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">11</td>
+                    <td>Austin</td>
+                    <td>Texas</td>
+                    <td>790,390</td>
+                    <td>1839</td>
+                    <td>322.48</td>
+                    <td>Known for the Longhorns, the State Capital, and the Music Scene</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">12</td>
+                    <td>Indianapolis</td>
+                    <td>Indiana</td>
+                    <td>843,393</td>
+                    <td>1821</td>
+                    <td>361.5</td>
+                    <td>Known for the Indy 500, the Colts, and the Pacers</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">13</td>
+                    <td>Jacksonville</td>
+                    <td>Florida</td>
+                    <td>842,583</td>
+                    <td>1822</td>
+                    <td>747.0</td>
+                    <td>Known for the Jaguars, the Beaches, and the Navy</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">14</td>
+                    <td>San Francisco</td>
+                    <td>California</td>
+                    <td>837,442</td>
+                    <td>1776</td>
+                    <td>231.9</td>
+                    <td>Known for the Golden Gate Bridge, Alcatraz, and the Cable Cars</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">15</td>
+                    <td>Columbus</td>
+                    <td>Ohio</td>
+                    <td>822553</td>
+                    <td>1812</td>
+                    <td>210.3</td>
+                    <td>Has the largest university in the United States</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">16</td>
+                    <td>Charlotte</td>
+                    <td>North Carolina</td>
+                    <td>792,862</td>
+                    <td>1768</td>
+                    <td>297.7</td>
+                    <td>Known for NASCAR, the Hornets, and the Panthers</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">17</td>
+                    <td>Fort Worth</td>
+                    <td>Texas</td>
+                    <td>792,727</td>
+                    <td>1849</td>
+                    <td>339.8</td>
+                    <td>Known for the Stockyards, the Cowboys, and the Rangers</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">18</td>
+                    <td>Detroit</td>
+                    <td>Michigan</td>
+                    <td>688,701</td>
+                    <td>1701</td>
+                    <td>138.8</td>
+                    <td>Home of the Big Three Automakers</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">19</td>
+                    <td>El Paso</td>
+                    <td>Texas</td>
+                    <td>674,433</td>
+                    <td>1850</td>
+                    <td>256.8</td>
+                    <td>Home to the University of Texas at El Paso</td>
+                    </tr>
+                    <tr>
+                    <td class="hc-sticky-col">20</td>
+                    <td>Memphis</td>
+                    <td>Tennessee</td>
+                    <td>653,450</td>
+                    <td>1819</td>
+                    <td>315.1</td>
+                    <td>Famous for Elvis Presley, Graceland, and the Blues</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <pre><code>
+            &#x3C;div class=&#x22;hc-table-container&#x22; style=&#x22;height: 200px;&#x22;&#x3E;
+            &#x3C;table class=&#x22;hc-table&#x22;&#x3E;
+                &#x3C;thead&#x3E;
+                    &#x3C;tr class=&#x22;hc-sticky-header&#x22;&#x3E;
+                        &#x3C;th class=&#x22;hc-sticky-col&#x22;&#x3E;Rank&#x3C;/th&#x3E;
+                        &#x3C;th&#x3E;City&#x3C;/th&#x3E;
+                        &#x3C;th&#x3E;State&#x3C;/th&#x3E;
+                        &#x3C;th&#x3E;Population&#x3C;/th&#x3E;
+                        &#x3C;th&#x3E;Founded&#x3C;/th&#x3E;
+                        &#x3C;th&#x3E;Size&#x3C;/th&#x3E;
+                        &#x3C;th&#x3E;Notes&#x3C;/th&#x3E;
+                    &#x3C;/tr&#x3E;
+                &#x3C;/thead&#x3E;
+                &#x3C;tbody&#x3E;
+                    &#x3C;tr&#x3E;
+                        &#x3C;td class=&#x22;hc-sticky-col&#x22;&#x3E;1&#x3C;/td&#x3E;
+                        &#x3C;td&#x3E;New York City&#x3C;/td&#x3E;
+                        &#x3C;td&#x3E;New York&#x3C;/td&#x3E;
+                        &#x3C;td&#x3E;7,888,121&#x3C;/td&#x3E;
+                        &#x3C;td&#x3E;1624&#x3C;/td&#x3E;
+                        &#x3C;td&#x3E;302.6&#x3C;/td&#x3E;
+
+                ...
+        </code></pre>
+    </hc-tile>
+
+    <hc-tile>
         <h5 id="table-action-icons">Table Action Icons</h5>
         <p>For tables that have actions repeated on each row, we recommend showing those actions as icons that appear
             when hovering

--- a/src/app/styles/table/table-demo.component.scss
+++ b/src/app/styles/table/table-demo.component.scss
@@ -18,3 +18,7 @@
         white-space: nowrap;
     }
 }
+
+li {
+    margin-left: 24px;
+}

--- a/src/app/styles/table/table-demo.component.scss
+++ b/src/app/styles/table/table-demo.component.scss
@@ -12,3 +12,9 @@
     padding-right: 0;
     width: 20px;
 }
+
+.hc-table-container {
+    td {
+        white-space: nowrap;
+    }
+}

--- a/src/app/styles/table/table-demo.component.ts
+++ b/src/app/styles/table/table-demo.component.ts
@@ -8,6 +8,10 @@ import {BaseDemoComponent} from '../../shared/base-demo.component';
     styleUrls: ['./table-demo.component.scss']
 })
 export class TableDemoComponent extends BaseDemoComponent {
+    hasBorders = false;
+    stickyHead = true;
+    stickyCol = true;
+
     constructor(sectionService: SectionService) {
         super(sectionService);
     }


### PR DESCRIPTION
We had a few really old issues out there about sticky table headers being buggy and not well documented. Now that we're not supporting IE11, this become easier.

**Component**
![image](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/e410b789-c197-49e1-87a4-1cb7d52e484e)

**CSS-only Examples**
![image](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/f5a02547-5d3c-4da4-bb75-786c3e6da3ac)

re #889 
re #685 
fix #1207 
