### PR TITLE
feat(sidenav): can provide alt header for groups

### DIFF
--- a/projects/cashmere/src/lib/sass/sidenav.scss
+++ b/projects/cashmere/src/lib/sass/sidenav.scss
@@ -322,7 +322,8 @@ $sidenav-width: 260px !default;
 @mixin hc-sidenav-collapsed-tab-group-header() {
     @include fontSize(10px);
     margin: 0;
-    padding: 0px 3px 4px;
+    padding: 0px 3px 3px;
+    line-height: 1.2;
     min-width: 0;
     overflow: hidden;
     justify-content: center;

--- a/projects/cashmere/src/lib/sidenav/sidenav.component.html
+++ b/projects/cashmere/src/lib/sidenav/sidenav.component.html
@@ -30,8 +30,14 @@
             <ng-container *ngIf="!collapsed || !tabGroup.hideChildrenOnCollapse">
                 <div class="hc-sidenav-tab-group-container">
                     <div class="hc-sidenav-tab-group-header {{tabGroup.tabCSSClass}}" title="{{tabGroup.description}}" (click)="onTabGroupHeaderClick($event, tabGroup)">
-                        <span *ngIf="tabGroup.labelHTML" [innerHTML]="tabGroup.labelHTML"></span>
-                        <span *ngIf="!tabGroup.labelHTML" class="hc-sidenav-tab-group-header-title">{{ tabGroup.title }}</span>
+                        <ng-container *ngIf="collapsed && (tabGroup.collapsedTitle || tabGroup.collapsedLabelHTML); else standardGroupLabel">
+                            <span *ngIf="tabGroup.collapsedLabelHTML" [innerHTML]="tabGroup.collapsedLabelHTML"></span>
+                            <span *ngIf="!tabGroup.collapsedLabelHTML" class="hc-sidenav-tab-group-header-title">{{ tabGroup.collapsedTitle }}</span>
+                        </ng-container>
+                        <ng-template #standardGroupLabel>
+                            <span *ngIf="tabGroup.labelHTML" [innerHTML]="tabGroup.labelHTML"></span>
+                            <span *ngIf="!tabGroup.labelHTML" class="hc-sidenav-tab-group-header-title">{{ tabGroup.title }}</span>
+                        </ng-template>
                         <span *ngIf="tabGroup.iconClass" class="{{tabGroup.iconClass}} hc-sidenav-tab-group-header-icon"></span>
                     </div>
                     <!-- Tab group items -->

--- a/projects/cashmere/src/lib/sidenav/sidenav.models.ts
+++ b/projects/cashmere/src/lib/sidenav/sidenav.models.ts
@@ -70,10 +70,14 @@ export class SidenavTabGroup implements LinkParent {
     iconClass?: string;
     /** Name of the link section. Used as the primary label in the UI. */
     public title: string;
+    /** Alternate name of the link section to show when sidenav is collapsed. */
+    public collapsedTitle: string;
     /** Name of the link section. shown on hover */
     public description: string;
     /** Serves as the primary label in the UI. Will override "title". **WARNING:** You are responsible to sanitize any unsafe user input. */
     public labelHTML: string;
+    /** Alternate markup to serve as the primary label in the UI when the sidenav is collapsed. Will override other title or label properties. **WARNING:** You are responsible to sanitize any unsafe user input. */
+    public collapsedLabelHTML: string;
     /** Nested links for this section*/
     public children: SidenavLink[];
     /** If true, will put child links into popover menu when the sidenav is collapsed */


### PR DESCRIPTION
when sidenav is collapsed and group header is being displayed, you can present a different group label
![altgroupheader](https://github.com/HealthCatalyst/Fabric.Cashmere/assets/12416432/3e2c90e3-4f2c-447a-a0d3-34d6b165278f)


re #2326