### PR TITLE
fix(table): update styles for sticky headers

### DIFF
--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -279,6 +279,10 @@ th.hc-table-sticky.hc-table-sticky-border-elem-top, .hc-sticky-header th{
     &:first-child {
         @include th-header-sticky-first-child();
     }
+
+    &:last-child {
+        @include th-header-sticky-last-child();
+    }
 }
 
 td, th:first-child {
@@ -293,6 +297,10 @@ td, th:first-child {
 
         &:first-child {
             @include th-header-sticky-first-child-gray();
+        }
+
+        &:last-child {
+            @include th-header-sticky-last-child-gray();
         }
     }
 }

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -416,8 +416,28 @@ $row-selected-border-color: $white;
     }
 }
 
+@mixin th-header-sticky-last-child() {
+    &:after {
+        content: ' ';
+        height: 100%;
+        width: 2px;
+        background-color: $white;
+        display: inline-block;
+        position: absolute;
+        right: -1px;
+        top: 0;
+    }
+}
+
+
 @mixin th-header-sticky-first-child-gray() {
     &:before {
+        background-color: $slate-gray-100;
+    }
+}
+
+@mixin th-header-sticky-last-child-gray() {
+    &:after {
         background-color: $slate-gray-100;
     }
 }
@@ -439,6 +459,10 @@ $row-selected-border-color: $white;
     &:first-child:before {
         content: none;
     }
+
+    &:last-child:after {
+        content: none;
+    }
 }
 
 // sticky w borders
@@ -448,6 +472,10 @@ $row-selected-border-color: $white;
     border: 1px solid $slate-gray-300;
     border-bottom: none;
     &:first-child:before {
+        content: none;
+    }
+
+    &:last-child:after {
         content: none;
     }
 }


### PR DESCRIPTION
Tried out the new sticky header code in CDP config UI. Found one little issue where right side border can bleed through from behind sticky header.