### PR TITLE
fix(example creation script): alter example project's package handling

### DIFF
--- a/projects/cashmere-examples/package-lock.json
+++ b/projects/cashmere-examples/package-lock.json
@@ -5,13 +5,11 @@
     "requires": true,
     "dependencies": {
         "@healthcatalyst/cashmere": {
-            "version": "12.7.2",
-            "resolved": "https://registry.npmjs.org/@healthcatalyst/cashmere/-/cashmere-12.7.2.tgz",
-            "integrity": "sha512-SoMceeRtZYQByBbBsOZEwQLZcWsDu7PnDDDQ3rzKVwhr2GgDsQUNOA8VleTSKK5dEpEAwMbgwL+dGV1LET3Kzw==",
+            "version": "17.2.3",
+            "resolved": "https://registry.npmjs.org/@healthcatalyst/cashmere/-/cashmere-17.2.3.tgz",
+            "integrity": "sha512-Bnq/nIXO44U5FJIRAO6kTHXmXR8EOO1e6qkJdPbeZt3yVa101hB2EnLOxmcsI2Ee9DArSg+inYeWPJdgsK0m/g==",
             "dev": true,
-            "requires": {
-                "tslib": "^2.0.0"
-            }
+            "requires": {"tslib": "^2.0.0"}
         },
         "tslib": {
             "version": "2.4.0",

--- a/scripts/new-example.ts
+++ b/scripts/new-example.ts
@@ -28,7 +28,7 @@ const existingExamples = readdirSync(examplesDir).filter(
 );
 
 const currentExampleDependencies = Object.keys(
-    JSON.parse(readFileSync(join(__dirname, '../projects/cashmere-examples/package.json')).toString()).peerDependencies
+    JSON.parse(readFileSync(join(__dirname, '../projects/cashmere-examples/package.json')).toString()).peerDependencies || []
 );
 
 const exampleTypes = ['simple', 'module'];
@@ -241,6 +241,13 @@ function installAdditionalPackages() {
     delete packageJson.dependencies;
     const jsonString = JSON.stringify(packageJson);
     writeFileSync(packageJsonPath, prettier.format(jsonString, {...prettierConfig, parser: 'json'}));
+
+    console.info(chalk.gray('removing packages from package-lock...'));
+    const packageLockJsonPath = join(cashmereExamplesProjectDir, 'package-lock.json');
+    const packageLockJson = JSON.parse(readFileSync(packageLockJsonPath).toString());
+    delete packageLockJson.packages;
+    const jsonLockString = JSON.stringify(packageLockJson);
+    writeFileSync(packageLockJsonPath, prettier.format(jsonLockString, {...prettierConfig, parser: 'json'}));
 }
 
 function runBuild() {


### PR DESCRIPTION
# Cashmere New Example Issues

## Default Peer Dependencies
It was noticed that the `npm run new:example` command failed with error "Could not run Object.Keys over undefined". 

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/b09aafa5-b0dc-401a-b9c3-e98877b83afa" />

---
I checked the target package.json that and there was no peerDependencies property for it to read from. A default empty array was added in the case of a non-existent or empty peerDependencies object. After that change was added, the script moved along and created a new example. As a test, the component was created with the `is-number` package.

<img width="925" alt="image" src="https://github.com/user-attachments/assets/7e34c193-9f28-4a79-8077-54e79b3055ba" />

<img width="549" alt="image" src="https://github.com/user-attachments/assets/ab92992f-af93-4879-82f5-4d27f7b33a46" />

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/284c53e3-87f8-4cb3-9a0e-23e07678bfa8" />

<img width="1330" alt="image" src="https://github.com/user-attachments/assets/cbb39e34-baf7-4508-beed-eb724a1f39b8" />


## Issues With Subsequent Runs
After the creation of the "foobar" component, it was noticed that the new-example script made few alterations to the example project's package-lock file. 
![image](https://github.com/user-attachments/assets/14f03f90-c1a7-4f85-87a6-ddd9b3ef4ef5)

Subsequent runs of the new-example script or `npm i` caused the below error.
<img width="940" alt="image" src="https://github.com/user-attachments/assets/41180158-3827-4ba6-abcb-79fceacbc0db" />

The error message led to me updating the version of cashmere that was in the package-lock, reverting the other changes, and trying again. I ran into the same issue where the **script would work the first time but fail on the next run.**

After some tinkering, it was noticed that **removing the packages object from the package-lock.json was needed to avoid the package conflicts.**

## Testing
The foobar example with the package `is-number` (above) was left in the project as a first run.

Running another example creation, "foo", with the `is-odd` package succeeded.
<img width="933" alt="image" src="https://github.com/user-attachments/assets/e54685b9-70ac-49a2-8f87-292e04e84618" />
- Note that `is-number` is listed on the "specify packages" line.

Running **a subsequent** example creation, "bar", with the `is-even` package succeeded.
<img width="960" alt="image" src="https://github.com/user-attachments/assets/434f4cf1-9baf-48f5-a884-8ae4dece6e3d" />
- Note that `is-number` and `is-odd` are listed on the "specify packages" line.

---
These examples were tested by temporarily implementing them and pulling in the downloaded packages.
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/bd15916b-73ba-4176-9fe6-729ab378e472" />

Output
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/9ab05907-285a-4a30-8d48-92433f8e8837" />

## Additional thoughts
I am not 100% certain that this is the best possible solution to this problem. I have tested it locally and it appears to be functional on first run as well as subsequent runs. I'm open to feedback and comments!
