### PR TITLE
hc-select bugs: placeholderValue and ng-content changes

### DIFF
--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.html
@@ -1,15 +1,16 @@
 <form>
     <hc-select [formControl]="selectControl">
-        <option *ngFor="let location of locations" [ngValue]="location">{{location.dbaName}}</option>
+        <option *ngFor="let location of locations" [ngValue]="location.id">{{ location.dbaName }}</option>
     </hc-select>
 </form>
 
-<button hc-button class="demo-button" (click)="setInsurance()">
-    Select Insurance Department
-</button>
+<button hc-button class="demo-button" (click)="setInsurance()">Select Insurance Department</button>
 
-<button hc-button class="demo-button" (click)="toggleActive()">
-    Enable/Disable Select
-</button>
+<button hc-button class="demo-button" (click)="toggleActive()">Enable/Disable Select</button>
 
-<p class="example-results">Form control value: <code>{{selectControl.value | json}}</code></p>
+<button hc-button class="demo-button" (click)="changeOptions()">Change Options</button>
+
+<p class="example-results">
+    Form control value:
+    <code>{{ selectControl.value | json }}</code>
+</p>

--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.scss
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.scss
@@ -1,5 +1,5 @@
 form {
-    max-width: 350px;
+    max-width: 650px;
 }
 
 .example-results {

--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.ts
@@ -13,13 +13,13 @@ export class SelectFormsExampleComponent {
     locations = [
         {id: 1, dbaName: 'Tax Commission'},
         {id: 2, dbaName: 'Insurance Department'},
-        {id: 3, dbaName: 'Environmental Quality'},
+        {id: 3, dbaName: 'Environmental Quality'}
     ];
 
-    selectControl = new FormControl(this.locations[0]);
+    selectControl = new FormControl(this.locations[0].id);
 
     setInsurance(): void {
-        this.selectControl.setValue(this.locations[1], {onlySelf: true});
+        this.selectControl.setValue(this.locations[1].id, {onlySelf: true});
     }
 
     toggleActive(): void {
@@ -28,5 +28,13 @@ export class SelectFormsExampleComponent {
         } else {
             this.selectControl.disable();
         }
+    }
+
+    changeOptions(): void {
+        this.locations = [
+            {id: 1, dbaName: 'Tax Commission (updated)'},
+            {id: 2, dbaName: 'Insurance Department (updated)'},
+            {id: 3, dbaName: 'Environmental Quality (updated)'}
+        ];
     }
 }

--- a/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.html
@@ -15,7 +15,7 @@
 <em>
     The placeholder option will default to a value of
     <code>""</code>
-    . But if you can set it another value as needed. Note that changing the placeholder value below deselects the placeholder.
+    . But you can set it to another value as needed. Note that changing the placeholder value below deselects the placeholder.
 </em>
 
 <hc-form-field inline>

--- a/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.html
@@ -2,24 +2,27 @@
     <hc-form-field inline>
         <hc-label>Select your facility:</hc-label>
         <hc-select placeholder="Select a city" [placeholderValue]="phVal" [formControl]="selectVal">
-            <option value="1">Philadelphia</option>
-            <option value="2">Atlanta</option>
+            <option *ngFor="let city of cities" [ngValue]="city">
+                {{ city.name }}
+            </option>
         </hc-select>
     </hc-form-field>
-    <button hc-button (click)="reset()">Reset to Empty String</button>
+    <button hc-button class="demo-button" (click)="reset('')">Set to Empty String</button>
+    <button hc-button class="demo-button" (click)="reset(null)">Set to null</button>
+    <button hc-button class="demo-button" (click)="reset(undefined)">Set to undefined</button>
 </div>
 
 <em>
-    The placeholder option will default to a value of <code>""</code>.
-    But if you can set it another value as needed.
-    Note that changing the placeholder value below deselects the placeholder.
+    The placeholder option will default to a value of
+    <code>""</code>
+    . But if you can set it another value as needed. Note that changing the placeholder value below deselects the placeholder.
 </em>
 
 <hc-form-field inline>
     <hc-label>Placeholder value:</hc-label>
     <hc-radio-group (change)="updatePlaceholderVal($event)" [inline]="true">
-        <hc-radio-button value="1" [checked]="true">Empty String</hc-radio-button>
+        <hc-radio-button value="1">Empty String</hc-radio-button>
         <hc-radio-button value="2">Null</hc-radio-button>
-        <hc-radio-button value="3">Undefined</hc-radio-button>
+        <hc-radio-button value="3" [checked]="true">Undefined</hc-radio-button>
     </hc-radio-group>
 </hc-form-field>

--- a/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.scss
+++ b/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.scss
@@ -1,5 +1,5 @@
 .select-sample {
-    max-width: 350px;
+    max-width: 650px;
     width: 100%;
 }
 

--- a/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-placeholder/select-placeholder-example.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
-import { FormControl } from '@angular/forms';
-import { RadioButtonChangeEvent } from '@healthcatalyst/cashmere';
+import {Component, OnInit} from '@angular/core';
+import {FormControl} from '@angular/forms';
+import {RadioButtonChangeEvent} from '@healthcatalyst/cashmere';
 
 /**
  * @title Select Component Placeholder
@@ -10,18 +10,31 @@ import { RadioButtonChangeEvent } from '@healthcatalyst/cashmere';
     templateUrl: 'select-placeholder-example.component.html',
     styleUrls: ['select-placeholder-example.component.scss']
 })
-export class SelectPlaceholderExampleComponent {
-    phVal: any = "";
-    selectVal = new FormControl("");
+export class SelectPlaceholderExampleComponent implements OnInit {
+    cities = [
+        {
+            name: 'Philadelphia'
+        },
+        {
+            name: 'Atlanta'
+        }
+    ];
 
-    reset(): void {
-        this.selectVal.setValue("");
+    phVal: any = undefined;
+    selectVal = new FormControl();
+
+    ngOnInit(): void {
+        this.selectVal.setValue(undefined);
     }
 
-    updatePlaceholderVal( selected: RadioButtonChangeEvent ): void {
-        if ( selected.value === "1" ) {
-            this.phVal = "";
-        } else if ( selected.value === "2" ) {
+    reset(value: any): void {
+        this.selectVal.setValue(value);
+    }
+
+    updatePlaceholderVal(selected: RadioButtonChangeEvent): void {
+        if (selected.value === '1') {
+            this.phVal = '';
+        } else if (selected.value === '2') {
             this.phVal = null;
         } else {
             this.phVal = undefined;

--- a/projects/cashmere/src/lib/select/select.component.html
+++ b/projects/cashmere/src/lib/select/select.component.html
@@ -9,7 +9,7 @@
         (blur)="_onBlur()"
         [required]="required"
     >
-        <option *ngIf="placeholder" [value]="placeholderValue" selected disabled hidden #selectPlaceholder>{{ placeholder }}</option>
+        <option *ngIf="placeholder" [ngValue]="placeholderValue" selected disabled hidden #selectPlaceholder>{{ placeholder }}</option>
         <ng-content></ng-content>
     </select>
 </div>

--- a/projects/cashmere/src/lib/select/select.component.html
+++ b/projects/cashmere/src/lib/select/select.component.html
@@ -8,6 +8,7 @@
         (focus)="focus.next()"
         (blur)="_onBlur()"
         [required]="required"
+        (cdkObserveContent)="_onContentUpdated()"
     >
         <option *ngIf="placeholder" [ngValue]="placeholderValue" selected disabled hidden #selectPlaceholder>{{ placeholder }}</option>
         <ng-content></ng-content>

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -65,12 +65,11 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
     get placeholderValue(): any {
         return this._placeholderValue;
     }
-    set placeholderValue( val: any ) {
-        if ( this.placeholder && this._nativePlaceholder ) {
-            this._placeholderValue = val;
-            this._renderer.setProperty( this._nativePlaceholder.nativeElement, 'value', val );
-            this._applyValueToNativeControl();
-        }
+
+    set placeholderValue(val: any) {
+        this._placeholderValue = val;
+        this._applyPlaceholderValueToNativeControl();
+        this._applyValueToNativeControl();
     }
 
     /** Enables or disables the component */
@@ -179,18 +178,19 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
     }
 
     ngAfterViewInit() {
+        this._applyPlaceholderValueToNativeControl();
         this._applyValueToNativeControl();
 
-        if ( this._ngControl?.statusChanges ) {
+        if (this._ngControl?.statusChanges) {
             // delay() is necessary to make sure any form or control state changes have been applied before rechecking error states
             this._ngControl.statusChanges.pipe(delay(0), takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
-        if ( this._form ) {
+        if (this._form) {
             this._form.ngSubmit.pipe(takeUntil(this._unsubscribe)).subscribe(() => this._updateErrorState());
         }
 
         /** Monkey patching the markAsTouched function to call error state checking because there is not an event for touched changes */
-        if ( this._ngControl && this._ngControl.control ) {
+        if (this._ngControl && this._ngControl.control) {
             // eslint-disable-next-line @typescript-eslint/no-this-alias
             const self = this;
             const originalMarkMethod = this._ngControl.control.markAsTouched;
@@ -226,7 +226,7 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
 
     writeValue(value: any) {
         // Prevent the form control from trying to write a value when removing the control
-        if ( this.onChange.name !== 'noop' ) {
+        if (this.onChange.name !== 'noop') {
             this._value = value;
             this._applyValueToNativeControl();
         }
@@ -243,6 +243,14 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         }
         const valueString = _buildValueString(id, this._value);
         this._renderer.setProperty(this._nativeSelect.nativeElement, 'value', valueString);
+    }
+
+    _applyPlaceholderValueToNativeControl() {
+        if (!this._nativePlaceholder) {
+            return;
+        }
+
+        this._renderer.setProperty(this._nativePlaceholder.nativeElement, 'value', this._placeholderValue);
     }
 
     _change(event: Event, value: any) {

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -278,6 +278,10 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
         return valueString.split(':')[0];
     }
 
+    _onContentUpdated(): void {
+        this._applyValueToNativeControl();
+    }
+
     private _updateErrorState() {
         const oldState = this._errorState;
 

--- a/projects/cashmere/src/lib/select/select.module.ts
+++ b/projects/cashmere/src/lib/select/select.module.ts
@@ -3,9 +3,10 @@ import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {SelectComponent} from './select.component';
 import {HcOptionDirective} from './hc-option.directive';
+import {ObserversModule} from '@angular/cdk/observers';
 
 @NgModule({
-    imports: [CommonModule, FormsModule],
+    imports: [CommonModule, FormsModule, ObserversModule],
     exports: [SelectComponent, HcOptionDirective],
     declarations: [SelectComponent, HcOptionDirective]
 })


### PR DESCRIPTION
Fixes #2207, fixes #2208, fixes #2209.

This PR fixes the behavior of hc-select when a non-string `placeholderValue` is set on page load, and when the option elements in ng-content change after page load.