### PR TITLE
feat(search bar): add event for clear button click

### DIFF
--- a/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.html
@@ -7,7 +7,8 @@
     [autoSearch]="autoSearch"
     [tight]="styleControl.value === 'tight'"
     [mobile]="styleControl.value === 'mobile'"
-    (triggerSearch)="search($event)">
+    (triggerSearch)="search($event)"
+    (clearClicked)="clearClicked()">
 </hc-search-bar>
 
 <hr />

--- a/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/search-bar-overview/search-bar-overview-example.component.ts
@@ -19,4 +19,8 @@ export class SearchBarOverviewExampleComponent {
     search(term: string): void {
         this.output += `Search for '${term}'\n`;
     }
+
+    clearClicked(): void {
+        this.output += `Clear clicked\n`;
+    }
 }

--- a/projects/cashmere/src/lib/input/clear-input.component.ts
+++ b/projects/cashmere/src/lib/input/clear-input.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 @Component({
     selector: 'hc-clear-input-btn',
@@ -10,10 +10,12 @@ import {Component, Input} from '@angular/core';
 export class ClearInputComponent {
     /** A reference to the HTML input element */
     @Input() public inputEl: HTMLInputElement;
+    @Output() public clearClicked = new EventEmitter<void>();
     public clear(): void {
         this.inputEl.value = '';
         this.inputEl.focus();
         this.inputEl.dispatchEvent(new CustomEvent('input')); // forces update of ngModel (if there is one)
         this.inputEl.dispatchEvent(new CustomEvent('keyup')); // fire off a keyup (for those inputs functioning as a search that are tied to keyup)
+        this.clearClicked.emit();
     }
 }

--- a/projects/cashmere/src/lib/search-bar/search-bar.component.html
+++ b/projects/cashmere/src/lib/search-bar/search-bar.component.html
@@ -2,6 +2,6 @@
     <input id="search-box" hcInput autocomplete="off" #searchFilter type="text" [disabled]="disabled" [mobile]="mobile"
         (keyup)="_onKeyUp($event, searchFilter.value)" (keyup.enter)="_onEnter(searchFilter.value)"
         placeholder="{{ placeholder }}" />
-    <hc-clear-input-btn *ngIf="showClearIcon" hcSuffix [inputEl]="searchFilter"></hc-clear-input-btn>
+    <hc-clear-input-btn *ngIf="showClearIcon" hcSuffix [inputEl]="searchFilter" (clearClicked)="clearClicked.emit()"></hc-clear-input-btn>
     <span *ngIf="showSearchIcon" hcSuffix class="hc-search-ico"></span>
 </hc-form-field>

--- a/projects/cashmere/src/lib/search-bar/search-bar.component.ts
+++ b/projects/cashmere/src/lib/search-bar/search-bar.component.ts
@@ -30,6 +30,8 @@ export class SearchBarComponent implements OnInit, OnDestroy, OnChanges {
     public debounce = 100;
     /** Fires when a search should be run. Outputs the search term. */
     @Output() triggerSearch = new EventEmitter<string>();
+    /** Fires when clear icon is clicked. */
+    @Output() clearClicked = new EventEmitter<void>();
     @ViewChild('searchFilter', {static: true}) private searchBar: ElementRef;
     /** Returns the current search term. */
     public get value(): string {


### PR DESCRIPTION
re #2189

Add a `clearClicked` event emitter that came up as a need for a CDP config UI use case.
![clickevent](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/e7ed3890-ddec-4e78-83d3-055b5d0cc63f)
