### PR TITLE
Allow @angular/cdk peer dependency greater than current version

### DIFF
--- a/projects/cashmere/package.json
+++ b/projects/cashmere/package.json
@@ -15,7 +15,7 @@
     },
     "typings": "./cashmere.d.ts",
     "peerDependencies": {
-        "@angular/cdk": "^17.3.8",
+        "@angular/cdk": ">=17.3.8",
         "@angular/common": ">= 17.3.8",
         "@angular/core": ">= 17.3.8",
         "@angular/forms": ">= 17.3.8",


### PR DESCRIPTION
Currently, we have a section on the Cashmere website suggesting that consumer Angular versions do not need to track the version used by Cashmere, but Angular CDK requires a major version match, while the rest do not. Without this, it's not possible, in practice, to upgrade to a newer version of Angular until Cashmere is also updated.

Tested this with Pop Analyzer locally and I was able to use Angular v18 without compilation issues and did not see any glaring issues when smoke testing.