### PR TITLE
docs(accessibility): renamed document

### DIFF
--- a/guides/accessibility/writing-for-accessibility.md
+++ b/guides/accessibility/writing-for-accessibility.md
@@ -1,4 +1,4 @@
-# Accessibility
+# Writing for Accessibility
 ###### Last updated June 14, 2023
 
 In general, follow the Microsoft Style Guide [Accessibility guidelines and requirements](https://docs.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements). Common guidance is highlighted below.

--- a/src/app/accessibility/accessibility-routes.module.ts
+++ b/src/app/accessibility/accessibility-routes.module.ts
@@ -18,12 +18,12 @@ const routes: Routes = [
                 }
             },
             {
-                path: 'ux-writing',
+                path: 'writing-for-accessibility',
                 component: MarkdownContentComponent,
                 data: {
-                    title: 'Ux Writing',
+                    title: 'Writing for Accessibility',
                     category: 'Foundations',
-                    document: require('../../../guides/accessibility/ux-writing.md')
+                    document: require('../../../guides/accessibility/writing-for-accessibility.md')
                 }
             },
             {


### PR DESCRIPTION
Relabeled an accessibility section from 'ux writing' to 'writing for accessibility', for clarity. The prev label wasn't wrong, but we have another section in the app named the same thing so I got confused.

re #2307