### PR TITLE
fix(table): fix sticky header styles

### DIFF
--- a/projects/cashmere/src/lib/sass/table.class.scss
+++ b/projects/cashmere/src/lib/sass/table.class.scss
@@ -277,7 +277,7 @@ tr:hover .hc-table-actions .hc-action-ico,
 
 
 // sticky no borders
-th.hc-table-sticky.hc-table-sticky-border-elem-top, .hc-sticky-header th{
+th.hc-table-sticky.hc-table-sticky-border-elem-top, .hc-sticky-header th, .hc-sticky-header th.hc-col-sortable-left, .hc-sticky-header th.hc-col-sortable{
     @include th-header-sticky();
 
     &:first-child {
@@ -317,7 +317,7 @@ td, th:first-child {
 
 // sticky w borders
 .hc-table-borders {
-    th.hc-table-sticky, .hc-sticky-header th {
+    th.hc-table-sticky, .hc-sticky-header th, .hc-sticky-header th.hc-col-sortable-left, .hc-sticky-header th.hc-col-sortable {
         @include th-border-header-sticky();
 
         &.hc-table-sticky-border-elem-left {

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -417,7 +417,7 @@ $row-selected-border-color: $white;
 }
 
 @mixin th-header-sticky-last-child() {
-    &:after {
+    &:before {
         content: ' ';
         height: 100%;
         width: 2px;
@@ -437,7 +437,7 @@ $row-selected-border-color: $white;
 }
 
 @mixin th-header-sticky-last-child-gray() {
-    &:after {
+    &:before {
         background-color: $slate-gray-100;
     }
 }


### PR DESCRIPTION
- Sticky styles would break when used in conjunction with the css sort headers, due to some styles being overriden
- Also noticed a sizing issue would happen on left aligned sort icons if used in the last column of a table with borders. Fixed that as well.

re #2199