### PR TITLE
feat(search-bar): add debounce input

### DIFF
--- a/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.html
@@ -1,5 +1,6 @@
 <hc-search-bar
     [placeholder]="placeholder"
+    [debounce]="debounce"
     [disabled]="disabled"
     [showSearchIcon]="showSearchIcon"
     [showClearIcon]="showClearIcon"
@@ -34,6 +35,13 @@
     <hc-checkbox id="showClearIcon" [(ngModel)]="showClearIcon">Show clear icon</hc-checkbox>
     <hc-checkbox id="autoSearch" [(ngModel)]="autoSearch">Trigger search on key up</hc-checkbox>
     <hc-checkbox id="disabled" [(ngModel)]="disabled">Disabled</hc-checkbox>
+</div>
+
+<div class="property-form-group">
+    <hc-form-field>
+        <hc-label>Debounce (ms):</hc-label>
+        <input hcInput [(ngModel)]="debounce" />
+    </hc-form-field>
 </div>
 
 <br />

--- a/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.ts
@@ -12,6 +12,7 @@ export class SearchBarOverviewExampleComponent {
     showSearchIcon = true;
     showClearIcon = true;
     autoSearch = true;
+    debounce = 100;
     output = "";
     styleControl = new FormControl("normal");
 

--- a/projects/cashmere/src/lib/search-bar/search-bar.component.ts
+++ b/projects/cashmere/src/lib/search-bar/search-bar.component.ts
@@ -15,16 +15,19 @@ export class SearchBarComponent implements OnInit, OnDestroy {
     @Input() disabled = false;
     /** Preseed the search bar with a particular text value. *Defaults to empty string.* */
     @Input() initialSearchTerm = '';
-    /** If true, show the search icon in the right side of the search bar. *Defaults to true.* */
+    /** If true, show the search icon in the right side of the search bar. *Defaults to `true`.* */
     @Input() showSearchIcon = true;
-    /** If true, show a clickable clear icon in the right side of the search bar when there's a search term present. *Defaults to true.* */
+    /** If true, show a clickable clear icon in the right side of the search bar when there's a search term present. *Defaults to `true`.* */
     @Input() showClearIcon = true;
-    /** If true, fire triggerSearch event on user keyup (with a built-in 100ms debounce). *Defaults to true.* */
+    /** If true, fire triggerSearch event on user keyup (with a built-in 100ms debounce). *Defaults to `true`.* */
     @Input() autoSearch = true;
     /** Sets whether the input should be sized for small screens (if true, overrides the `tight` param) *Defaults to `false`.* */
     @Input() mobile = false;
     /** If true, condense the default padding and reduce the font size. *Defaults to `false`.*  */
     @Input() tight = false;
+    /** Sets the time in milliseconds to wait before triggering a search. *Defaults to `100`. */
+    @Input()
+    public debounce = 100;
     /** Fires when a search should be run. Outputs the search term. */
     @Output() triggerSearch = new EventEmitter<string>();
     @ViewChild('searchFilter', {static: true}) private searchBar: ElementRef;
@@ -42,7 +45,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 
     public ngOnInit(): void {
         this.searchStream
-            .pipe(debounceTime(100), distinctUntilChanged())
+            .pipe(debounceTime(this.debounce), distinctUntilChanged())
             .pipe(takeUntil(this.destroy$))
             .subscribe(t => {
                 this.triggerSearch.emit(t);


### PR DESCRIPTION
I figured `debounce` should be configurable. I was going to add it to the example as well but, this implementation doesn't allow altering the debounce time after `ngOnInit` has fired. 

This didn't seem like a big enough reason for me to alter the implementation, but, let me know if you disagree and I'm sure I can come up with something.