### PR TITLE
fix(search-bar): the background image repeating.

### DIFF
--- a/projects/cashmere/src/lib/sass/search-bar.scss
+++ b/projects/cashmere/src/lib/sass/search-bar.scss
@@ -19,6 +19,7 @@
     width: 15px;
     cursor: pointer;
     background-image: url($ico-search-grey);
+    background-repeat: no-repeat;
 }
 
 @mixin hc-search-bar-ico-tight() {


### PR DESCRIPTION
The icon in the search bar was repeating itself when switching to 'tight' styling.