### PR TITLE
2312 sidenav updates

### DIFF
--- a/projects/cashmere-examples/src/lib/sidenav-tab-group/sidenav-tab-group-example.component.html
+++ b/projects/cashmere-examples/src/lib/sidenav-tab-group/sidenav-tab-group-example.component.html
@@ -6,10 +6,10 @@
         [tabGroups]="tabGroups"
         [darkMode]="true"
     >
-
     </hc-sidenav>
 
     <div class="example-app-content">
         <p>This example demonstrates using <strong>tab groups</strong> (in this example, "Browsers").</p>
+        <hc-checkbox [formControl]="hideChildrenOnCollapse">Hide tab group children when sidenav is collapsed</hc-checkbox>
     </div>
 </div>

--- a/projects/cashmere-examples/src/lib/sidenav-tab-group/sidenav-tab-group-example.component.ts
+++ b/projects/cashmere-examples/src/lib/sidenav-tab-group/sidenav-tab-group-example.component.ts
@@ -1,4 +1,5 @@
-import {Component} from '@angular/core';
+import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { SidenavLink, SidenavTabGroup } from '@healthcatalyst/cashmere';
 
 /**
@@ -10,6 +11,12 @@ import { SidenavLink, SidenavTabGroup } from '@healthcatalyst/cashmere';
     styleUrls: ['sidenav-tab-group-example.component.scss']
 })
 export class SidenavTabGroupExampleComponent {
+    hideChildrenOnCollapse: FormControl = new FormControl(true);
+
+    constructor() {
+        this.hideChildrenOnCollapse.valueChanges.subscribe(() => this.toggleGroupCollapse());
+    }
+
     tabs: SidenavLink[] = [
         new SidenavLink({title: 'GitHub', iconClass: 'fa fa-github', description: 'Source code repositories'}),
         new SidenavLink({title: 'Stack Overflow', iconClass: 'fa fa-stack-overflow', description: 'Q&A site for developers'}),
@@ -26,4 +33,10 @@ export class SidenavTabGroupExampleComponent {
             new SidenavLink({title: 'Edge', iconClass: 'fa fa-edge', description: 'The new IE'})
         ]})
     ];
+
+    toggleGroupCollapse() {
+        this.tabGroups.forEach(group => {
+            group.hideChildrenOnCollapse = this.hideChildrenOnCollapse.value;
+        });
+    }
 }

--- a/projects/cashmere/src/lib/sass/sidenav.scss
+++ b/projects/cashmere/src/lib/sass/sidenav.scss
@@ -193,10 +193,13 @@ $sidenav-width: 260px !default;
     padding-bottom: 5px;
     margin-left: 18px;
     font-weight: 500;
-    pointer-events: none;
     animation: HCFadeIn 0.3s;
     border-bottom: 1px solid transparentize($slate-gray-300, 0.75);
     margin-right: 16px;
+}
+
+@mixin hc-sidenav-group-header-icon() {
+    animation: HCFadeIn 0.2s;
 }
 
 @mixin hc-sidenav-tab-group-list-container() {
@@ -314,6 +317,31 @@ $sidenav-width: 260px !default;
 
 @mixin hc-sidenav-collapsed-tab-group() {
     height: auto;
+}
+
+@mixin hc-sidenav-collapsed-tab-group-header() {
+    @include fontSize(10px);
+    margin: 0;
+    padding: 0px 3px 4px;
+    min-width: 0;
+    overflow: hidden;
+    justify-content: center;
+
+    span {
+        min-width: 0;
+        text-overflow: ellipsis;
+        text-align: center;
+        overflow: hidden;
+        text-wrap: nowrap;
+    }
+
+    .hc-sidenav-tab-group-header-title {
+        width: 100%;
+    }
+}
+
+@mixin hc-sidenav-collapsed-tab-group-header-icon() {
+    display: none;
 }
 
 @mixin hc-sidenav-collapsed-tab-group-menu-btn() {

--- a/projects/cashmere/src/lib/sass/sidenav.scss
+++ b/projects/cashmere/src/lib/sass/sidenav.scss
@@ -51,16 +51,19 @@ $sidenav-width: 260px !default;
     color: $white;
     &:hover {
         background-color: darken($charcoal-blue, 10%);
+        color: $white;
     }
 
     &:focus {
         outline: none;
         box-shadow: 0 0 0 2px transparentize($blue, 0.75) inset;
         background-color: darken($charcoal-blue, 10%);
+        color: $white;
     }
 
     &:active {
         background-color: darken($charcoal-blue, 15%);
+        color: $white;
     }
 }
 

--- a/projects/cashmere/src/lib/sidenav/sidenav.component.html
+++ b/projects/cashmere/src/lib/sidenav/sidenav.component.html
@@ -27,12 +27,12 @@
         <!-- #### Tab groups -->
         <div *ngFor="let tabGroup of tabGroups" class="hc-sidenav-tab-group"
             [class.hc-sidenav-tab-group-nested]="tabGroup.hasNestedLinks">
-            <ng-container *ngIf="!collapsed">
+            <ng-container *ngIf="!collapsed || !tabGroup.hideChildrenOnCollapse">
                 <div class="hc-sidenav-tab-group-container">
-                    <div class="hc-sidenav-tab-group-header" title="{{tabGroup.description}}">
+                    <div class="hc-sidenav-tab-group-header {{tabGroup.tabCSSClass}}" title="{{tabGroup.description}}" (click)="onTabGroupHeaderClick($event, tabGroup)">
                         <span *ngIf="tabGroup.labelHTML" [innerHTML]="tabGroup.labelHTML"></span>
-                        <span *ngIf="!tabGroup.labelHTML">{{ tabGroup.title }}</span>
-                        <span *ngIf="tabGroup.iconClass" class="{{tabGroup.iconClass}}"></span>
+                        <span *ngIf="!tabGroup.labelHTML" class="hc-sidenav-tab-group-header-title">{{ tabGroup.title }}</span>
+                        <span *ngIf="tabGroup.iconClass" class="{{tabGroup.iconClass}} hc-sidenav-tab-group-header-icon"></span>
                     </div>
                     <!-- Tab group items -->
                     <ng-container *ngIf="!isLoadingTabs">
@@ -49,9 +49,9 @@
             </ng-container>
 
             <!-- Tab group menu button in collapsed sidebar-->
-            <ng-container *ngIf="collapsed">
+            <ng-container *ngIf="collapsed && tabGroup.hideChildrenOnCollapse">
                 <div [hcPop]="tabPop" [context]="tabGroup.title || ''" [trigger]="'hover'"
-                    class="hc-sidenav-tab-group-collapsed-menu-btn">
+                    class="hc-sidenav-tab-group-collapsed-menu-btn {{tabGroup.tabCSSClass}}">
                     <span class="hc-sidenav-tab-group-collapsed-menu-ico" [hcPop]="tabLinkPop"
                         [context]="{parent: tabGroup}">
                         <span [class]="tabGroup.iconClass"></span>
@@ -123,7 +123,7 @@
     <div class="hc-sidenav-tab-tree-line-vert" [class.hc-sidenav-no-tree-lines]="!showTreeLines"
         [class.hc-sidenav-no-collapsing-links]="!collapsibleChildren" [hcPop]="tabLinkPop" [context]="{parent: tab}"
         [trigger]="(collapsed && tab.children?.length > 0 && !tab.parent) ? 'click' : 'none'">
-        <a class="hc-sidenav-tab"
+        <a class="hc-sidenav-tab {{tab.tabCSSClass}}"
             [class.hc-sidenav-active-tab]="!routerLinkActiveClass ? tab.key === activeTabKey && !isFav : false"
             [class.hc-sidenav-disabled-tab]="tab.disabled" [class.hc-sidenav-unclickable-tab]="!tab.clickable"
             [class.last-leaf-node]="tab.isLastLeafNode" [title]="tab.description || ''"

--- a/projects/cashmere/src/lib/sidenav/sidenav.component.scss
+++ b/projects/cashmere/src/lib/sidenav/sidenav.component.scss
@@ -160,6 +160,10 @@
         @include hc-sidenav-tab-group-header();
     }
 
+    .hc-sidenav-tab-group-header-icon {
+        @include hc-sidenav-group-header-icon();
+    }
+
     .hc-sidenav-tab-group-list-container {
         @include hc-sidenav-tab-group-list-container();
     }
@@ -220,6 +224,14 @@
         .hc-sidenav-tab-name {
             @include nested-link-submenu-tab-name();
         }
+    }
+
+    .hc-sidenav-tab-group-header {
+        @include hc-sidenav-collapsed-tab-group-header();
+    }
+
+    .hc-sidenav-tab-group-header-icon {
+        @include hc-sidenav-collapsed-tab-group-header-icon();
     }
 }
 

--- a/projects/cashmere/src/lib/sidenav/sidenav.component.ts
+++ b/projects/cashmere/src/lib/sidenav/sidenav.component.ts
@@ -1,7 +1,6 @@
 import {Component, Input, ViewEncapsulation, EventEmitter, Output} from '@angular/core';
 import { LinkParent, SidenavLink, SidenavLinkClickEvent, SidenavTabGroup } from './sidenav.models';
 import { isDefined } from '../util';
-import { HcPopComponent } from '../pop';
 
 /** Component for standard sidebar navigation */
 @Component({
@@ -68,6 +67,8 @@ export class SidenavComponent {
         return this._tabGroups;
     }
     private _tabGroups: SidenavTabGroup[] = [];
+    /** Event triggered when a tab group header is clicked. */
+    @Output() tabGroupHeaderClicked = new EventEmitter<SidenavLinkClickEvent>();
 
     /** @docs-private */
     hasNestedLinks = false;
@@ -147,6 +148,11 @@ export class SidenavComponent {
 
         if (!link.onClick) { return; }
         link.onClick(event, link);
+    }
+
+    /** @docs-private */
+    onTabGroupHeaderClick(event: MouseEvent, link: SidenavLink): void {
+        this.tabGroupHeaderClicked.emit({event, link});
     }
 
     /** @docs-private */

--- a/projects/cashmere/src/lib/sidenav/sidenav.models.ts
+++ b/projects/cashmere/src/lib/sidenav/sidenav.models.ts
@@ -8,6 +8,7 @@ export interface LinkParent {
     labelHTML: string;
     children: SidenavLink[];
     parent?: LinkParent;
+    tabCSSClass?: string;
 }
 
 export class SidenavLink implements LinkParent {
@@ -25,6 +26,8 @@ export class SidenavLink implements LinkParent {
     public description: string;
     /** Passed to routerLink */
     public routerLink?: string;
+    /** Additional CSS class to apply */
+    public tabCSSClass?: string;
     /** Instead of a route, can provide a callback function.
      * Alternative is to listen to SideNav's tabClicked or favoriteClicked `@Output` events. */
     public onClick?: (e: MouseEvent, link: SidenavLink) => void;
@@ -73,11 +76,15 @@ export class SidenavTabGroup implements LinkParent {
     public labelHTML: string;
     /** Nested links for this section*/
     public children: SidenavLink[];
+    /** If true, will put child links into popover menu when the sidenav is collapsed */
+    public hideChildrenOnCollapse = true;
+    /** Additional CSS class to apply */
+    public tabCSSClass?: string;
 
     /** @docs-private */
     public hasNestedLinks: boolean;
 
-    constructor(partial: Partial<SidenavLink>) {
+    constructor(partial: Partial<SidenavTabGroup>) {
         Object.assign(this, partial);
         this.hasNestedLinks = this.children.some(child => child.children?.length > 0);
         this.children?.forEach(child => child.parent = this);


### PR DESCRIPTION
- fixed minor css bug with dark mode sidenavs
- added some new options
     - custom css classes on tabs and group headers
     - ability to handle clicks on group headers
     - option to hide or not hide children links of tab groups when collapsing the sidebar

![newSidenavGroupOptions](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/82b87a8b-1eca-44e2-9929-e6cd5a335f0b)
