### PR TITLE
fix(input): error check on markAsTouched

### DIFF
--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.component.html
@@ -23,3 +23,4 @@
 </div>
 
 <button hc-button title="NgForm Reset" buttonStyle="secondary" (click)="resetForm()">NgForm Reset</button>
+<button hc-button title="Mark as touched" buttonStyle="secondary" (click)="markAsTouched()">Mark as Touched</button>

--- a/projects/cashmere-examples/src/lib/input-required/input-required-example.component.ts
+++ b/projects/cashmere-examples/src/lib/input-required/input-required-example.component.ts
@@ -22,4 +22,9 @@ export class InputRequiredExampleComponent {
     resetForm(): void {
         this.exampleForm.resetForm();
     }
+
+    // Calling markAsTouched on an input formControl will fire an error state check
+    markAsTouched(): void {
+        this.exampleFormGroup.markAllAsTouched();
+    }
 }

--- a/projects/cashmere/src/lib/input/input.directive.ts
+++ b/projects/cashmere/src/lib/input/input.directive.ts
@@ -209,6 +209,25 @@ export class InputDirective extends HcFormControlComponent implements AfterViewI
         if ( this._form ) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
+        
+        /** Monkey patching the markAsTouched function to call error state checking because there is not an event for touched changes */
+        if ( this._ngControl && this._ngControl.control ) {
+            // eslint-disable-next-line @typescript-eslint/no-this-alias
+            const self = this;
+            const originalMarkMethod = this._ngControl.control.markAsTouched;
+            this._ngControl.control.markAsTouched = function () {
+                // eslint-disable-next-line prefer-rest-params
+                originalMarkMethod.apply(this, arguments);
+                self._updateErrorState();
+            };
+
+            const originalMarkAllMethod = this._ngControl.control.markAllAsTouched;
+            this._ngControl.control.markAllAsTouched = function () {
+                // eslint-disable-next-line prefer-rest-params
+                originalMarkAllMethod.apply(this, arguments);
+                self._updateErrorState();
+            };
+        }
     }
 
     constructor(


### PR DESCRIPTION
Because there is no way to listen for changes to the `touched` state on an Input, we use the blur event as a proxy.  But in instances where the developer is calling `markAsTouched` or `markAllAsTouched`, a blur event won't be fired, and the developer will expect error state checking to occur.  This update patches the native functions to call Cashmere error state error checking.