### PR TITLE
fix(toast): vertically center toast content

### DIFF
--- a/projects/cashmere/src/lib/toaster/hc-toast.component.html
+++ b/projects/cashmere/src/lib/toaster/hc-toast.component.html
@@ -18,7 +18,7 @@
             </div>
             <div *ngIf="!_customImage" class="hc-toast-icon"></div>
         </div>
-        <div>
+        <div class="hc-toast-content-container">
             <div class="hc-toast-header">{{_headerText}}</div>
             <div class="hc-toast-body">{{_bodyText}}</div>
         </div>

--- a/projects/cashmere/src/lib/toaster/hc-toast.component.scss
+++ b/projects/cashmere/src/lib/toaster/hc-toast.component.scss
@@ -117,6 +117,13 @@ $hc-header-font-size: 18px !default;
     align-items: center;
 }
 
+.hc-toast-content-container {
+    display: flex;
+    align-items: start;
+    flex-direction: column;
+    justify-content: center;
+}
+
 .hc-toast-close {
     padding-left: 20px;
     padding-right: 3px;


### PR DESCRIPTION
make sure content is centered, even if a header is not provided

fix #2324

![image](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/98f3fbe0-a8d0-4414-ae44-4793549051f0)
