### PR TITLE
docs(app-branding-demo): adding an app title generator for navbar

### DIFF
--- a/src/app/foundations/app-branding/app-branding-demo.component.html
+++ b/src/app/foundations/app-branding/app-branding-demo.component.html
@@ -1,0 +1,52 @@
+<div class="demo-content">
+    <h1>App Title Generator</h1>
+    <h6>Last updated February 15, 2024</h6>
+
+    <hc-tile>
+        <h5 id="overview">Overview</h5>
+        <p>
+            The App Title Generator is a tool to create the application
+            title followed just after the Health Catalyst icon in the navbar.
+            For example "Cashmere" in the top navbar of this page is the
+            application title.
+        </p>
+        <p>
+            Use the configuration options below to make your own application
+            title image:
+        </p>
+
+        <div class="property-form-group">
+            <hc-form-field>
+                <hc-label>Theme:</hc-label>
+                <hc-select [(ngModel)]="theme" (change)="generateLogo()">
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                </hc-select>
+            </hc-form-field>
+
+            <hc-form-field>
+                <hc-label>Primary Normal Text:</hc-label>
+                <input hcInput [(ngModel)]="slimText" (change)="generateLogo()" />
+            </hc-form-field>
+            <hc-form-field>
+                <hc-label>Secondary Bold Text:</hc-label>
+                <input hcInput [(ngModel)]="boldText" (change)="generateLogo()" />
+            </hc-form-field>
+        </div>
+
+        <div id="image-container">
+            <canvas #canvasContainer id="canvas-container" width="2113" height="203"></canvas>
+            <img #imageOutput id="image-output" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
+        </div>
+
+        <p class="hint-text">
+            The produced image is transparent. Use the theme appropriate theme for the backdrop the image will be placed on.
+        </p>
+
+        <a hc-button id="download-button" buttonStyle="primary-alt" download href="">
+            <hc-icon fontSet="fa" fontIcon="fa-download" class="icon-left"></hc-icon>&nbsp;
+            Download Application Title Image
+        </a>
+    </hc-tile>
+
+</div>

--- a/src/app/foundations/app-branding/app-branding-demo.component.scss
+++ b/src/app/foundations/app-branding/app-branding-demo.component.scss
@@ -1,0 +1,33 @@
+@import 'scss/colors';
+
+@font-face {
+    font-family: "CarnasLight";
+    src: url("https://db.onlinewebfonts.com/t/473809dc8ea2e0342b9b9298d654ad04.eot");
+    src: url("https://db.onlinewebfonts.com/t/473809dc8ea2e0342b9b9298d654ad04.eot?#iefix")format("embedded-opentype"),
+    url("https://db.onlinewebfonts.com/t/473809dc8ea2e0342b9b9298d654ad04.woff2")format("woff2"),
+    url("https://db.onlinewebfonts.com/t/473809dc8ea2e0342b9b9298d654ad04.woff")format("woff"),
+    url("https://db.onlinewebfonts.com/t/473809dc8ea2e0342b9b9298d654ad04.ttf")format("truetype"),
+    url("https://db.onlinewebfonts.com/t/473809dc8ea2e0342b9b9298d654ad04.svg#Carnas W03 Light")format("svg");
+}
+
+#canvas-container {
+    display: none;
+}
+
+#image-output {
+    font-family: CarnasLight, "Noto Sans", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    border: 1px solid #cccccc;
+    max-height: 91px;
+    background-position: 0 0;
+    background-size: 100%;
+    background-repeat: no-repeat;
+    // background-image: url(); // use this to test the image against a known application title
+}
+
+.hint-text {
+    font-family: CarnasLight, "Noto Sans", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-style: italic;
+    color: $gray-400;
+    font-weight: 300;
+    font-size: 15px;
+}

--- a/src/app/foundations/app-branding/app-branding-demo.component.ts
+++ b/src/app/foundations/app-branding/app-branding-demo.component.ts
@@ -1,0 +1,80 @@
+import {Component, ElementRef, ViewChild} from '@angular/core';
+import {SectionService} from '../../shared/section.service';
+import {BaseDemoComponent} from '../../shared/base-demo.component';
+
+@Component({
+    selector: 'hc-app-branding-demo',
+    templateUrl: './app-branding-demo.component.html',
+    styleUrls: ['./app-branding-demo.component.scss']
+})
+export class AppBrandingDemoComponent extends BaseDemoComponent {
+
+    @ViewChild('canvasContainer') canvasContainer:ElementRef;
+    @ViewChild('imageOutput') imageOutput:ElementRef;
+    theme = "dark";
+    slimText = "Cashmere";
+    boldText = "Dashboard";
+
+    constructor(sectionService: SectionService) {
+        super(sectionService);
+    }
+
+    ngAfterViewInit() {
+        setTimeout(() => this.generateLogo(), 2000); // font may not have loaded yet
+        this.generateLogo();
+    }
+
+    generateLogo() {
+        const canvas = this.canvasContainer.nativeElement;
+        const ctx = canvas.getContext("2d", {alpha: true});
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        let textColor = "";
+        if(this.theme === "light") {
+            textColor = "#000000";
+            this.imageOutput.nativeElement.style.backgroundColor = "#ffffff";
+        }
+        else {
+            textColor = "#ffffff";
+            this.imageOutput.nativeElement.style.backgroundColor = "#384655";
+        }
+        const baseFont = "182px CarnasLight";
+        const slimTextLetterSpacing = ".75px";
+        const boldTextLetterSpacing = "4px";
+        ctx.font = baseFont;
+        ctx.letterSpacing = slimTextLetterSpacing;
+        const slimTextRect = ctx.measureText(this.slimText);
+        ctx.font = "bold " + baseFont;
+        ctx.letterSpacing = boldTextLetterSpacing;
+        const boldTextRect = ctx.measureText(this.boldText);
+        canvas.width = slimTextRect.width + 2 + boldTextRect.width;
+        canvas.height = 203;
+
+        const textOffsetX = 0;
+        const textOffsetY = 156; //slimTextRect.fontBoundingBoxAscent-21;
+
+        // slim text
+        ctx.font = baseFont;
+        ctx.letterSpacing = slimTextLetterSpacing;
+        ctx.fillStyle = textColor; // setting font resets fillStyle :P
+        ctx.fillText(this.slimText, textOffsetX, textOffsetY);
+
+        //bold text
+        ctx.font = "bold " + baseFont;
+        ctx.letterSpacing = boldTextLetterSpacing;
+        ctx.fillStyle = textColor; // setting font resets fillStyle :P
+        ctx.fillText(this.boldText, textOffsetX + slimTextRect.width, textOffsetY);
+
+        // create data url
+        const dataUrl = canvas.toDataURL();
+        this.imageOutput.nativeElement.src = dataUrl;
+
+        // create a clean download link
+        const downloadLink = document.getElementById("download-button") as HTMLFormElement;
+        if(downloadLink) {
+            downloadLink.href = dataUrl;
+            let filename = `${this.slimText}${this.boldText ? "-" + this.boldText : ""}`;
+            filename = filename.toLowerCase().replace(/[^0-1a-z\s-]/, '').trim().replace(/\s/, '-');
+            downloadLink.download = filename + `.png`;
+        }
+    }
+}

--- a/src/app/foundations/foundations-routes.module.ts
+++ b/src/app/foundations/foundations-routes.module.ts
@@ -10,6 +10,7 @@ import {LogoDemoComponent} from './logo/logo-demo.component';
 import {ProductsDemoComponent} from './products/products-demo.component';
 import {FontsDemoComponent} from './fonts/fonts-demo.component';
 import { AIDemoComponent } from './ai/ai-demo.component';
+import { AppBrandingDemoComponent } from './app-branding/app-branding-demo.component';
 import { FaviconDemoComponent } from './favicons/favicon-demo.component';
 
 const routes: Routes = [
@@ -61,6 +62,11 @@ const routes: Routes = [
                 path: 'products',
                 component: ProductsDemoComponent,
                 data: {title: 'Product Icons', category: 'Brand'}
+            },
+            {
+                path: 'app-branding',
+                component: AppBrandingDemoComponent,
+                data: {title: 'App Title Generator', category: 'Brand'}
             },
             {
                 path: 'ai-branding',

--- a/src/app/foundations/foundations.module.ts
+++ b/src/app/foundations/foundations.module.ts
@@ -11,9 +11,10 @@ import {ApplicationInsightsService} from '../shared/application-insights/applica
 import {LogoDemoComponent} from './logo/logo-demo.component';
 import {FontsDemoComponent} from './fonts/fonts-demo.component';
 import {ProductsDemoComponent} from './products/products-demo.component';
-import { AIDemoComponent } from './ai/ai-demo.component';
-import { IconPickerComponent } from './products/icon-picker/icon-picker.component';
-import { FaviconDemoComponent } from './favicons/favicon-demo.component';
+import {AIDemoComponent} from './ai/ai-demo.component';
+import {AppBrandingDemoComponent} from './app-branding/app-branding-demo.component';
+import {IconPickerComponent} from './products/icon-picker/icon-picker.component';
+import {FaviconDemoComponent} from './favicons/favicon-demo.component';
 
 @NgModule({
     imports: [SharedModule, FoundationsRoutesModule],
@@ -28,6 +29,7 @@ import { FaviconDemoComponent } from './favicons/favicon-demo.component';
         BrandColorDemoComponent,
         LogoDemoComponent,
         AIDemoComponent,
+        AppBrandingDemoComponent,
         ProductsDemoComponent,
         IconPickerComponent,
         FontsDemoComponent


### PR DESCRIPTION
I created a tool to generate the application title text people frequently ask for.

I was not sure the exact font used to create these titles. But I found one that is pretty close. `Carnas Light`
It should be pretty easy to plug in the actual font-family found in `app-branding-demo.scss` and then updating all the references to use it.

The new title generator can be found in Foundations -> Brand -> App Title Generator

![Screen Shot 2024-02-15 at 5 54 06 PM](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/3945263/538bb21e-d796-4459-a575-ed61fed21d99)