### PR TITLE
fix(sidenav): fix tooltip for collapsed tabs with nested links

### DIFF
--- a/projects/cashmere/src/lib/sidenav/sidenav.component.html
+++ b/projects/cashmere/src/lib/sidenav/sidenav.component.html
@@ -135,7 +135,7 @@
             tabindex="0"
             (keydown.enter)="onTabClick($event, tab)"
             (click)="onTabClick($event, tab)"
-            [hcPop]="tabPop" [trigger]="collapsed && !tab.parent && !isFav && !(tab.children?.length > 0) ? 'hover' : 'none'"
+            [hcPop]="tabPop" [trigger]="collapsed && !tab.parent && !isFav ? 'hover' : 'none'"
             [context]="tab.title || ''"
         >
             <span class="hc-sidenav-tab-tree-line-horz"></span>


### PR DESCRIPTION
Tiny little fix: I realized that hcTooltips weren't showing for tabs with nested links, like this one.

![image](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/a3caa9b2-3003-4669-8b41-76778a77dc1a)
